### PR TITLE
ci: fix `kola testiso` invocation

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -10,6 +10,6 @@ cosaPod(buildroot: true) {
         shwrap("cd /srv/fcos && cosa buildextend-live")
     }
     stage("Test ISO") {
-        shwrap("cd /srv/fcos && kola testiso --cosa-build builds/latest/x86_64/meta.json -S")
+        shwrap("cd /srv/fcos && kola testiso -S")
     }
 }


### PR DESCRIPTION
The current invocation no longer works now that `--cosa-build` was
renamed to just `--build` (in hindsight, I should've probably kept
`--cosa-build` for a bit as an alias).

Anyway, we can drop that argument completely now actually. So let's do
that!