### PR TITLE
Block device handling improvements

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -130,7 +130,7 @@ impl Drop for Mount {
     }
 }
 
-pub fn reread_partition_table(file: &File) -> Result<()> {
+pub fn reread_partition_table(file: &mut File) -> Result<()> {
     let fd = file.as_raw_fd();
     // Reread sometimes fails inexplicably.  Retry several times before
     // giving up.

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use error_chain::bail;
-use nix::{ioctl_none, mount};
+use nix::errno::Errno;
+use nix::{self, ioctl_none, ioctl_write_ptr_bad, mount, request_code_none};
 use serde::Deserialize;
 use std::fs::{remove_dir, File};
+use std::io::{Seek, SeekFrom};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -147,8 +149,35 @@ pub fn reread_partition_table(file: &mut File) -> Result<()> {
     Ok(())
 }
 
-// create unsafe ioctl wrapper
+/// Try discarding all blocks from the underlying block device.
+/// Return true if successful, false if the underlying device doesn't
+/// support discard, or an error otherwise.
+pub fn try_discard_all(file: &mut File) -> Result<bool> {
+    // get device size
+    let length = file
+        .seek(SeekFrom::End(0))
+        .chain_err(|| "seeking device file")?;
+    file.seek(SeekFrom::Start(0))
+        .chain_err(|| "seeking device file")?;
+
+    // discard
+    let fd = file.as_raw_fd();
+    let range: [u64; 2] = [0, length];
+    match unsafe { blkdiscard(fd, &range) } {
+        Ok(_) => Ok(true),
+        Err(e) => {
+            if e == nix::Error::from_errno(Errno::EOPNOTSUPP) {
+                Ok(false)
+            } else {
+                Err(Error::with_chain(e, "discarding device contents"))
+            }
+        }
+    }
+}
+
+// create unsafe ioctl wrappers
 ioctl_none!(blkrrpart, 0x12, 95);
+ioctl_write_ptr_bad!(blkdiscard, request_code_none!(0x12, 119), [u64; 2]);
 
 pub fn udev_settle() -> Result<()> {
     // There's a potential window after rereading the partition table where

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn run() -> Result<()> {
     {
         bail!("{} is not a block device", &config.device);
     }
-    reread_partition_table(&dest)
+    reread_partition_table(&mut dest)
         .chain_err(|| format!("checking for exclusive access to {}", &config.device))?;
 
     // copy and postprocess disk image
@@ -476,7 +476,7 @@ fn clear_partition_table(dest: &mut File) -> Result<()> {
         .chain_err(|| "flushing partition table to disk")?;
     dest.sync_all()
         .chain_err(|| "syncing partition table to disk")?;
-    reread_partition_table(&dest)?;
+    reread_partition_table(dest)?;
     udev_settle()?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,6 +248,10 @@ fn parse_args() -> Result<Config> {
 /// If this function fails, the caller should wipe the partition table
 /// to ensure the user doesn't boot from a partially-written disk.
 fn write_disk(config: &Config, source: &mut ImageSource, dest: &mut File) -> Result<()> {
+    // Try to discard the entire device as a courtesy to the SSD wear
+    // leveler or LVM thin pool.
+    try_discard_all(dest)?;
+
     // copy the image
     write_image(source, dest)?;
     reread_partition_table(dest)?;
@@ -467,6 +471,13 @@ fn write_platform(mountpoint: &Path, platform: &str) -> Result<()> {
 /// Clear the partition table.  For use after a failure.
 fn clear_partition_table(dest: &mut File) -> Result<()> {
     println!("Clearing partition table");
+    // Try to discard the entire device as a courtesy to the SSD wear
+    // leveler or LVM thin pool.  Report errors and continue.
+    if let Err(e) = try_discard_all(dest) {
+        eprint!("{}", ChainedError::display_chain(&e));
+    }
+    // Discard might fail and doesn't imply zeroing, so manually clear the
+    // first MiB.
     dest.seek(SeekFrom::Start(0))
         .chain_err(|| "seeking to start of disk")?;
     let zeroes: [u8; 1024 * 1024] = [0; 1024 * 1024];


### PR DESCRIPTION
- If the output path is not a block device, produce an error message that doesn't talk about typewriters
- Issue discard request for entire output device before writing to it, and also after a failure
- Minor cleanups