### PR TITLE
download: Avoid using `is_some()`

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -147,7 +147,7 @@ fn write_image_and_sig(
     write_image(source, &mut dest, decompress, None)?;
 
     // write signature, if relevant
-    if !decompress && source.signature.is_some() {
+    if let (false, Some(signature)) = (decompress, source.signature.as_ref()) {
         let mut sig_dest = OpenOptions::new()
             .write(true)
             .create(true)
@@ -155,7 +155,7 @@ fn write_image_and_sig(
             .open(sig_path)
             .chain_err(|| format!("opening {}", sig_path.display()))?;
         sig_dest
-            .write_all(source.signature.as_ref().unwrap())
+            .write_all(signature)
             .chain_err(|| "writing signature data")?;
     }
 


### PR DESCRIPTION
I think using that API call is a bit of a code smell; it isn't
*wrong* but I think it's better to use matching like `if let Some(x)`.
Among other things it avoids an `unwrap()` call which is *definitely*
a code smell.  It's harder for the compiler to optimize out the
`unwrap()` too since it has to reason about the `is_some()` logic.

If agreed I'll change a few other places like this too.