### PR TITLE
Add list-stream subcommand

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -261,7 +261,7 @@ fn parse_install(matches: &ArgMatches) -> Result<Config> {
         )?)
     };
     // and report it to the user
-    println!("{}", location);
+    eprintln!("{}", location);
 
     // build configuration
     Ok(Config::Install(InstallConfig {

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -21,6 +21,7 @@ use crate::source::*;
 
 pub enum Config {
     Install(InstallConfig),
+    Download(DownloadConfig),
     IsoEmbed(IsoEmbedConfig),
     IsoShow(IsoShowConfig),
     IsoRemove(IsoRemoveConfig),
@@ -32,6 +33,13 @@ pub struct InstallConfig {
     pub ignition: Option<String>,
     pub platform: Option<String>,
     pub firstboot_kargs: Option<String>,
+    pub insecure: bool,
+}
+
+pub struct DownloadConfig {
+    pub location: Box<dyn ImageLocation>,
+    pub directory: String,
+    pub decompress: bool,
     pub insecure: bool,
 }
 
@@ -147,6 +155,62 @@ pub fn parse_args() -> Result<Config> {
                 ),
         )
         .subcommand(
+            SubCommand::with_name("download")
+                .about("Download a CoreOS image")
+                .arg(
+                    Arg::with_name("stream")
+                        .short("s")
+                        .long("stream")
+                        .value_name("name")
+                        .help("Fedora CoreOS stream")
+                        .default_value("stable")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("architecture")
+                        .long("architecture")
+                        .value_name("name")
+                        .help("Target CPU architecture")
+                        .default_value(uname.machine())
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("image-url")
+                        .short("u")
+                        .long("image-url")
+                        .value_name("URL")
+                        .help("Manually specify the image URL")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("directory")
+                        .short("C")
+                        .long("directory")
+                        .value_name("path")
+                        .help("Destination directory")
+                        .default_value(".")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("decompress")
+                        .short("d")
+                        .long("decompress")
+                        .help("Decompress image and don't save signature"),
+                )
+                .arg(
+                    Arg::with_name("insecure")
+                        .long("insecure")
+                        .help("Skip signature verification"),
+                )
+                .arg(
+                    Arg::with_name("stream-base-url")
+                        .long("stream-base-url")
+                        .value_name("URL")
+                        .help("Base URL for Fedora CoreOS stream metadata")
+                        .takes_value(true),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("iso")
                 .about("Embed an Ignition config in a CoreOS live ISO image")
                 .subcommand(
@@ -217,6 +281,7 @@ pub fn parse_args() -> Result<Config> {
 
     match app_matches.subcommand() {
         ("install", Some(matches)) => parse_install(&matches),
+        ("download", Some(matches)) => parse_download(&matches),
         ("iso", Some(iso_matches)) => match iso_matches.subcommand() {
             ("embed", Some(matches)) => parse_iso_embed(&matches),
             ("show", Some(matches)) => parse_iso_show(&matches),
@@ -273,6 +338,48 @@ fn parse_install(matches: &ArgMatches) -> Result<Config> {
         ignition: matches.value_of("ignition-path").map(String::from),
         platform: matches.value_of("platform").map(String::from),
         firstboot_kargs: matches.value_of("firstboot-kargs").map(String::from),
+        insecure: matches.is_present("insecure"),
+    }))
+}
+
+fn parse_download(matches: &ArgMatches) -> Result<Config> {
+    // Build image location.  Ideally we'd use conflicts_with (and an
+    // ArgGroup for streams), but that doesn't play well with default
+    // arguments, so we manually prioritize modes.
+    let location: Box<dyn ImageLocation> = if matches.is_present("image-url") {
+        let image_url = Url::parse(matches.value_of("image-url").expect("image-url missing"))
+            .chain_err(|| "parsing image URL")?;
+        Box::new(UrlLocation::new(&image_url))
+    } else {
+        let base_url = if matches.is_present("stream-base-url") {
+            Some(
+                Url::parse(
+                    matches
+                        .value_of("stream-base-url")
+                        .expect("stream-base-url missing"),
+                )
+                .chain_err(|| "parsing stream base URL")?,
+            )
+        } else {
+            None
+        };
+        Box::new(StreamLocation::new(
+            matches.value_of("stream").expect("stream missing"),
+            matches
+                .value_of("architecture")
+                .expect("architecture missing"),
+            base_url.as_ref(),
+        )?)
+    };
+
+    // build configuration
+    Ok(Config::Download(DownloadConfig {
+        location,
+        directory: matches
+            .value_of("directory")
+            .map(String::from)
+            .expect("directory missing"),
+        decompress: matches.is_present("decompress"),
         insecure: matches.is_present("insecure"),
     }))
 }

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -175,6 +175,24 @@ pub fn parse_args() -> Result<Config> {
                         .takes_value(true),
                 )
                 .arg(
+                    Arg::with_name("platform")
+                        .short("p")
+                        .long("platform")
+                        .value_name("name")
+                        .help("Fedora CoreOS platform name")
+                        .default_value("metal")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("format")
+                        .short("f")
+                        .long("format")
+                        .value_name("name")
+                        .help("Image format")
+                        .default_value("raw.xz")
+                        .takes_value(true),
+                )
+                .arg(
                     Arg::with_name("image-url")
                         .short("u")
                         .long("image-url")
@@ -322,6 +340,8 @@ fn parse_install(matches: &ArgMatches) -> Result<Config> {
             matches
                 .value_of("architecture")
                 .expect("architecture missing"),
+            "metal",
+            "raw.xz",
             base_url.as_ref(),
         )?)
     };
@@ -368,6 +388,8 @@ fn parse_download(matches: &ArgMatches) -> Result<Config> {
             matches
                 .value_of("architecture")
                 .expect("architecture missing"),
+            matches.value_of("platform").expect("platform missing"),
+            matches.value_of("format").expect("format missing"),
             base_url.as_ref(),
         )?)
     };

--- a/src/download.rs
+++ b/src/download.rs
@@ -36,6 +36,7 @@ pub fn write_image(source: &mut ImageSource, dest: &mut File) -> Result<()> {
     };
 
     // wrap again for progress reporting
+    let artifact_type = source.artifact_type.clone();
     let have_length = source.length_hint.is_some();
     let length_hint = source.length_hint.unwrap_or(0);
     let mut position: u64 = 0;
@@ -48,13 +49,14 @@ pub fn write_image(source: &mut ImageSource, dest: &mut File) -> Result<()> {
             last_report = Instant::now();
             if have_length {
                 eprint!(
-                    "> Read {}/{} ({}%)   \r",
+                    "> Read {} {}/{} ({}%)   \r",
+                    &artifact_type,
                     format_bytes(position),
                     format_bytes(length_hint),
                     100 * position / length_hint
                 );
             } else {
-                eprint!("> Read {}   \r", format_bytes(position));
+                eprint!("> Read {} {}   \r", &artifact_type, format_bytes(position));
             }
             let _ = std::io::stdout().flush();
         }

--- a/src/download.rs
+++ b/src/download.rs
@@ -25,7 +25,7 @@ use crate::source::*;
 use crate::verify::*;
 
 /// Copy the image to disk and verify its signature.
-pub fn write_image(source: &mut ImageSource, dest: &mut File) -> Result<()> {
+pub fn write_image(source: &mut ImageSource, dest: &mut File, decompress: bool) -> Result<()> {
     // wrap source for GPG verification
     let mut verify_reader: Box<dyn Read> = {
         if let Some(signature) = source.signature.as_ref() {
@@ -72,7 +72,9 @@ pub fn write_image(source: &mut ImageSource, dest: &mut File) -> Result<()> {
         // verify default buffer size >= the largest magic number we might
         // care about
         assert!(sniff.len() >= 8);
-        if &sniff[0..2] == b"\x1f\x8b" {
+        if !decompress {
+            Box::new(buf_reader)
+        } else if &sniff[0..2] == b"\x1f\x8b" {
             Box::new(GzDecoder::new(buf_reader))
         } else if &sniff[0..6] == b"\xfd7zXZ\x00" {
             Box::new(XzDecoder::new(buf_reader))

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,0 +1,127 @@
+// Copyright 2019 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use byte_unit::Byte;
+use flate2::read::GzDecoder;
+use progress_streams::ProgressReader;
+use std::fs::File;
+use std::io::{copy, BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::time::{Duration, Instant};
+use xz2::read::XzDecoder;
+
+use crate::errors::*;
+use crate::source::*;
+use crate::verify::*;
+
+/// Copy the image to disk and verify its signature.
+pub fn write_image(source: &mut ImageSource, dest: &mut File) -> Result<()> {
+    // wrap source for GPG verification
+    let mut verify_reader: Box<dyn Read> = {
+        if let Some(signature) = source.signature.as_ref() {
+            Box::new(GpgReader::new(&mut source.reader, signature)?)
+        } else {
+            Box::new(&mut source.reader)
+        }
+    };
+
+    // wrap again for progress reporting
+    let have_length = source.length_hint.is_some();
+    let length_hint = source.length_hint.unwrap_or(0);
+    let mut position: u64 = 0;
+    let mut last_report = Instant::now();
+    let mut progress_reader = ProgressReader::new(&mut verify_reader, |progress: usize| {
+        position += progress as u64;
+        if last_report.elapsed() >= Duration::from_secs(1)
+            || (have_length && position == length_hint)
+        {
+            last_report = Instant::now();
+            if have_length {
+                print!(
+                    "> Read {}/{} ({}%)   \r",
+                    format_bytes(position),
+                    format_bytes(length_hint),
+                    100 * position / length_hint
+                );
+            } else {
+                print!("> Read {}   \r", format_bytes(position));
+            }
+            let _ = std::io::stdout().flush();
+        }
+    });
+
+    // Wrap in a BufReader so we can peek at the first few bytes for
+    // format sniffing.  Don't trust the content-type since the server
+    // may not be configured correctly, or the file might be local.
+    // Then wrap in a reader for decompression.
+    let mut buf_reader = BufReader::new(&mut progress_reader);
+    let mut decompress_reader: Box<dyn Read> = {
+        let sniff = buf_reader.fill_buf().chain_err(|| "sniffing input")?;
+        // verify default buffer size >= the largest magic number we might
+        // care about
+        assert!(sniff.len() >= 8);
+        if &sniff[0..2] == b"\x1f\x8b" {
+            Box::new(GzDecoder::new(buf_reader))
+        } else if &sniff[0..6] == b"\xfd7zXZ\x00" {
+            Box::new(XzDecoder::new(buf_reader))
+        } else {
+            Box::new(buf_reader)
+        }
+    };
+
+    // Cache the first MiB of input and write zeroes instead.  This ensures
+    // that the disk image can't be used accidentally before its GPG signature
+    // is verified.
+    let mut first_mb: [u8; 1024 * 1024] = [0; 1024 * 1024];
+    dest.write_all(&first_mb)
+        .chain_err(|| "clearing first MiB of disk")?;
+    decompress_reader
+        .read_exact(&mut first_mb)
+        .chain_err(|| "decoding first MiB of image")?;
+
+    // do the rest of the copy
+    // This physically writes any runs of zeroes, rather than sparsifying,
+    // but sparsifying is unsafe.  We can't trust that all runs of zeroes in
+    // the image represent unallocated blocks, so we must ensure that zero
+    // blocks are actually stored as zeroes to avoid image corruption.
+    // Discard is insufficient for this: even if our discard request
+    // succeeds, discard is not guaranteed to zero blocks (see kernel
+    // commits 98262f2762f0 and 48920ff2a5a9).  Ideally we could use
+    // BLKZEROOUT to perform hardware-accelerated zeroing and then
+    // sparse-copy the image, falling back to non-sparse copy if hardware
+    // acceleration is unavailable.  But BLKZEROOUT doesn't support
+    // BLKDEV_ZERO_NOFALLBACK, so we'd risk gigabytes of redundant I/O.
+    copy(&mut decompress_reader, dest).chain_err(|| "decoding and writing image")?;
+
+    // verify_reader has now checked the signature, so fill in the first MiB
+    dest.seek(SeekFrom::Start(0))
+        .chain_err(|| "seeking to start of disk")?;
+    dest.write_all(&first_mb)
+        .chain_err(|| "writing to first MiB of disk")?;
+
+    // flush
+    dest.flush().chain_err(|| "flushing data to disk")?;
+    dest.sync_all().chain_err(|| "syncing data to disk")?;
+
+    // log final newline
+    println!();
+
+    Ok(())
+}
+
+/// Format a size in bytes.
+fn format_bytes(count: u64) -> String {
+    Byte::from_bytes(count.into())
+        .get_appropriate_unit(true)
+        .format(1)
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -47,14 +47,14 @@ pub fn write_image(source: &mut ImageSource, dest: &mut File) -> Result<()> {
         {
             last_report = Instant::now();
             if have_length {
-                print!(
+                eprint!(
                     "> Read {}/{} ({}%)   \r",
                     format_bytes(position),
                     format_bytes(length_hint),
                     100 * position / length_hint
                 );
             } else {
-                print!("> Read {}   \r", format_bytes(position));
+                eprint!("> Read {}   \r", format_bytes(position));
             }
             let _ = std::io::stdout().flush();
         }
@@ -114,7 +114,7 @@ pub fn write_image(source: &mut ImageSource, dest: &mut File) -> Result<()> {
     dest.sync_all().chain_err(|| "syncing data to disk")?;
 
     // log final newline
-    println!();
+    eprintln!();
 
     Ok(())
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -66,7 +66,7 @@ pub fn install(config: &InstallConfig) -> Result<()> {
         bail!("install failed");
     }
 
-    println!("Install complete.");
+    eprintln!("Install complete.");
     Ok(())
 }
 
@@ -102,7 +102,7 @@ fn write_disk(config: &InstallConfig, source: &mut ImageSource, dest: &mut File)
 
 /// Write the Ignition config.
 fn write_ignition(mountpoint: &Path, config_src: &str) -> Result<()> {
-    println!("Writing Ignition config");
+    eprintln!("Writing Ignition config");
 
     // make parent directory
     let mut config_dest = mountpoint.to_path_buf();
@@ -132,7 +132,7 @@ fn write_ignition(mountpoint: &Path, config_src: &str) -> Result<()> {
 
 /// Write first-boot kernel arguments.
 fn write_firstboot_kargs(mountpoint: &Path, args: &str) -> Result<()> {
-    println!("Writing first-boot kernel arguments");
+    eprintln!("Writing first-boot kernel arguments");
 
     // write the arguments
     let mut config_dest = mountpoint.to_path_buf();
@@ -159,7 +159,7 @@ fn write_platform(mountpoint: &Path, platform: &str) -> Result<()> {
         return Ok(());
     }
 
-    println!("Setting platform to {}", platform);
+    eprintln!("Setting platform to {}", platform);
 
     // walk /boot/loader/entries/*.conf
     let mut config_path = mountpoint.to_path_buf();
@@ -212,7 +212,7 @@ fn write_platform(mountpoint: &Path, platform: &str) -> Result<()> {
 
 /// Clear the partition table.  For use after a failure.
 fn clear_partition_table(dest: &mut File) -> Result<()> {
-    println!("Clearing partition table");
+    eprintln!("Clearing partition table");
     // Try to discard the entire device as a courtesy to the SSD wear
     // leveler or LVM thin pool.  Report errors and continue.
     if let Err(e) = try_discard_all(dest) {

--- a/src/install.rs
+++ b/src/install.rs
@@ -26,7 +26,12 @@ use crate::source::*;
 
 pub fn install(config: &InstallConfig) -> Result<()> {
     // set up image source
-    let mut source = config.location.source()?;
+    // we only support installing from a single artifact
+    let mut sources = config.location.sources()?;
+    let mut source = sources.pop().chain_err(|| "no artifacts found")?;
+    if !sources.is_empty() {
+        bail!("found multiple artifacts");
+    }
     if source.signature.is_none() {
         if config.insecure {
             eprintln!("Signature not found; skipping verification as requested");

--- a/src/install.rs
+++ b/src/install.rs
@@ -12,22 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use byte_unit::Byte;
 use error_chain::{bail, ChainedError};
-use flate2::read::GzDecoder;
-use progress_streams::ProgressReader;
 use std::fs::{create_dir_all, read_dir, File, OpenOptions};
-use std::io::{copy, BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::io::{copy, Read, Seek, SeekFrom, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
-use std::time::{Duration, Instant};
-use xz2::read::XzDecoder;
 
 use crate::blockdev::*;
 use crate::cmdline::*;
+use crate::download::*;
 use crate::errors::*;
 use crate::source::*;
-use crate::verify::*;
 
 pub fn install(config: &InstallConfig) -> Result<()> {
     // set up image source
@@ -101,101 +96,6 @@ fn write_disk(config: &InstallConfig, source: &mut ImageSource, dest: &mut File)
             write_platform(mount.mountpoint(), platform)?;
         }
     }
-
-    Ok(())
-}
-
-/// Copy the image to disk and verify its signature.
-fn write_image(source: &mut ImageSource, dest: &mut File) -> Result<()> {
-    // wrap source for GPG verification
-    let mut verify_reader: Box<dyn Read> = {
-        if let Some(signature) = source.signature.as_ref() {
-            Box::new(GpgReader::new(&mut source.reader, signature)?)
-        } else {
-            Box::new(&mut source.reader)
-        }
-    };
-
-    // wrap again for progress reporting
-    let have_length = source.length_hint.is_some();
-    let length_hint = source.length_hint.unwrap_or(0);
-    let mut position: u64 = 0;
-    let mut last_report = Instant::now();
-    let mut progress_reader = ProgressReader::new(&mut verify_reader, |progress: usize| {
-        position += progress as u64;
-        if last_report.elapsed() >= Duration::from_secs(1)
-            || (have_length && position == length_hint)
-        {
-            last_report = Instant::now();
-            if have_length {
-                print!(
-                    "> Read {}/{} ({}%)   \r",
-                    format_bytes(position),
-                    format_bytes(length_hint),
-                    100 * position / length_hint
-                );
-            } else {
-                print!("> Read {}   \r", format_bytes(position));
-            }
-            let _ = std::io::stdout().flush();
-        }
-    });
-
-    // Wrap in a BufReader so we can peek at the first few bytes for
-    // format sniffing.  Don't trust the content-type since the server
-    // may not be configured correctly, or the file might be local.
-    // Then wrap in a reader for decompression.
-    let mut buf_reader = BufReader::new(&mut progress_reader);
-    let mut decompress_reader: Box<dyn Read> = {
-        let sniff = buf_reader.fill_buf().chain_err(|| "sniffing input")?;
-        // verify default buffer size >= the largest magic number we might
-        // care about
-        assert!(sniff.len() >= 8);
-        if &sniff[0..2] == b"\x1f\x8b" {
-            Box::new(GzDecoder::new(buf_reader))
-        } else if &sniff[0..6] == b"\xfd7zXZ\x00" {
-            Box::new(XzDecoder::new(buf_reader))
-        } else {
-            Box::new(buf_reader)
-        }
-    };
-
-    // Cache the first MiB of input and write zeroes instead.  This ensures
-    // that the disk image can't be used accidentally before its GPG signature
-    // is verified.
-    let mut first_mb: [u8; 1024 * 1024] = [0; 1024 * 1024];
-    dest.write_all(&first_mb)
-        .chain_err(|| "clearing first MiB of disk")?;
-    decompress_reader
-        .read_exact(&mut first_mb)
-        .chain_err(|| "decoding first MiB of image")?;
-
-    // do the rest of the copy
-    // This physically writes any runs of zeroes, rather than sparsifying,
-    // but sparsifying is unsafe.  We can't trust that all runs of zeroes in
-    // the image represent unallocated blocks, so we must ensure that zero
-    // blocks are actually stored as zeroes to avoid image corruption.
-    // Discard is insufficient for this: even if our discard request
-    // succeeds, discard is not guaranteed to zero blocks (see kernel
-    // commits 98262f2762f0 and 48920ff2a5a9).  Ideally we could use
-    // BLKZEROOUT to perform hardware-accelerated zeroing and then
-    // sparse-copy the image, falling back to non-sparse copy if hardware
-    // acceleration is unavailable.  But BLKZEROOUT doesn't support
-    // BLKDEV_ZERO_NOFALLBACK, so we'd risk gigabytes of redundant I/O.
-    copy(&mut decompress_reader, dest).chain_err(|| "decoding and writing image")?;
-
-    // verify_reader has now checked the signature, so fill in the first MiB
-    dest.seek(SeekFrom::Start(0))
-        .chain_err(|| "seeking to start of disk")?;
-    dest.write_all(&first_mb)
-        .chain_err(|| "writing to first MiB of disk")?;
-
-    // flush
-    dest.flush().chain_err(|| "flushing data to disk")?;
-    dest.sync_all().chain_err(|| "syncing data to disk")?;
-
-    // log final newline
-    println!();
 
     Ok(())
 }
@@ -332,11 +232,4 @@ fn clear_partition_table(dest: &mut File) -> Result<()> {
     reread_partition_table(dest)?;
     udev_settle()?;
     Ok(())
-}
-
-/// Format a size in bytes.
-fn format_bytes(count: u64) -> String {
-    Byte::from_bytes(count.into())
-        .get_appropriate_unit(true)
-        .format(1)
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -79,7 +79,7 @@ fn write_disk(config: &InstallConfig, source: &mut ImageSource, dest: &mut File)
     try_discard_all(dest)?;
 
     // copy the image
-    write_image(source, dest)?;
+    write_image(source, dest, true)?;
     reread_partition_table(dest)?;
     udev_settle()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 
 mod blockdev;
 mod cmdline;
+mod download;
 mod errors;
 mod install;
 mod iso;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod verify;
 use error_chain::quick_main;
 
 use crate::cmdline::*;
+use crate::download::*;
 use crate::errors::*;
 use crate::install::*;
 use crate::iso::*;
@@ -34,6 +35,7 @@ fn run() -> Result<()> {
     let config = parse_args().chain_err(|| "parsing arguments")?;
 
     match config {
+        Config::Download(c) => download(&c),
         Config::Install(c) => install(&c),
         Config::IsoEmbed(c) => iso_embed(&c),
         Config::IsoShow(c) => iso_show(&c),

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use crate::download::*;
 use crate::errors::*;
 use crate::install::*;
 use crate::iso::*;
+use crate::source::*;
 
 quick_main!(run);
 
@@ -36,6 +37,7 @@ fn run() -> Result<()> {
 
     match config {
         Config::Download(c) => download(&c),
+        Config::ListStream(c) => list_stream(&c),
         Config::Install(c) => install(&c),
         Config::IsoEmbed(c) => iso_embed(&c),
         Config::IsoShow(c) => iso_show(&c),

--- a/src/source.rs
+++ b/src/source.rs
@@ -26,8 +26,8 @@ use crate::errors::*;
 const DEFAULT_STREAM_BASE_URL: &str = "https://builds.coreos.fedoraproject.org/streams/";
 
 pub trait ImageLocation: Display {
-    // Obtain the image length and signature and start fetching the image
-    fn source(&self) -> Result<ImageSource>;
+    // Obtain image lengths and signatures and start fetching the images
+    fn sources(&self) -> Result<Vec<ImageSource>>;
 }
 
 // Local image source
@@ -84,7 +84,7 @@ impl Display for FileLocation {
 }
 
 impl ImageLocation for FileLocation {
-    fn source(&self) -> Result<ImageSource> {
+    fn sources(&self) -> Result<Vec<ImageSource>> {
         // open local file for reading
         let mut out = OpenOptions::new()
             .read(true)
@@ -117,13 +117,13 @@ impl ImageLocation for FileLocation {
             .to_string_lossy()
             .to_string();
 
-        Ok(ImageSource {
+        Ok(vec![ImageSource {
             reader: Box::new(out),
             length_hint: Some(length),
             signature,
             filename,
             artifact_type: "disk".to_string(),
-        })
+        }])
     }
 }
 
@@ -154,7 +154,7 @@ impl Display for UrlLocation {
 }
 
 impl ImageLocation for UrlLocation {
-    fn source(&self) -> Result<ImageSource> {
+    fn sources(&self) -> Result<Vec<ImageSource>> {
         let client = reqwest::Client::new();
 
         // fetch signature
@@ -194,13 +194,13 @@ impl ImageLocation for UrlLocation {
             .chain_err(|| "walking image URL")?
             .to_string();
 
-        Ok(ImageSource {
+        Ok(vec![ImageSource {
             reader: Box::new(resp),
             length_hint,
             signature,
             filename,
             artifact_type: self.artifact_type.clone(),
-        })
+        }])
     }
 }
 
@@ -241,7 +241,7 @@ impl Display for StreamLocation {
 }
 
 impl ImageLocation for StreamLocation {
-    fn source(&self) -> Result<ImageSource> {
+    fn sources(&self) -> Result<Vec<ImageSource>> {
         let client = reqwest::Client::new();
 
         // fetch stream metadata
@@ -288,7 +288,7 @@ impl ImageLocation for StreamLocation {
                 .chain_err(|| "parsing signature URL from stream metadata")?,
             &artifact_type,
         )
-        .source()
+        .sources()
     }
 }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -103,6 +103,14 @@ impl<R: Read> GpgReader<R> {
             child: verify,
         })
     }
+
+    /// Read and discard all the bytes from the underlying reader, and
+    /// verify the signature.
+    pub fn consume(&mut self) -> Result<()> {
+        let mut buf: [u8; 4096] = [0; 4096];
+        while self.read(&mut buf).chain_err(|| "reading signed content")? > 0 {}
+        Ok(())
+    }
 }
 
 impl<R: Read> Read for GpgReader<R> {


### PR DESCRIPTION
Allow users to examine the architectures, platforms, and formats available within FCOS stream metadata.  Don't support listing artifacts within a format, since the `download` subcommand will download all of them.

Requires #78.

cc @lucab 