### PR TITLE
Release 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "coreos-installer"
-version = "0.1.2"
+version = "0.1.3-alpha.0"
 dependencies = [
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "coreos-installer"
-version = "0.1.2-alpha.0"
+version = "0.1.2"
 dependencies = [
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.1.2-alpha.0"
+version = "0.1.2"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.1.2"
+version = "0.1.3-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Benjamin Gilbert <bgilbert@redhat.com> (2):
      da95cd2 dracut: drop dracut modules
      6dd597a systemd: add scripts and systemd units for running at boot

Colin Walters <walters@verbum.org> (1):
      35b41f9 systemd: Add After=network-online.target

Dusty Mabe <dusty@dustymabe.com> (16):
      cdb76d0 systemd: service: fix calls to get commandline arg values
      8841fb8 systemd: generator: rename cmdline_arg() to karg()
      7e115d0 systemd: installer: indicate we want the network
      2d61ae3 systemd: reboot service: fix path to systemctl
      cb6dc61 systemd: generator: mv reboot flag file creation to generator
      87c8c31 systemd: service: Make reboot service run after installer
      1dffdf9 systemd: services: log more to the console
      352af2d systemd: use OnFailureJobMode=replace-irreversibly
      dd3aa1c systemd: add coreos-installer-noreboot.service
      15a7926 systemd: set SYSTEMD_SULOGIN_FORCE=1 for emergency.service
      3a197c9 Remove coreos.inst.stream_base_url karg
      bc14b5e systemd: make "network up" checking more robust
      e7502b4 systemd: remove rudimentary network checking code
      c56f501 Cargo.toml: remove package.metadata.release.upload-doc option
      42acdb3 Cargo.toml: use default tag prefix
      0707602 Cargo.toml: replace deprecated option with new version

Jonathan Lebon <jonathan@jlebon.com> (1):
      5674d4a Add Makefile