### PR TITLE
install: Add option to skip clearing partition table on error

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -35,6 +35,7 @@ pub struct InstallConfig {
     pub platform: Option<String>,
     pub firstboot_kargs: Option<String>,
     pub insecure: bool,
+    pub preserve_on_error: bool,
 }
 
 pub struct DownloadConfig {
@@ -151,6 +152,11 @@ pub fn parse_args() -> Result<Config> {
                         .help("Target CPU architecture")
                         .default_value(uname.machine())
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("preserve-on-error")
+                        .long("preserve-on-error")
+                        .help("Don't clear partition table on error"),
                 )
                 // positional args
                 .arg(
@@ -379,6 +385,7 @@ fn parse_install(matches: &ArgMatches) -> Result<Config> {
         platform: matches.value_of("platform").map(String::from),
         firstboot_kargs: matches.value_of("firstboot-kargs").map(String::from),
         insecure: matches.is_present("insecure"),
+        preserve_on_error: matches.is_present("preserve-on-error"),
     }))
 }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -78,7 +78,11 @@ pub fn install(config: &InstallConfig) -> Result<()> {
         eprint!("{}", ChainedError::display_chain(&err));
 
         // clean up
-        clear_partition_table(&mut dest)?;
+        if config.preserve_on_error {
+            eprintln!("Preserving partition table as requested");
+        } else {
+            clear_partition_table(&mut dest)?;
+        }
 
         // return a generic error so our exit status is right
         bail!("install failed");


### PR DESCRIPTION
If `--preserve-on-error` is specified, don't clear the destination partition table on error, as a debugging aid.

For https://github.com/coreos/coreos-installer/issues/165#issuecomment-588380848.