### PR TITLE
build: Add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all:
+	@echo "(Nothing to do)"
+
+install:
+	install -D -t $(DESTDIR)/usr/libexec -m 0755 coreos-installer
+	for x in dracut/*; do install -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$$(basename $$x) $$x/*; done


### PR DESCRIPTION
Same rationale as https://github.com/coreos/ignition-dracut/pull/106

See https://github.com/cgwalters/build-api

With this for example, we can just have the RHEL spec file do
`make install DESTDIR=$RPM_BUILD_ROOT` just like everything else;
helping to ensure that as much logic as possible remains upstream.