### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+RELEASE ?= 0
+
+ifeq ($(RELEASE),1)
+	PROFILE ?= release
+	CARGO_ARGS = --release
+else
+	PROFILE ?= debug
+	CARGO_ARGS =
+endif
+
+.PHONY: all
+all:
+	cargo build ${CARGO_ARGS}
+
+.PHONY: install
+install: install-bin install-systemd
+
+.PHONY: install-bin
+install-bin: all
+	install -D -t ${DESTDIR}/usr/bin target/${PROFILE}/coreos-installer
+
+.PHONY: install-systemd
+install-systemd: all
+	install -D -m 644 -t $(DESTDIR)/usr/lib/systemd/system systemd/*.{service,target}
+	install -D -t $(DESTDIR)/usr/lib/systemd/system-generators systemd/coreos-installer-generator
+	install -D -t $(DESTDIR)/usr/libexec systemd/coreos-installer-service

--- a/README.md
+++ b/README.md
@@ -38,9 +38,26 @@ usual way:
 sudo dnf install coreos-installer
 ```
 
+# Build and install from source tree
+
+To build from the source tree:
+
+```sh
+make
+```
+
+To install the binary and systemd units to a target rootfs
+(e.g. under a
+[coreos-assembler](https://github.com/coreos/coreos-assembler)
+workdir):
+
+```sh
+make install DESTDIR=/my/dest/dir
+```
+
 # Install with Cargo
 
-You can also install coreos-installer with Rust's Cargo package manager:
+You can also install just the coreos-installer binary with Rust's Cargo package manager:
 
 ```sh
 cargo install coreos-installer


### PR DESCRIPTION
A bit unfortunate to wrap `cargo build` like this, though AFAIK `cargo`
doesn't have support for installing other data files today. (And plus,
we're making `make && make install DESTDIR=/path/to/cosa/workdir/rootfs`
the standard API for our projects.)

Works on top of https://github.com/coreos/coreos-installer/pull/119.