### PR TITLE
systemd: Add After=network-online.target

### DIFF
--- a/systemd/coreos-installer.service
+++ b/systemd/coreos-installer.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=CoreOS Installer
 Before=coreos-installer.target
+After=network-online.target
 Wants=network-online.target
 ConditionKernelCommandLine=coreos.inst.install_dev
 


### PR DESCRIPTION
From https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
"Cut the crap! How do I make sure that my service starts after the network is really online?"

We were just missing this one.  Came out of a discussion
about testing for network availability in
https://github.com/coreos/coreos-installer/pull/127