### PR TITLE
Revert "Use `dd conv=sparse`"

### DIFF
--- a/coreos-installer
+++ b/coreos-installer
@@ -682,7 +682,7 @@ write_image_to_disk() {
     fi
 
     $DECOMPRESSION_TOOL /mnt/dl/imagefile.compressed |\
-    dd bs=1M iflag=fullblock oflag=direct conv=sparse of="${DEST_DEV}" status=none
+    dd bs=1M iflag=fullblock oflag=direct of="${DEST_DEV}" status=none
     RETCODE=$?
     if [[ $RETCODE -ne 0 ]]; then
         log "failed to write image to disk"


### PR DESCRIPTION
This reverts commit 33ba62ef154c32b6e5d8b4278e7f56180a31d8c5.

As bgilbert points out in
https://github.com/coreos/coreos-installer/pull/20#issuecomment-547561379

> This isn't safe. The image might contain zeroed blocks for reasons other
> than unallocated space, and if the target disk already has data on it,
> we'll write a corrupt image to disk.