### PR TITLE
service: add some retries when downloading

### DIFF
--- a/systemd/coreos-installer-service
+++ b/systemd/coreos-installer-service
@@ -59,7 +59,7 @@ ignition_url="$(karg coreos.inst.ignition_url)"
 if [ -n "${ignition_url}" -a "${ignition_url}" != "skip" ]; then
     ignition_file="$(mktemp -t coreos-installer-XXXXXX)"
     trap "rm -f \"${ignition_file}\"" EXIT
-    curl --progress-bar --fail -o "${ignition_file}" "${ignition_url}"
+    curl --progress-bar --retry 5 --fail -o "${ignition_file}" "${ignition_url}"
     args+=("--ignition" "${ignition_file}")
 fi
 


### PR DESCRIPTION
This adds some retries to curl when downloading Ignition config.
It should give us some room for resiliency in case of transient
network hiccups.
Proactive measure, this has not yet been observed/reported as a
direct cause of failures in the wild.

Related: https://github.com/coreos/coreos-installer/pull/127