### PR TITLE
module-setup.sh: Explicitly add gzip

### DIFF
--- a/dracut/30coreos-installer/module-setup.sh
+++ b/dracut/30coreos-installer/module-setup.sh
@@ -22,6 +22,7 @@ install() {
     inst_multiple /usr/bin/dd
     inst_multiple /usr/bin/gpg2
     inst_multiple /usr/bin/grep
+    inst_multiple /usr/bin/gzip
     inst_multiple /usr/bin/lsblk
     inst_multiple /usr/bin/ps
     inst_multiple /usr/bin/sha256sum


### PR DESCRIPTION
`zcat` is just a thin shell wrapper around `gzip`. So we need to
explicitly add that to the initrd as well.