### PR TITLE
various CLI invocation fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,42 @@ embedded ignition config should run on first boot.
 
 ## Testing out the installer script by running it directly
 
-**This does not work yet**
-
 Grab `coreos-installer` and execute it on an already booted system.
-You'll want to write to a disk that is not currently in use.
+
+**NOTE** The installer writes directly to a block device (disk) and
+         consumes the entire device. The device specified to the
+         installer needs to be available and not currently in use. You
+         cannot target a disk that is currently mounted.
+
+The easiest way to access a disk that is not currently in use is to
+boot up the coreos-installer ISO. If you boot the ISO and don't provide
+any extra arguments you will be presented with a usage message and
+then a prompt where you can execute the installer via the CLI:
 
 ```
-coreos-installer arg1 arg2 arg3
+/usr/libexec/coreos-installer -d sdd -i https://example.com/ignition.cfg -b https://example.com/fedora-coreos-metal-bios.raw.gz
 ```
+
+Afterwards you'll need to reboot the machine.
+
+Alternatively, you can install coreos-installer on a desktop/laptop
+machine and write out an image to a spare disk attached to the system.
+This can be dangerous if you specify the wrong disk to the installer.
+
+You'll want to make sure all of the 
+[dependencies](https://github.com/coreos/coreos-installer/blob/master/dracut/30coreos-installer/module-setup.sh#L18)
+are installed on your machine. If you are on Fedora you can install
+the coreos-installer rpm (and all dependencies) using DNF via
+`dnf install coreos-installer`. The path to the script will be
+`/usr/libexec/coreos-installer`.
+
+```
+sudo /path/to/coreos-installer -d sdg -i https://example.com/ignition.cfg -b https://example.com/fedora-coreos-metal-bios.raw.gz
+```
+
+Afterwards, remove the disk from the computer and insert it into and
+boot the target machine where it is desired to run CoreOS.
+
 
 ## Testing out the installer running in the initramfs (early boot)
 

--- a/coreos-installer
+++ b/coreos-installer
@@ -698,12 +698,7 @@ main() {
     # If networking options were present, persist to firstboot initramfs
     write_networking_opts
 
-    if [ ! -f /tmp/skip_reboot ]
-    then
-        log "Install complete"
-        sleep 5
-        reboot
-    fi
+    log "Install complete"
 }
 
 main $@

--- a/coreos-installer
+++ b/coreos-installer
@@ -665,6 +665,12 @@ This tool installs Fedora CoreOS on a block device.
 
 # Main function for running the installer
 main() {
+
+    if [[ $EUID -ne 0 ]]; then
+       echo "$0 must be run as root"
+       exit 1
+    fi
+
     parse_args $@
 
     # set a global environment variable that can be used

--- a/coreos-installer
+++ b/coreos-installer
@@ -306,16 +306,25 @@ mount_boot_partition() {
         log "mountpoint $mountpoint must be a directory"
         exit 1
     fi
-    # TODO check to make sure the disk with label 'boot'
-    #      is part of ${DEST_DEV}
+
+    # Find the boot partition by analyzing the user provided
+    # device. Don't want to rely on /dev/disk/by-label/boot since
+    # there may be more than one device with the "boot" label.
+    # The first command will find the partition with the boot label
+    # and the eval command will set the $UUID variable that we use later.
+    set -o pipefail
+    output=$(lsblk "${DEST_DEV}" --output NAME,LABEL,UUID --pairs | grep 'LABEL="boot"')
+    eval $(echo $output | tr ' ' '\n' | tail -n 1)
+    set +o pipefail
+
     let retry=0
     while true
     do
-        mount /dev/disk/by-label/boot $mountpoint
+        mount "/dev/disk/by-uuid/${UUID}" /mnt/boot_partition
         RETCODE=$?
         if [[ $RETCODE -ne 0 ]]; then
             if [[ $retry -lt 30 ]]; then
-                # retry and sleep to allow udevd to populate /dev/disk/by-label
+                # retry and sleep to allow udevd to populate /dev/disk/by-uuid
                 sleep 1
                 let retry=$retry+1
                 continue
@@ -419,9 +428,6 @@ get_img_url() {
 # Validate that selected device exists
 ############################################################
 check_selected_device() {
-    DEST_DEV=$(cat /tmp/selected_dev)
-    DEST_DEV=/dev/$DEST_DEV
-
     if [ ! -b $DEST_DEV ]
     then
         log "${DEST_DEV} does not exist."
@@ -660,6 +666,12 @@ This tool installs Fedora CoreOS on a block device.
 # Main function for running the installer
 main() {
     parse_args $@
+
+    # set a global environment variable that can be used
+    # by a few of the functions below.
+    DEST_DEV=$(cat /tmp/selected_dev)
+    DEST_DEV=/dev/$DEST_DEV
+
     #import_gpg_key
     get_img_url
     #get_sig_file_type

--- a/coreos-installer
+++ b/coreos-installer
@@ -347,7 +347,7 @@ write_ignition_file() {
     # mount the boot partition
     mkdir -p /mnt/boot_partition
     mount_boot_partition /mnt/boot_partition
-    trap 'umount /mnt/boot_partition' RETURN
+    trap 'umount /mnt/boot_partition; trap - RETURN' RETURN
 
     mkdir -p /mnt/boot_partition/ignition
     cp /tmp/ignition.ign /mnt/boot_partition/ignition/config.ign
@@ -370,7 +370,7 @@ write_networking_opts() {
     # check for the boot partition
     mkdir -p /mnt/boot_partition
     mount_boot_partition /mnt/boot_partition
-    trap 'umount /mnt/boot_partition' RETURN
+    trap 'umount /mnt/boot_partition; trap - RETURN' RETURN
 
     echo "set ignition_network_kcmdline=\"$(cat /tmp/networking_opts)\"" >> /mnt/boot_partition/ignition.firstboot
 }

--- a/coreos-installer
+++ b/coreos-installer
@@ -296,21 +296,22 @@ ZskQ/mDUv6F4w6N8Vk9R/nJTfpI36vWTcH7xxLNoNRlL2b/7ra6dB8YPsOdLy158
 
 
 ############################################################
-# Helper to write the ignition config to disk
+# Helper to mount the boot partition from the device
 ############################################################
-write_ignition_file() {
-    if [ ! -f /tmp/ignition.ign ]; then
-        return
-    fi
+mount_boot_partition() {
+    # First argument is the location of the mountpoint
+    mountpoint=$1
 
-    # check for the boot partition
-    mkdir -p /mnt/boot_partition
+    if [ ! -d $mountpoint ]; then
+        log "mountpoint $mountpoint must be a directory"
+        exit 1
+    fi
     # TODO check to make sure the disk with label 'boot'
     #      is part of ${DEST_DEV}
     let retry=0
     while true
     do
-        mount /dev/disk/by-label/boot /mnt/boot_partition
+        mount /dev/disk/by-label/boot $mountpoint
         RETCODE=$?
         if [[ $RETCODE -ne 0 ]]; then
             if [[ $retry -lt 30 ]]; then
@@ -322,9 +323,22 @@ write_ignition_file() {
             log "failed mounting boot partition"
             exit 1
         fi
-        trap 'umount /mnt/boot_partition' RETURN
         break;
     done
+}
+
+############################################################
+# Helper to write the ignition config to disk
+############################################################
+write_ignition_file() {
+    if [ ! -f /tmp/ignition.ign ]; then
+        return
+    fi
+
+    # mount the boot partition
+    mkdir -p /mnt/boot_partition
+    mount_boot_partition /mnt/boot_partition
+    trap 'umount /mnt/boot_partition' RETURN
 
     mkdir -p /mnt/boot_partition/ignition
     cp /tmp/ignition.ign /mnt/boot_partition/ignition/config.ign
@@ -346,9 +360,7 @@ write_networking_opts() {
     log "Embedding provided networking options"
     # check for the boot partition
     mkdir -p /mnt/boot_partition
-    # TODO check to make sure the disk with label 'boot'
-    #      is part of ${DEST_DEV}
-    mount /dev/disk/by-label/boot /mnt/boot_partition
+    mount_boot_partition /mnt/boot_partition
     trap 'umount /mnt/boot_partition' RETURN
 
     echo "set ignition_network_kcmdline=\"$(cat /tmp/networking_opts)\"" >> /mnt/boot_partition/ignition.firstboot

--- a/dracut/30coreos-installer/coreos-installer.service
+++ b/dracut/30coreos-installer/coreos-installer.service
@@ -7,6 +7,8 @@ OnFailureJobMode=isolate
 [Service]
 Type=simple
 ExecStart=/usr/libexec/coreos-installer
+# Perform reboot after install unless asked not to.
+ExecStop=/bin/sh -c 'test -f /tmp/skip_reboot || sleep 5 && reboot'
 #StandardInput=tty-force
 StandardInput=tty
 StandardOutput=kmsg+console

--- a/dracut/30coreos-installer/module-setup.sh
+++ b/dracut/30coreos-installer/module-setup.sh
@@ -21,8 +21,12 @@ install() {
     inst_multiple /usr/bin/dc
     inst_multiple /usr/bin/dd
     inst_multiple /usr/bin/gpg2
+    inst_multiple /usr/bin/grep
+    inst_multiple /usr/bin/lsblk
     inst_multiple /usr/bin/ps
     inst_multiple /usr/bin/sha256sum
+    inst_multiple /usr/bin/tail
+    inst_multiple /usr/bin/tr
     inst_multiple /usr/bin/zcat
 
     # sbin

--- a/dracut/30coreos-installer/module-setup.sh
+++ b/dracut/30coreos-installer/module-setup.sh
@@ -15,16 +15,19 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple /usr/bin/gpg2
-    inst_multiple /usr/bin/curl
-    inst_multiple /usr/sbin/wipefs
-    inst_multiple /usr/sbin/blockdev
-    inst_multiple /usr/bin/dd
-    inst_multiple /usr/bin/dc
+    # bin
     inst_multiple /usr/bin/awk
+    inst_multiple /usr/bin/curl
+    inst_multiple /usr/bin/dc
+    inst_multiple /usr/bin/dd
+    inst_multiple /usr/bin/gpg2
     inst_multiple /usr/bin/ps
     inst_multiple /usr/bin/sha256sum
     inst_multiple /usr/bin/zcat
+
+    # sbin
+    inst_multiple /usr/sbin/blockdev
+    inst_multiple /usr/sbin/wipefs
 
     inst_simple /usr/libexec/coreos-installer
 

--- a/dracut/30coreos-installer/parse-coreos.sh
+++ b/dracut/30coreos-installer/parse-coreos.sh
@@ -52,6 +52,9 @@ then
     echo 1 > /tmp/skip_media_check
 fi
 
+# This one is not consumed by the CLI but actually by the
+# coreos-installer.service systemd unit that is run in the
+# initramfs. We don't default to rebooting from the CLI.
 if getargbool 0 coreos.inst.skip_reboot
 then
     echo "Asserting reboot skip" >> /tmp/debug


### PR DESCRIPTION
This PR contains various fixups that were found while testing out the CLI invocation
of coreos-installer. Probably most effective to review each commit individually.

- f897ff0 o README: add notes for CLI invocation         
- 3870e93 o coreos-installer: clear the trap handler after umount
- 4bc7da9 o coreos-installer: move reboot logic to dracut service
- efe979d o coreos-installer: make sure we run as root
- 666303d o coreos-installer: verify boot partition device
- 520ff67 o coreos-installer: make new mount_boot_partition function
- 4bc70c3 o dracut: alphabetical sort of dracut dependencies
