### PR TITLE
Release 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "coreos-installer"
-version = "0.1.3"
+version = "0.1.4-alpha.0"
 dependencies = [
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "coreos-installer"
-version = "0.1.3-alpha.0"
+version = "0.1.3"
 dependencies = [
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.1.3-alpha.0"
+version = "0.1.3"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.1.3"
+version = "0.1.4-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:
- Rename `--ignition` to `--ignition-file`.  `--ignition` is still accepted for compatibility.
- Don't discard disk contents before installing, so we don't delete data partitions when reprovisioning
- Add `--preserve-on-error` debug option to skip clearing partition table on error

Minor changes:
- Fail install early if image sector size doesn't match destination
- Ensure specified Ignition config exists before starting install
- Improve error message when mounting `/boot` if no partitions found
- Ignore HTTP errors on signature fetch if `--insecure` is specified
- Simplify download progress reporting if stderr is not a tty
- Retry when downloading `coreos.inst.ignition_url`
- Add upper-bound timeout to HTTP requests