### PR TITLE
Cargo.toml: remove package.metadata.release.upload-doc option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.1.2-alpha.0"
 
 [package.metadata.release]
 sign-commit = true
-upload-doc = false
 disable-push = true
 disable-publish = true
 pre-release-commit-message = "cargo: coreos-installer release {{version}}"


### PR DESCRIPTION
Support for this was removed upstream [1] and now I get can error
like this when running cargo-release:

```
Fatal: Invalid TOML file format: unknown field `upload-doc`
```

[1] https://github.com/sunng87/cargo-release/commit/739d746