### PR TITLE
Remove coreos.inst.stream_base_url karg

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ line.
   machine.
 * `coreos.inst.insecure` - Permit the OS image to be unsigned.  Optional.
 * `coreos.inst.skip_reboot` - Don't reboot after installing.  Optional.
-* `coreos.inst.stream_base_url` - Override the base URL of Fedora CoreOS
-  stream metadata.  Optional.
 
 ## Installing from ISO
 

--- a/systemd/coreos-installer-service
+++ b/systemd/coreos-installer-service
@@ -98,7 +98,6 @@ fi
 copy_arg coreos.inst.image_url       --image-url
 copy_arg coreos.inst.platform_id     --platform
 copy_arg coreos.inst.stream          --stream
-copy_arg coreos.inst.stream_base_url --stream-base-url
 
 # Insecure boolean
 if karg_bool coreos.inst.insecure; then


### PR DESCRIPTION
Pending the discussion in #124 let's minimize the number of kargs
for now. coreos.inst.stream_base_url was identified as one that
wasn't absolutely necessary.

This is a followup to #119 to address this discussion:
https://github.com/coreos/coreos-installer/pull/119#discussion_r363791801