### PR TITLE
systemd: report failures to console before emergency shell

### DIFF
--- a/systemd/coreos-installer-emergency.service
+++ b/systemd/coreos-installer-emergency.service
@@ -1,0 +1,22 @@
+# Forked and modified from /lib/systemd/system/emergency.service
+[Unit]
+Description=Report CoreOS Installer Failures to Console
+DefaultDependencies=no
+Conflicts=shutdown.target
+Conflicts=rescue.service
+Before=emergency.target
+Before=emergency.service
+
+[Service]
+Type=forking
+ExecStart=/usr/lib/systemd/systemd-coreos-installer-emergency
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit
+KillMode=process
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+TimeoutSec=330
+
+[Install]
+WantedBy=emergency.target

--- a/systemd/coreos-installer-service
+++ b/systemd/coreos-installer-service
@@ -92,6 +92,10 @@ fi
 # Ensure device nodes have been created
 udevadm settle
 
+# Enable the service for reporting failures to console
+echo "systemctl enable coreos-installer-emergency.service"
+systemctl enable coreos-installer-emergency.service
+
 # Install
 echo "coreos-installer ${args[@]}"
 coreos-installer "${args[@]}"

--- a/systemd/systemd-coreos-installer-emergency
+++ b/systemd/systemd-coreos-installer-emergency
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Fored and modified from https://github.com/coreos/ignition-dracut/blob/master/dracut/99emergency-timeout/timeout.sh
+
+_wait_for_journalctl_to_stop() {
+    local time_since_last_log=0
+
+    local time_started="$(date '+%s')"
+    local now="$(date '+%s')"
+
+    while [ ${time_since_last_log} -lt 5 -a $((now-time_started)) -lt 15 ]; do
+        sleep 1
+
+        local last_log_timestamp="$(journalctl -e -n 1 -q -o short-unix | cut -d '.' -f 1)"
+        local now="$(date '+%s')"
+
+        local time_since_last_log=$((now-last_log_timestamp))
+    done
+}
+
+_prompt_for_timeout() {
+    local timeout=300
+    local interval=15
+
+    if systemctl show "coreos-installer.service" | grep -q "^ActiveState=failed$"; then
+        # coreos-installer has failed, suppress kernel logs so that coreos-installer logs stay
+        # on the screen
+        dmesg --console-off
+
+        # There's a couple straggler systemd messages. Wait until it's been 5
+        # seconds since something was written to the journal.
+        _wait_for_journalctl_to_stop
+
+        # Print CoreOS Installer logs
+        cat <<EOF
+-------------------------------------------------------------------------------
+CoreOS Installer has failed.
+Here are the CoreOS Installer logs:
+
+EOF
+        journalctl -u coreos-installer.service -b --no-pager --no-hostname -o cat
+        echo -n -e "\n"
+    fi
+
+    # Regularly prompt with time remaining.  This ensures the prompt doesn't
+    # get lost among kernel and systemd messages, and makes it clear what's
+    # going on if the user just connected a serial console.
+    while [[ $timeout > 0 ]]; do
+        local m=$(( $timeout / 60 ))
+        local s=$(( $timeout % 60 ))
+        local m_label="minutes"
+        if [[ $m = 1 ]]; then
+            m_label="minute"
+        fi
+
+        if [[ $s != 0 ]]; then
+            echo -n -e "Press Enter for emergency shell or wait $m $m_label $s seconds for reboot.      \r"
+        else
+            echo -n -e "Press Enter for emergency shell or wait $m $m_label for reboot.                 \r"
+        fi
+
+        local anything
+        if read -t $interval anything; then
+            return
+        fi
+
+        timeout=$(( $timeout - $interval ))
+    done
+
+    echo -e "\nRebooting."
+    # This is not very nice, but since reboot.target likely conflicts with
+    # the existing goal target wrt the desired state of shutdown.target,
+    # there doesn't seem to be a better option.
+    systemctl reboot --force
+    exit 0
+}
+
+# If we're invoked from a dracut breakpoint rather than
+# dracut-emergency.service, we won't have a controlling terminal and stdio
+# won't be connected to it. Explicitly read/write /dev/console.
+_prompt_for_timeout < /dev/console > /dev/console


### PR DESCRIPTION
Currently users have to manually type `systemctl status coreos-installer.service` after pressing Enter when hitting error state.

Adds a service `coreos-installer-emergency.service` before entering `emergency.service` that reports failures to console when `coreos-installer.service` failed.

The script `systemd-coreos-installer-emergency` is a fork from `timeout.sh` of `ignition-dracut` with minor adjustment for coreos-installer. It is placed under `/usr/lib/systemd/systemd-coreos-installer-emergency`.

Currently `coreos-installer-emergency.service` is enabled when running `coreos-installer-service` before executing `coreo-installer` command.

Closes: https://github.com/coreos/coreos-installer/issues/145
Signed-off-by: Allen Bai <abai@redhat.com>
References: https://github.com/coreos/ignition-dracut/blob/master/dracut/99emergency-timeout/timeout.sh