### PR TITLE
Add list-stream subcommand, tabular version

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -350,15 +350,8 @@ fn parse_install(matches: &ArgMatches) -> Result<Config> {
             .chain_err(|| "parsing image URL")?;
         Box::new(UrlLocation::new(&image_url))
     } else {
-        let base_url = if matches.is_present("stream-base-url") {
-            Some(
-                Url::parse(
-                    matches
-                        .value_of("stream-base-url")
-                        .expect("stream-base-url missing"),
-                )
-                .chain_err(|| "parsing stream base URL")?,
-            )
+        let base_url = if let Some(stream_base_url) = matches.value_of("stream-base-url") {
+            Some(Url::parse(stream_base_url).chain_err(|| "parsing stream base URL")?)
         } else {
             None
         };
@@ -398,15 +391,8 @@ fn parse_download(matches: &ArgMatches) -> Result<Config> {
             .chain_err(|| "parsing image URL")?;
         Box::new(UrlLocation::new(&image_url))
     } else {
-        let base_url = if matches.is_present("stream-base-url") {
-            Some(
-                Url::parse(
-                    matches
-                        .value_of("stream-base-url")
-                        .expect("stream-base-url missing"),
-                )
-                .chain_err(|| "parsing stream base URL")?,
-            )
+        let base_url = if let Some(stream_base_url) = matches.value_of("stream-base-url") {
+            Some(Url::parse(stream_base_url).chain_err(|| "parsing stream base URL")?)
         } else {
             None
         };

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -22,6 +22,7 @@ use crate::source::*;
 pub enum Config {
     Install(InstallConfig),
     Download(DownloadConfig),
+    ListStream(ListStreamConfig),
     IsoEmbed(IsoEmbedConfig),
     IsoShow(IsoShowConfig),
     IsoRemove(IsoRemoveConfig),
@@ -41,6 +42,11 @@ pub struct DownloadConfig {
     pub directory: String,
     pub decompress: bool,
     pub insecure: bool,
+}
+
+pub struct ListStreamConfig {
+    pub stream_base_url: Option<Url>,
+    pub stream: String,
 }
 
 pub struct IsoEmbedConfig {
@@ -229,6 +235,26 @@ pub fn parse_args() -> Result<Config> {
                 ),
         )
         .subcommand(
+            SubCommand::with_name("list-stream")
+                .about("List available images in a Fedora CoreOS stream")
+                .arg(
+                    Arg::with_name("stream")
+                        .short("s")
+                        .long("stream")
+                        .value_name("name")
+                        .help("Fedora CoreOS stream")
+                        .default_value("stable")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("stream-base-url")
+                        .long("stream-base-url")
+                        .value_name("URL")
+                        .help("Base URL for Fedora CoreOS stream metadata")
+                        .takes_value(true),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("iso")
                 .about("Embed an Ignition config in a CoreOS live ISO image")
                 .subcommand(
@@ -300,6 +326,7 @@ pub fn parse_args() -> Result<Config> {
     match app_matches.subcommand() {
         ("install", Some(matches)) => parse_install(&matches),
         ("download", Some(matches)) => parse_download(&matches),
+        ("list-stream", Some(matches)) => parse_list_stream(&matches),
         ("iso", Some(iso_matches)) => match iso_matches.subcommand() {
             ("embed", Some(matches)) => parse_iso_embed(&matches),
             ("show", Some(matches)) => parse_iso_show(&matches),
@@ -403,6 +430,21 @@ fn parse_download(matches: &ArgMatches) -> Result<Config> {
             .expect("directory missing"),
         decompress: matches.is_present("decompress"),
         insecure: matches.is_present("insecure"),
+    }))
+}
+
+fn parse_list_stream(matches: &ArgMatches) -> Result<Config> {
+    let stream_base_url = if let Some(base_url) = matches.value_of("stream-base-url") {
+        Some(Url::parse(base_url).chain_err(|| "parsing stream base URL")?)
+    } else {
+        None
+    };
+    Ok(Config::ListStream(ListStreamConfig {
+        stream_base_url,
+        stream: matches
+            .value_of("stream")
+            .map(String::from)
+            .expect("stream missing"),
     }))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use crate::download::*;
 use crate::errors::*;
 use crate::install::*;
 use crate::iso::*;
+use crate::source::*;
 
 quick_main!(run);
 
@@ -36,6 +37,7 @@ fn run() -> Result<()> {
 
     match config {
         Config::Download(c) => download(&c),
+        Config::ListStream(c) => list_stream(&c),
         Config::Install(c) => install(&c),
         Config::IsoEmbed(c) => iso_embed(&c),
         Config::IsoShow(c) => iso_show(&c),


### PR DESCRIPTION
Allow users to examine the architectures, platforms, and  formats available within FCOS stream metadata.  Don't support listing artifacts within a format, since the `download` subcommand will download all of them.

Unlike #79, this version generates a table with all arch/platform/format tuples, and doesn't provide arguments for filtering.  Sample output:

```
$ ./coreos-installer list-stream  -s testing
Architecture  Platform   Format
x86_64        aws        vmdk.xz
x86_64        metal      installer-pxe
x86_64        metal      installer.iso
x86_64        metal      iso
x86_64        metal      pxe
x86_64        metal      raw.xz
x86_64        openstack  qcow2.xz
x86_64        qemu       qcow2.xz
x86_64        vmware     ova
```

Requires #78.