### PR TITLE
Release 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "coreos-installer"
-version = "0.1.1-alpha.0"
+version = "0.1.1"
 dependencies = [
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "coreos-installer"
-version = "0.1.1"
+version = "0.1.2-alpha.0"
 dependencies = [
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.1.1"
+version = "0.1.2-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.1.1-alpha.0"
+version = "0.1.1"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
 * Improve error messages when rereading partition table
 * Fix mounting boot device on CentOS 7.6
 * verify: Explicitly trust imported keys
 * verify: Switch to `always` trust model
 * main: get rid of wildcard imports
 * Packaging and release fixes
 * docs: add technical details about iso-embedding
 * README: Rewrite for Rust implementation
 * docs: fix typo in release-checklist