### PR TITLE
install: add --ignition-url

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -119,6 +119,8 @@ pub fn parse_args() -> Result<Config> {
                         .short("s")
                         .long("stream")
                         .value_name("name")
+                        .conflicts_with("image-file")
+                        .conflicts_with("image-url")
                         .help("Fedora CoreOS stream")
                         .takes_value(true),
                 )
@@ -126,6 +128,8 @@ pub fn parse_args() -> Result<Config> {
                     Arg::with_name("image-url")
                         .short("u")
                         .long("image-url")
+                        .conflicts_with("stream")
+                        .conflicts_with("image-file")
                         .value_name("URL")
                         .help("Manually specify the image URL")
                         .takes_value(true),
@@ -134,6 +138,8 @@ pub fn parse_args() -> Result<Config> {
                     Arg::with_name("image-file")
                         .short("f")
                         .long("image-file")
+                        .conflicts_with("stream")
+                        .conflicts_with("image-url")
                         .value_name("path")
                         .help("Manually specify a local image file")
                         .takes_value(true),
@@ -513,9 +519,6 @@ fn parse_install(matches: &ArgMatches) -> Result<Config> {
         .chain_err(|| format!("getting sector size of {}", &device))?
         .get();
 
-    // Build image location.  Ideally we'd use conflicts_with (and an
-    // ArgGroup for streams), but that doesn't play well with default
-    // arguments, so we manually prioritize modes.
     let location: Box<dyn ImageLocation> = if matches.is_present("image-file") {
         Box::new(FileLocation::new(
             matches.value_of("image-file").expect("image-file missing"),

--- a/src/download.rs
+++ b/src/download.rs
@@ -306,6 +306,24 @@ pub fn write_image(
     Ok(())
 }
 
+pub fn download_to_tempfile(url: &str) -> Result<File> {
+    let mut f = tempfile::tempfile()?;
+
+    let client = new_http_client()?;
+    let mut resp = client
+        .get(url)
+        .send()
+        .chain_err(|| format!("sending request for '{}'", url))?
+        .error_for_status()
+        .chain_err(|| format!("fetching '{}'", url))?;
+
+    copy(&mut resp, &mut f)?;
+    f.seek(SeekFrom::Start(0))
+        .chain_err(|| format!("rewinding file for '{}'", url))?;
+
+    Ok(f)
+}
+
 /// Format a size in bytes.
 fn format_bytes(count: u64) -> String {
     Byte::from_bytes(count.into())

--- a/src/source.rs
+++ b/src/source.rs
@@ -457,7 +457,7 @@ fn fetch_stream(client: blocking::Client, url: &Url) -> Result<Stream> {
 }
 
 /// Customize and build a new HTTP client.
-fn new_http_client() -> Result<blocking::Client> {
+pub fn new_http_client() -> Result<blocking::Client> {
     blocking::ClientBuilder::new()
         .timeout(HTTP_COMPLETION_TIMEOUT)
         .build()


### PR DESCRIPTION
This matches our support for it for the disk image.

A big difference though is that we don't usually have GPG signatures for
integrity checking and authenticity. At the very least, we refuse to
fetch over pure HTTP without passing `--ignition-hash` or
`--insecure-ignition`. (I didn't want to wrap this under the same
`--insecure` switch since one may still want to verify signatures on the
disk image itself).

Closes: #118
