### PR TITLE
verify: Switch to `always` trust model

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -85,11 +85,8 @@ impl<R: Read> GpgReader<R> {
             .arg("--homedir")
             .arg(gpgdir.path())
             .arg("--batch")
-            // avoid warnings about untrusted keys
             .arg("--trust-model")
-            .arg("tofu")
-            .arg("--tofu-default-policy")
-            .arg("good")
+            .arg("always")
             .arg("--verify")
             .arg(&signature_path)
             .arg("-")


### PR DESCRIPTION
Older gpg, such as 2.0.22 in CentOS 7.6, doesn't support the TOFU trust model.  Switch to `always`, which makes older hosts work at the cost of a worse spurious warning.  Old verification text:

```
gpg: Signature made Mon 14 Oct 2019 11:59:16 PM EDT
gpg:                using RSA key EF3C111FCFC659B9
gpg: Good signature from "Fedora (30) <fedora-30-primary@fedoraproject.org>" [full]
gpg: fedora-30-primary@fedoraproject.org: Verified 1 signatures in the past
     0 seconds.  Encrypted 0 messages.
```

New verification text:

```
gpg: Signature made Mon 14 Oct 2019 11:59:16 PM EDT
gpg:                using RSA key EF3C111FCFC659B9
gpg: Good signature from "Fedora (30) <fedora-30-primary@fedoraproject.org>" [unknown]
gpg: WARNING: Using untrusted key!
```

The `WARNING` line is intentional on the part of gpg (to note that the stored trust is being overridden) and there doesn't seem to be a good way to omit it.  We could switch to `gpgv`, but that doesn't check for key expiration, which seems a useful thing to warn about.