### PR TITLE
coreos-installer: Honor redirects via curl

### DIFF
--- a/coreos-installer
+++ b/coreos-installer
@@ -361,7 +361,7 @@ get_img_url() {
         fi
 
         IMAGE_URL=$(cat /tmp/image_url)
-        curl -sIf $IMAGE_URL >/tmp/image_info 2>&1
+        curl -LsIf $IMAGE_URL >/tmp/image_info 2>&1
         RETCODE=$?
         if [ $RETCODE -ne 0 ]
         then
@@ -391,14 +391,14 @@ get_img_url() {
 get_sig_file_type() {
     SIG_URL=$IMAGE_URL.sig
     echo "Getting SIG_URL $SIG_URL" >> /tmp/debug
-    curl -sIf $SIG_URL > /dev/null 2>&1
+    curl -LsIf $SIG_URL > /dev/null 2>&1
     RETCODE=$?
     if [ $RETCODE -ne 0 ]
     then
         echo "$SIG_URL not found" >> /tmp/debug
         SIG_URL=$IMAGE_URL.sha256sum
         echo "Getting SIG_URL $SIG_URL" >> /tmp/debug
-        curl -sI $SIG_URL > /dev/null 2>&1 
+        curl -LsI $SIG_URL > /dev/null 2>&1 
         if [ $? -ne 0 ]
         then
             SIG_TYPE=none
@@ -498,7 +498,7 @@ mount_tmpfs() {
 #########################################################
 download_image() {
     echo "Downloading install image" >> /tmp/debug
-    curl -s -o /mnt/dl/imagefile.gz $IMAGE_URL &
+    curl -L -s -o /mnt/dl/imagefile.gz $IMAGE_URL &
     curlpid=$!
 
     while ps --pid $curlpid; do
@@ -519,7 +519,7 @@ download_image() {
 #########################################################
 download_sig() {
     echo "Getting signature" >> /tmp/debug
-    curl -s -o /mnt/dl/imagefile.gz.sig $SIG_URL
+    curl -L -s -o /mnt/dl/imagefile.gz.sig $SIG_URL
     if [ $? -ne 0 ]
     then
         dialog --title 'CoreOS Installer' --msgbox "Unable to download sig file. Dropping to shell" 10 70


### PR DESCRIPTION
Adds `-L` to all `curl` calls to honor redirects.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1709247