### PR TITLE
ci: Compress images once, use explicit scenario list

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -8,10 +8,14 @@ cosaPod(buildroot: true) {
     stage("Build metal+live") {
         shwrap("cd /srv/fcos && cosa build metal")
         shwrap("cd /srv/fcos && cosa buildextend-metal4k")
+        // Compress once
         shwrap("cd /srv/fcos && cosa buildextend-live")
+        shwrap("cd /srv/fcos && cosa compress --artifact=metal --artifact=metal4k")
     }
     stage("Test ISO") {
-        shwrap("cd /srv/fcos && kola testiso -S")
-        shwrap("cd /srv/fcos && kola testiso -SP --qemu-native-4k")
+        // No need to run the iso-live-login scenario (in theory, and also right
+        // now it's buggy)
+        shwrap("cd /srv/fcos && kola testiso -S --scenarios pxe-install,iso-install")
+        shwrap("cd /srv/fcos && kola testiso -S --scenarios iso-install --qemu-native-4k")
     }
 }


### PR DESCRIPTION
This is done in the RHCOS pipeline and will be done soon in FCOS
https://github.com/coreos/fedora-coreos-pipeline/pull/218

Also switch to explicit scenario list as another workaround
for https://github.com/coreos/coreos-assembler/pull/1365