### PR TITLE
Stop discarding disk contents

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -14,12 +14,11 @@
 
 use error_chain::bail;
 use nix::errno::Errno;
-use nix::{self, ioctl_none, ioctl_read_bad, ioctl_write_ptr_bad, mount, request_code_none};
+use nix::{self, ioctl_none, ioctl_read_bad, mount, request_code_none};
 use regex::Regex;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::{remove_dir, File};
-use std::io::{Seek, SeekFrom};
 use std::num::NonZeroU32;
 use std::os::raw::c_int;
 use std::os::unix::io::AsRawFd;
@@ -224,36 +223,9 @@ pub fn get_sector_size(file: &mut File) -> Result<NonZeroU32> {
     }
 }
 
-/// Try discarding all blocks from the underlying block device.
-/// Return true if successful, false if the underlying device doesn't
-/// support discard, or an error otherwise.
-pub fn try_discard_all(file: &mut File) -> Result<bool> {
-    // get device size
-    let length = file
-        .seek(SeekFrom::End(0))
-        .chain_err(|| "seeking device file")?;
-    file.seek(SeekFrom::Start(0))
-        .chain_err(|| "seeking device file")?;
-
-    // discard
-    let fd = file.as_raw_fd();
-    let range: [u64; 2] = [0, length];
-    match unsafe { blkdiscard(fd, &range) } {
-        Ok(_) => Ok(true),
-        Err(e) => {
-            if e == nix::Error::from_errno(Errno::EOPNOTSUPP) {
-                Ok(false)
-            } else {
-                Err(Error::with_chain(e, "discarding device contents"))
-            }
-        }
-    }
-}
-
 // create unsafe ioctl wrappers
 ioctl_none!(blkrrpart, 0x12, 95);
 ioctl_read_bad!(blksszget, request_code_none!(0x12, 104), c_int);
-ioctl_write_ptr_bad!(blkdiscard, request_code_none!(0x12, 119), [u64; 2]);
 
 pub fn udev_settle() -> Result<()> {
     // "udevadm settle" silently no-ops if the udev socket is missing, and


### PR DESCRIPTION
In 7b89735c0906 we started issuing block discard requests over the destination disk, before install and after install failure, as a courtesy to SSD wear levelers and LVM thin pools.  However, this assumes that the entire disk is ours to discard.  Users might want to reprovision an existing machine without disturbing a data partition they've created on the boot disk; their Ignition config can then recreate the data partition in the same place and reuse the filesystem inside.

Discard the discard functionality for now.  We shouldn't require users to explicitly specify `--dont-delete-my-data`, and the semantics of `--delete-my-data` (under whatever name, e.g. `--discard-device`) would be difficult to explain relative to the value they provide.  Users can still run `blkdiscard(8)` before coreos-installer if they need that functionality.

Fixes #170.