### PR TITLE
blockdev: use 'kpartx' for reading/clearing partition table of dm-devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY src src/
 RUN cargo build --release
 
 FROM registry.fedoraproject.org/fedora:31
-RUN dnf install -y /usr/bin/gpg /usr/bin/lsblk /usr/sbin/udevadm && \
+RUN dnf install -y /usr/bin/gpg /usr/bin/lsblk /usr/sbin/udevadm /usr/sbin/kpartx && \
     dnf clean all
 COPY --from=builder /build/target/release/coreos-installer /usr/sbin
 ENTRYPOINT ["/usr/sbin/coreos-installer"]


### PR DESCRIPTION
When installing CoreOS on DM device, such as '/dev/mapper/mpatha' or '/dev/dm-0',
regular 'ioctl(fd, BLKRRPART)' call always fails with EINVAL. This also means,
that our check for device being mounted, which on regular devices fails with EBUSY,
is not valid anymore, that's why now /proc/mounts is used.

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>