### PR TITLE
dracut: fix logic error in parse-coreos.sh

### DIFF
--- a/dracut/30coreos-installer/parse-coreos.sh
+++ b/dracut/30coreos-installer/parse-coreos.sh
@@ -58,7 +58,7 @@ then
     echo 1 > /tmp/skip_reboot
 fi
 
-if $(getarg coreos.inst=); then
+if [ "$(getarg coreos.inst=)" = "yes" ]; then
     # Suppress initrd-switch-root.service from starting
     rm -f /etc/initrd-release
     # Suppress most console messages for the installer to run without interference


### PR DESCRIPTION
This was causing bash to try to run a command called
`yes` when `coreos.inst=yes` was passed as a karg
and the following error would show up on screen:

```
dracut-cmdline[272]: //lib/dracut/hooks/cmdline/90-parse-coreos.sh: line 46: yes: command not found
dracut-cmdline[272]: //lib/dracut/hooks/cmdline/90-parse-coreos.sh: line 46: yes: command not found
```