### PR TITLE
Use `dd conv=sparse`

### DIFF
--- a/coreos-installer
+++ b/coreos-installer
@@ -588,7 +588,7 @@ write_image_to_disk() {
     log "Writing disk image"
     
     zcat /mnt/dl/imagefile.gz |\
-    dd bs=1M iflag=fullblock oflag=direct of="${DEST_DEV}" status=none
+    dd bs=1M iflag=fullblock oflag=direct conv=sparse of="${DEST_DEV}" status=none
 
     for try in 0 1 2 4; do
         sleep "$try"  # Give the device a bit more time on each attempt.


### PR DESCRIPTION
This will skip the empty space in the filesystems, and will
rather dramatically speed up the install.

Not really necessary after
https://github.com/coreos/coreos-assembler/pull/332
but doesn't conflict either.