### PR TITLE
blockdev: specifically wait for /boot to show up

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -104,10 +104,10 @@ fn write_disk(
     // copy the image
     write_image(source, dest, true)?;
     reread_partition_table(dest)?;
-    udev_settle()?;
 
     // postprocess
     if ignition.is_some() || config.firstboot_kargs.is_some() || config.platform.is_some() {
+        udev_settle_until_partition_appears(&config.device, "boot")?;
         let mount = mount_boot(&config.device)?;
         if let Some(ignition) = ignition {
             write_ignition(mount.mountpoint(), ignition)?;
@@ -118,6 +118,8 @@ fn write_disk(
         if let Some(platform) = config.platform.as_ref() {
             write_platform(mount.mountpoint(), platform)?;
         }
+    } else {
+        udev_settle()?;
     }
 
     Ok(())


### PR DESCRIPTION
We want to be resilient to systems where the kernel may take a while
to send the updates out, or udevd hasn't reacted to them yet, or there's
some other IO stuttering.

So we keep running `udevadm settle` until the boot partition shows up.
Note we're not actually waiting a long time in the loop itself in total
(just 1s). The real waiting happens at `udevadm settle` (which doesn't
really _do_ anything else than wait for udev rules to be processed). The
loop here is just to have a better chance to have `udevadm settle` watch
for the actual udev events we care about (see the related comment about
this that I deleted).

See also: https://github.com/coreos/fedora-coreos-tracker/issues/385