### PR TITLE
coreos-installer-service: support multiple kargs for firstboot

### DIFF
--- a/systemd/coreos-installer-service
+++ b/systemd/coreos-installer-service
@@ -23,6 +23,16 @@ karg() {
     echo "${value}"
 }
 
+kargs() {
+    local name="$1" values="$2"
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            values+="${arg#*=} "
+        fi
+    done
+    echo "${values}"
+}
+
 karg_bool() {
     local value=$(karg "$@")
     case "$value" in
@@ -67,9 +77,12 @@ fi
 firstboot_args=""
 for param in "${PERSIST_KERNEL_NET_PARAMS[@]}" "${PERSIST_DRACUT_NET_PARAMS[@]}"
 do
-    value=$(karg "${param}")
-    if [ -n "${value}" ]; then
-        firstboot_args+="${param}=${value} "
+    values=$(kargs "${param}")
+    if [ -n "${values}" ]; then
+        for value in values
+        do
+            firstboot_args+="${param}=${value} "
+        done
     fi
 done
 # Only pass firstboot-kargs if additional networking options have been


### PR DESCRIPTION
Supports kargs where one key has potentially multiple values when picking up firstboot kernel arguments. Logic similar to previous legacy installer code and dracut library:
 - https://github.com/coreos/coreos-installer/commit/f77a77f9a5c80dc404cf4c305f0bb0bc6cd3cd72#diff-615cbe070c3ee7df261b5c6c02545d86
 - https://github.com/zfsonlinux/dracut/blob/df03141dbc9896b808cebdcc7358745dc2e8b979/modules.d/99base/dracut-lib.sh#L239

Closes: https://github.com/coreos/coreos-installer/issues/156
Signed-off-by: Allen Bai <abai@redhat.com>