### PR TITLE
coreos-installer: Use sed to overwrite ignition.platform.id in BLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ standalone script or during bootup via a dracut module.
 * `coreos.inst.image_url` - The URL of the CoreOS image to install to this device
 * `coreos.inst.ignition_url` - The URL of the CoreOS Ignition config (optional, enter
   `coreos.inst.ignition_url=skip` to not load an Ignition config)
-* `coreos.inst.platform_id` - The ignition platform ID the coreos image to install to
+* `coreos.inst.platform_id` - The Ignition platform ID the CoreOS image to install to
 
 ## Using the installer on FCOS or RHCOS
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ standalone script or during bootup via a dracut module.
 * `coreos.inst.image_url` - The URL of the CoreOS image to install to this device
 * `coreos.inst.ignition_url` - The URL of the CoreOS Ignition config (optional, enter
   `coreos.inst.ignition_url=skip` to not load an Ignition config)
-* `coreos.inst.platform_id` - The Ignition platform ID the CoreOS image to install to
+* `coreos.inst.platform_id` - The Ignition platform ID of the platform the CoreOS image is being installed on
 
 ## Using the installer on FCOS or RHCOS
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ standalone script or during bootup via a dracut module.
 * `coreos.inst.image_url` - The URL of the CoreOS image to install to this device
 * `coreos.inst.ignition_url` - The URL of the CoreOS Ignition config (optional, enter
   `coreos.inst.ignition_url=skip` to not load an Ignition config)
+* `coreos.inst.platform_id` - The ignition platform ID the coreos image to install to
 
 ## Using the installer on FCOS or RHCOS
 
@@ -64,6 +65,7 @@ kernel command line telling it what you want it to do. For example:
 - `coreos.inst.install_dev=sda`
 - `coreos.inst.image_url=http://example.com/fedora-coreos-30.20190801.0-metal.raw.xz`
 - `coreos.inst.ignition_url=http://example.com/config.ign`
+- `coreos.inst.platform_id=qemu`
 
 Now press `<ENTER>` (isolinux) or `<CTRL-x>` (grub) to kick off the
 install. The install will occur on tty2 and there are very few good

--- a/coreos-installer
+++ b/coreos-installer
@@ -378,6 +378,43 @@ write_networking_opts() {
     echo "set ignition_network_kcmdline=\"$(cat /tmp/networking_opts)\"" >> /mnt/boot_partition/ignition.firstboot
 }
 
+#########################################################
+# Helper to persist ignition platform id to initramfs first boot
+#########################################################
+write_platform_id() {
+    local tmp_platform_id="/tmp/platform_id"
+    local proc_cmdline="/proc/cmdline"
+
+    if [ ! -f ${tmp_platform_id} ]; then
+        log "Not overwriting ignition platform id, no platform id provided"
+        return
+    else
+        local platform_id="$(cat ${tmp_platform_id})"
+    fi
+
+
+    log "Overwriting ignition platform id"
+    # check for the boot partition
+    mkdir -p /mnt/boot_partition
+    mount_boot_partition /mnt/boot_partition
+    trap 'umount /mnt/boot_partition; trap - RETURN' RETURN
+    local conf_files=$(ls /mnt/boot_partition/loader/entries/ | grep 'conf')
+
+    for f in $conf_files
+    do
+        # Update boot loader entry first
+        local conf_files_path="/mnt/boot_partition/loader/entries/$f"
+        if grep -q 'ignition.platform.id' $conf_files_path; then
+            sed -i "s/ignition.platform.id=.* /ignition.platform.id=${platform_id} /" $conf_files_path
+        else
+            echo " ignition.platform.id=${platform_id}" >> $conf_files_path
+        fi
+    done
+
+    rm -f ${tmp_platform_id}
+    log "Set ignition.platform.id=\"${platform_id}\""
+}
+
 ############################################################
 # Helper to persist additional options to initramfs first boot
 ############################################################
@@ -673,17 +710,20 @@ Options:
                 kcmdline.
     -b BASEURL  The URL to the image, alternatively specify
                 coreos.inst.image_url on the kcmdline.
+    -p PLATFORM_ID The platform ID, alternatively specify
+                coreos.inst.platform_id on the kcmdline.
     -h          This.
 
 This tool installs CoreOS style disk images on a block device.
 "
 
-    while getopts "d:i:b:h" OPTION
+    while getopts "d:i:b:p:h" OPTION
     do
         case $OPTION in
             d) DEVICE="$OPTARG" ;;
             i) IGNITION="$OPTARG" ;;
             b) BASE_URL="${OPTARG%/}" ;;
+            p) PLATFORM_ID="$OPTARG" ;;
             h) echo "$USAGE"; exit;;
             *) exit 1;;
         esac
@@ -702,6 +742,11 @@ This tool installs CoreOS style disk images on a block device.
     if [[ ! -z "${BASE_URL}" ]]
     then
         echo "${BASE_URL}" > /tmp/image_url
+    fi
+
+    if [[ ! -z "${PLATFORM_ID}" ]]
+    then
+        echo "${PLATFORM_ID}" > /tmp/platform_id
     fi
 }
 
@@ -740,6 +785,9 @@ main() {
     # If networking options were present, persist to firstboot initramfs
     write_networking_opts
     write_additional_opts
+
+    # If ignition platform id is provided, write to /mnt/boot_partition/ignition.firstboot
+    write_platform_id
 
     log "Install complete"
 }

--- a/coreos-installer
+++ b/coreos-installer
@@ -401,12 +401,12 @@ write_platform_id() {
 
     for f in $conf_files
     do
-        if grep -q -E "ignition.platform.id=[a-z]* " $f || grep -q -E "ignition.platform.id=[a-z]*$" $f; then
+        if grep -q -E "ignition.platform.id=[^ ]*" $f; then
             # ignition.platform.id is followed by whitespace or EOF
-            sed -i "s/ignition.platform.id=[a-z]*/ignition.platform.id=${platform_id}/" $f
+            sed -i -r "s/ignition.platform.id=[^ ]*?/ignition.platform.id=${platform_id}/" $f
         else
             # ignition.platform.id is not presented in BLS
-            sed -i "/^options/ s/$/ ignition.platform.id=${platform_id}" $f
+            sed -i "/^options/ s/$/ ignition.platform.id=${platform_id}/" $f
         fi
     done
 

--- a/coreos-installer
+++ b/coreos-installer
@@ -383,7 +383,6 @@ write_networking_opts() {
 #########################################################
 write_platform_id() {
     local tmp_platform_id="/tmp/platform_id"
-    local proc_cmdline="/proc/cmdline"
 
     if [ ! -f ${tmp_platform_id} ]; then
         log "Not overwriting ignition platform id, no platform id provided"
@@ -402,10 +401,11 @@ write_platform_id() {
 
     for f in $conf_files
     do
-        # Update boot loader entry first
-        if grep -q 'ignition.platform.id' $f; then
-            sed -i "s/ignition.platform.id=.* /ignition.platform.id=${platform_id} /" $f
+        if grep -q -E "ignition.platform.id=[a-z]* " $f || grep -q -E "ignition.platform.id=[a-z]*$" $f; then
+            # ignition.platform.id is followed by whitespace or EOF
+            sed -i "s/ignition.platform.id=[a-z]*/ignition.platform.id=${platform_id}/" $f
         else
+            # ignition.platform.id is not presented in BLS
             sed -i "/^options/ s/$/ ignition.platform.id=${platform_id}" $f
         fi
     done
@@ -702,16 +702,16 @@ write_image_to_disk() {
 parse_args() {
     USAGE="Usage: $0 [options]
 Options:
-    -d DEVICE   Install to the given device, alternatively specify
-                coreos.inst.install_dev on the kcmdline.
-    -i IGNITION The URL (or path) to the given Ignition config,
-                alternatively specify coreos.inst.ignition_url on the
-                kcmdline.
-    -b BASEURL  The URL to the image, alternatively specify
-                coreos.inst.image_url on the kcmdline.
+    -d DEVICE      Install to the given device, alternatively specify
+                   coreos.inst.install_dev on the kcmdline.
+    -i IGNITION    The URL (or path) to the given Ignition config,
+                   alternatively specify coreos.inst.ignition_url on the
+                   kcmdline.
+    -b BASEURL     The URL to the image, alternatively specify
+                   coreos.inst.image_url on the kcmdline.
     -p PLATFORM_ID The platform ID, alternatively specify
-                coreos.inst.platform_id on the kcmdline.
-    -h          This.
+                   coreos.inst.platform_id on the kcmdline.
+    -h             This.
 
 This tool installs CoreOS style disk images on a block device.
 "
@@ -785,7 +785,7 @@ main() {
     write_networking_opts
     write_additional_opts
 
-    # If ignition platform id is provided, write to /mnt/boot_partition/ignition.firstboot
+    # If ignition platform id is provided, overwrite ignition.platform.id in BLS
     write_platform_id
 
     log "Install complete"

--- a/coreos-installer
+++ b/coreos-installer
@@ -398,21 +398,20 @@ write_platform_id() {
     mkdir -p /mnt/boot_partition
     mount_boot_partition /mnt/boot_partition
     trap 'umount /mnt/boot_partition; trap - RETURN' RETURN
-    local conf_files=$(ls /mnt/boot_partition/loader/entries/ | grep 'conf')
+    local conf_files=$(ls /mnt/boot_partition/loader/entries/*conf)
 
     for f in $conf_files
     do
         # Update boot loader entry first
-        local conf_files_path="/mnt/boot_partition/loader/entries/$f"
-        if grep -q 'ignition.platform.id' $conf_files_path; then
-            sed -i "s/ignition.platform.id=.* /ignition.platform.id=${platform_id} /" $conf_files_path
+        if grep -q 'ignition.platform.id' $f; then
+            sed -i "s/ignition.platform.id=.* /ignition.platform.id=${platform_id} /" $f
         else
-            echo " ignition.platform.id=${platform_id}" >> $conf_files_path
+            sed -i "/^options/ s/$/ ignition.platform.id=${platform_id}" $f
         fi
     done
 
     rm -f ${tmp_platform_id}
-    log "Set ignition.platform.id=\"${platform_id}\""
+    log "Set ignition.platform.id=\"${platform_id}\" kernel CLI parameter in BLS configs"
 }
 
 ############################################################

--- a/dracut/30coreos-installer/parse-coreos.sh
+++ b/dracut/30coreos-installer/parse-coreos.sh
@@ -24,6 +24,12 @@ then
     echo $IGNITION_URL >> /tmp/ignition_url
 fi
 
+local PLATFORM_ID=$(getarg coreos.inst.platform_id=)
+if [ ! -z "$PLATFORM_ID" ]
+then
+    echo "preset ignition platform id to ${PLATFORM_ID}" >> /tmp/debug
+    echo $PLATFORM_ID >> /tmp/platform_id
+fi
 
 # Kernel networking args
 # Currently only persisting `ipv6.disable`, but additional options may be added


### PR DESCRIPTION
Adds a command line option that reads ignition.platform.id from user
and applys / overwrites it in BLS.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/191
Signed-off-by: Zonggen (Allen) Bai, abai@redhat.com