### PR TITLE
Just retry image fetches 5 times

### DIFF
--- a/coreos-installer
+++ b/coreos-installer
@@ -463,10 +463,12 @@ get_img_url() {
         curl -LsIf $IMAGE_URL >/tmp/image_info 2>&1
         RETCODE=$?
         if [ $RETCODE -ne 0 ]
-        then
-            if [[ $RETCODE -eq 22 && $retry -lt 5 ]]
+            if [[ $retry -lt 5 ]]
             then
-                # Network isn't up yet, sleep for a sec and retry
+                # The curl return codes are a huge mix of "programmer errors" and
+                # "things that might happen on the network".  We previously tried
+                # to distinguish the two.  Ignition has nice code for "retry unless we get a precise fatal error like 404"
+                # but eh, let's just retry 5 times.
                 sleep 1
                 let retry=$retry+1
                 continue


### PR DESCRIPTION
OpenShift CI hit a provisioning failure in Packet.

Reading `man curl`, it's not just code `22` we need to retry on
but also things like:

- `7      Failed to connect to host.`
- `18     Partial file. Only a part of the file was transferred.`
- `92     Stream error in HTTP/2 framing layer.`

And the man page explicitly says others could be added in the future.
We could make this nicer but this is the legacy branch.

Let's just retry unconditionally a few times.