### PR TITLE
Add coreos-installer.target and make default

### DIFF
--- a/dracut/30coreos-installer/coreos-installer-generator
+++ b/dracut/30coreos-installer/coreos-installer-generator
@@ -1,0 +1,23 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+set -e
+
+UNIT_DIR="${1:-/tmp}"
+
+cmdline=( $(</proc/cmdline) )
+cmdline_arg() {
+    local name="$1" value="$2"
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            value="${arg#*=}"
+        fi
+    done
+    echo "${value}"
+}
+
+if [[ $(cmdline_arg coreos.inst) == "yes" ]]; then
+    ln -sf "/usr/lib/systemd/system/coreos-installer.target" \
+        "${UNIT_DIR}/default.target"
+fi

--- a/dracut/30coreos-installer/coreos-installer.service
+++ b/dracut/30coreos-installer/coreos-installer.service
@@ -1,15 +1,9 @@
 [Unit]
 Description=CoreOS Installer
-Requires=network-online.target
-After=network-online.target
-After=dracut-initqueue.service
-Before=dracut-pre-mount.service
-ConditionKernelCommandLine=coreos.inst=yes
-OnFailure=emergency.target
-OnFailureIsolate=yes
+After=coreos-installer.target
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/libexec/coreos-installer
 #StandardInput=tty-force
 StandardInput=tty

--- a/dracut/30coreos-installer/coreos-installer.target
+++ b/dracut/30coreos-installer/coreos-installer.target
@@ -1,0 +1,15 @@
+[Unit]
+Description=CoreOS Installer Target
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+AllowIsolate=yes
+
+Requires=coreos-installer.service
+
+# run after most things are up and the (likely) root device is available
+Requires=basic.target initrd-root-device.target
+After=basic.target initrd-root-device.target
+
+# we rely on dracut to set up the network
+Requires=dracut-cmdline.service dracut-pre-trigger.service dracut-initqueue.service
+After=dracut-cmdline.service dracut-pre-trigger.service dracut-initqueue.service

--- a/dracut/30coreos-installer/module-setup.sh
+++ b/dracut/30coreos-installer/module-setup.sh
@@ -29,11 +29,17 @@ install() {
     inst_multiple /usr/bin/ps
     inst_multiple /usr/bin/sha256sum
     inst_multiple /usr/bin/zcat
-    inst_simple /usr/libexec/coreos-installer
-    inst_simple "$moddir/coreos-installer.service" "${systemdsystemunitdir}/coreos-installer.service"
-    inst_hook cmdline 90 "$moddir/parse-coreos.sh"
-    mkdir -p "${initdir}${systemdsystemconfdir}/initrd.target.wants"
-    ln_r "${systemdsystemunitdir}/coreos-installer.service"\
-        "${systemdsystemconfdir}/initrd.target.wants/coreos-installer.service"
-}
 
+    inst_simple /usr/libexec/coreos-installer
+
+    inst_simple "$moddir/coreos-installer-generator" \
+        "$systemdutildir/system-generators/coreos-installer-generator"
+
+    inst_simple "$moddir/coreos-installer.target" \
+        "${systemdsystemunitdir}/coreos-installer.target"
+
+    inst_simple "$moddir/coreos-installer.service" \
+        "${systemdsystemunitdir}/coreos-installer.service"
+
+    inst_hook cmdline 90 "$moddir/parse-coreos.sh"
+}


### PR DESCRIPTION
What we really want when in "installer mode" is to override the default
flow of the bootup. The cleanest way to do this is to define a new
default target for systemd rather than `initrd.target`. That way we
don't have to awkwardly wedge ourselves between existing services. One
practical consequence of this for example is that systemd no longer
prints "Waiting" messages, since we're freely running without
constraints.

Closes: #4