### PR TITLE
Read Ignition platform ID and write to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ standalone script or during bootup via a dracut module.
 * coreos.inst.image_url - The url of the coreos image to install to this device
 * coreos.inst.ignition_url - The url of the coreos ignition config (optional, enter
   coreos.inst.ignition_url=skip to not load an ignition config)
+* coreos.inst.platform_id - The ignition platform ID the coreos image to install to
 
 ## Using the installer on FCOS or RHCOS
 
@@ -100,6 +101,7 @@ kernel command line telling it what you want it to do. For example:
 - `coreos.inst.install_dev=sda`
 - `coreos.inst.image_url=http://example.com/fedora-coreos-30.107-metal-bios.raw.gz`
 - `coreos.inst.ignition_url=http://example.com/config.ign`
+- `coreos.inst.platform_id=qemu`
 
 **NOTE** make sure to use a `metal-uefi` image if booting via UEFI
 

--- a/coreos-installer
+++ b/coreos-installer
@@ -386,7 +386,14 @@ write_platform_id() {
     local tmp_platform_id="/tmp/platform_id"
 
     if [ ! -f ${tmp_platform_id} ]; then
-        log "Not writing ignition platform id to ignition.firstboot, no platform id provided"
+        local default_platform_id=$(grep -o "ignition.platform.id=[a-zA-Z0-9]*" /proc/cmdline)
+        if [[ ! -z ${default_platform_id} ]]; then
+            log "Writing default ignition platform id to ignition.firstboot"
+            echo ${default_platform_id} >> ${ignition_firstboot}
+            log "Wrote ${default_platform_id} to ignition.firstboot"
+        else
+            log "Not writing ignition platform id to ignition.firstboot, no platform id provided"
+        fi
         return
     fi
 

--- a/coreos-installer
+++ b/coreos-installer
@@ -378,6 +378,29 @@ write_networking_opts() {
     echo "set ignition_network_kcmdline=\"$(cat /tmp/networking_opts)\"" >> /mnt/boot_partition/ignition.firstboot
 }
 
+#########################################################
+# Helper to persist ignition platform id to initramfs first boot
+#########################################################
+write_platform_id() {
+    local ignition_firstboot="/mnt/boot_partition/ignition.firstboot"
+    local tmp_platform_id="/tmp/platform_id"
+
+    if [ ! -f ${tmp_platform_id} ]; then
+        log "Not writing ignition platform id to ignition.firstboot, no platform id provided"
+        return
+    fi
+
+    log "Writing ignition platform id to ignition.firstboot"
+
+    if [[ ! -f ${ignition_firstboot} ]]; then
+        mkdir -p /boot/ ; touch ${ignition_firstboot}
+    fi
+    cat ${tmp_platform_id} >> ${ignition_firstboot}
+
+    rm -f ${tmp_platform_id}
+    log "Wrote $(cat ${ignition_firstboot}) to ignition.firstboot"
+}
+
 ############################################################
 # Helper to persist additional options to initramfs first boot
 ############################################################
@@ -673,17 +696,20 @@ Options:
                 kcmdline.
     -b BASEURL  The URL to the image, alternatively specify
                 coreos.inst.image_url on the kcmdline.
+    -p PLATFORM_ID The platform ID, alternatively specify
+                coreos.inst.platform_id on the kcmdline.
     -h          This.
 
 This tool installs CoreOS style disk images on a block device.
 "
 
-    while getopts "d:i:b:h" OPTION
+    while getopts "d:i:b:p:h" OPTION
     do
         case $OPTION in
             d) DEVICE="$OPTARG" ;;
             i) IGNITION="$OPTARG" ;;
             b) BASE_URL="${OPTARG%/}" ;;
+            p) PLATFORM_ID="$OPTARG" ;;
             h) echo "$USAGE"; exit;;
             *) exit 1;;
         esac
@@ -702,6 +728,11 @@ This tool installs CoreOS style disk images on a block device.
     if [[ ! -z "${BASE_URL}" ]]
     then
         echo "${BASE_URL}" > /tmp/image_url
+    fi
+
+    if [[ ! -z "${PLATFORM_ID}" ]]
+    then
+        echo "${PLATFORM_ID}" > /tmp/platform_id
     fi
 }
 
@@ -740,6 +771,9 @@ main() {
     # If networking options were present, persist to firstboot initramfs
     write_networking_opts
     write_additional_opts
+
+    # If ignition platform id is provided, write to /mnt/boot_partition/ignition.firstboot
+    write_platform_id
 
     log "Install complete"
 }

--- a/coreos-installer
+++ b/coreos-installer
@@ -382,30 +382,24 @@ write_networking_opts() {
 # Helper to persist ignition platform id to initramfs first boot
 #########################################################
 write_platform_id() {
-    local ignition_firstboot="/mnt/boot_partition/ignition.firstboot"
+    local ignition_platform_id="/mnt/boot_partition/ignition_platform_id"
     local tmp_platform_id="/tmp/platform_id"
 
     if [ ! -f ${tmp_platform_id} ]; then
-        local default_platform_id=$(grep -o "ignition.platform.id=[a-zA-Z0-9]*" /proc/cmdline)
-        if [[ ! -z ${default_platform_id} ]]; then
-            log "Writing default ignition platform id to ignition.firstboot"
-            echo ${default_platform_id} >> ${ignition_firstboot}
-            log "Wrote ${default_platform_id} to ignition.firstboot"
-        else
-            log "Not writing ignition platform id to ignition.firstboot, no platform id provided"
-        fi
+        log "Not writing ignition platform id to ignition_platform_id, no platform id provided"
         return
     fi
 
-    log "Writing ignition platform id to ignition.firstboot"
+    log "Writing ignition platform id to ignition_platform_id"
+    # check for the boot partition
+    mkdir -p /mnt/boot_partition
+    mount_boot_partition /mnt/boot_partition
+    trap 'umount /mnt/boot_partition; trap - RETURN' RETURN
 
-    if [[ ! -f ${ignition_firstboot} ]]; then
-        mkdir -p /boot/ ; touch ${ignition_firstboot}
-    fi
-    cat ${tmp_platform_id} >> ${ignition_firstboot}
+    echo "set ignition.platform.id=\"$(cat ${tmp_platform_id})\"" >> ${ignition_platform_id}
 
     rm -f ${tmp_platform_id}
-    log "Wrote $(cat ${ignition_firstboot}) to ignition.firstboot"
+    log "Wrote $(cat ${ignition_platform_id}) to ignition_platform_id"
 }
 
 ############################################################

--- a/dracut/30coreos-installer/parse-coreos.sh
+++ b/dracut/30coreos-installer/parse-coreos.sh
@@ -24,6 +24,12 @@ then
     echo $IGNITION_URL >> /tmp/ignition_url
 fi
 
+local PLATFORM_ID=$(getarg coreos.inst.platform_id=)
+if [ ! -z "$PLATFORM_ID" ]
+then
+    echo "preset ignition platform id to ${PLATFORM_ID}" >> /tmp/debug
+    echo $PLATFORM_ID >> /tmp/platform_id
+fi
 
 # Kernel networking args
 # Currently only persisting `ipv6.disable`, but additional options may be added


### PR DESCRIPTION
This change makes coreos-installer reads ignition platform id from command line option `-p` and appends the value to ignition.firstboot. Also reads Ignition platform ID from kcmdline then to /tmp/platform_id, which will then be picked up and written to ignition.firstboot.

Edit: Now writes to the file `ignition_platform_id`.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/191