### PR TITLE
README: fix .treeinfo contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ cat <<'EOF' > .treeinfo
 arch = x86_64
 family = Fedora
 platforms = x86_64
+version = 29
 [images-x86_64]
 initrd = initramfs.img
 kernel = vmlinuz


### PR DESCRIPTION
Adds the line `version = 29` to the `.treeinfo` file declaration.
Without this the `virt-install` will fail with `No option 'version' in
section: 'general'`.