### PR TITLE
systemd: remove SYSTEMD_SULOGIN_FORCE override for emergency.service

### DIFF
--- a/systemd/coreos-installer-generator
+++ b/systemd/coreos-installer-generator
@@ -33,9 +33,4 @@ if [ -n "$(karg coreos.inst.install_dev)" ]; then
     if ! karg_bool coreos.inst.skip_reboot; then
         touch /run/coreos-installer-reboot
     fi
-
-    # Allow emergency.service to execute even with locked root account
-    mkdir -p /etc/systemd/system/emergency.service.d
-    echo -e '[Service]\nEnvironment=SYSTEMD_SULOGIN_FORCE=1\n' \
-        > /etc/systemd/system/emergency.service.d/override.conf
 fi


### PR DESCRIPTION
This is no longer needed since we changed all of Fedora CoreOS to
set SYSTEMD_SULOGIN_FORCE=1 for emergency.service in
https://github.com/coreos/fedora-coreos-config/commit/eb74f2ea3e9b453902315539e4f327481162c4f8