### PR TITLE
install: use 4k image when when targeting 4k drives

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -7,9 +7,11 @@ cosaPod(buildroot: true) {
 
     stage("Build metal+live") {
         shwrap("cd /srv/fcos && cosa build metal")
+        shwrap("cd /srv/fcos && cosa buildextend-metal4k")
         shwrap("cd /srv/fcos && cosa buildextend-live")
     }
     stage("Test ISO") {
         shwrap("cd /srv/fcos && kola testiso -S")
+        shwrap("cd /srv/fcos && kola testiso -SP --qemu-native-4k")
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -235,11 +235,15 @@ impl Display for StreamLocation {
         if self.stream_base_url.is_some() {
             write!(
                 f,
-                "Downloading image and signature referenced from {}",
-                self.stream_url
+                "Downloading image ({}) and signature referenced from {}",
+                self.format, self.stream_url
             )
         } else {
-            write!(f, "Downloading {} image and signature", self.stream)
+            write!(
+                f,
+                "Downloading {} image ({}) and signature",
+                self.stream, self.format
+            )
         }
     }
 }


### PR DESCRIPTION
Detect the sector size of the target device, then select the right
format from the stream metadata based on that.

Closes: #201