### PR TITLE
tests/iso: test Ignition cpio read/write roundtrip

### DIFF
--- a/src/iso.rs
+++ b/src/iso.rs
@@ -275,3 +275,16 @@ fn extract_cpio(buf: &[u8]) -> Result<Vec<u8>> {
             .chain_err(|| "finishing reading CPIO entry")?;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cpio_roundtrip() {
+        let input = r#"{}"#;
+        let cpio = make_cpio(input.as_bytes()).unwrap();
+        let output = extract_cpio(&cpio).unwrap();
+        assert_eq!(input.as_bytes(), output.as_slice());
+    }
+}


### PR DESCRIPTION
This adds a basic smoke test to check that reading/writing logic for
embedded Ignition config can roundtrip without issues.