### PR TITLE
installer: added coreos.inst.callhome_url option

### DIFF
--- a/coreos-installer
+++ b/coreos-installer
@@ -609,7 +609,7 @@ log() {
 }
 
 #########################################################
-#And Write the image to disk
+#Write the image to disk
 #########################################################
 write_image_to_disk() {
     log "Writing disk image"
@@ -631,6 +631,18 @@ write_image_to_disk() {
 
     log "Waiting for udev"
     udevadm settle
+}
+
+############################################################
+#Perform a HTTP POST to URL to signal that the install is complete
+############################################################
+call_home() {
+    CALLHOME_URL=$(cat /tmp/callhome_url)
+    if [ ! -z "$CALLHOME_URL" ]
+      echo "Calling home: $CALLHOME_URL" >> /tmp/debug
+      curl -k -o /dev/null --data-binary @/tmp/debug "$CALLHOME_URL" >>/tmp/debug 2>&1
+      rm -f /tmp/callhome_url
+    fi
 }
 
 parse_args() {
@@ -709,6 +721,9 @@ main() {
 
     # If networking options were present, persist to firstboot initramfs
     write_networking_opts
+
+    # And call home as the very last step before rebooting
+    call_home
 
     log "Install complete"
 }

--- a/dracut/30coreos-installer/parse-coreos.sh
+++ b/dracut/30coreos-installer/parse-coreos.sh
@@ -24,6 +24,13 @@ then
     echo $IGNITION_URL >> /tmp/ignition_url
 fi
 
+local CALLHOME_URL=$(getarg coreos.inst.callhome_url=)
+if [ ! -z "$CALLHOME_URL" ]
+then
+    echo "preset call home url to $CALLHOME_URL" >> /tmp/debug
+    echo "$CALLHOME_URL" >> /tmp/callhome_url
+fi
+
 # Dracut networking args
 # Parse all args (other than rd.neednet) and persist those into /tmp/networking_opts
 # List from https://www.mankier.com/7/dracut.cmdline#Description-Network


### PR DESCRIPTION
Implements a simple callback mechanism for provisioning management software (like Foreman or Red Hat Satellite) to inform the system to exit build mode and reconfigure TFTP/PXE services.

Issue: https://github.com/coreos/coreos-installer/issues/21