### PR TITLE
30coreos-installer: drop unused inst_modules

### DIFF
--- a/dracut/30coreos-installer/module-setup.sh
+++ b/dracut/30coreos-installer/module-setup.sh
@@ -15,9 +15,6 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple /usr/bin/chvt
-    inst_multiple /usr/bin/lsblk
-    inst_multiple /usr/bin/tee
     inst_multiple /usr/bin/gpg2
     inst_multiple /usr/bin/curl
     inst_multiple /usr/sbin/wipefs


### PR DESCRIPTION
With #16 we no longer need `chvt`, `lsblk` or `tee`.