### PR TITLE
 Install as coreos-installer.legacy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ all:
 	@echo "(Nothing to do)"
 
 install:
-	install -D -t $(DESTDIR)/usr/libexec -m 0755 coreos-installer
+	install -D -m 0755 coreos-installer $(DESTDIR)/usr/libexec/coreos-installer.legacy
 	for x in dracut/*; do install -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$$(basename $$x) $$x/*; done

--- a/dracut/30coreos-installer/coreos-installer-generator
+++ b/dracut/30coreos-installer/coreos-installer-generator
@@ -4,6 +4,12 @@
 
 set -e
 
+# Verify we are in the legacy installer initramfs.
+# Requires https://github.com/coreos/coreos-assembler/pull/1389
+if ! [ -f /etc/coreos-legacy-installer-initramfs ] ; then
+  exit 0
+fi
+
 UNIT_DIR="${1:-/tmp}"
 
 cmdline=( $(</proc/cmdline) )

--- a/dracut/30coreos-installer/coreos-installer.service
+++ b/dracut/30coreos-installer/coreos-installer.service
@@ -6,7 +6,7 @@ OnFailureJobMode=isolate
 
 [Service]
 Type=simple
-ExecStart=/usr/libexec/coreos-installer
+ExecStart=/usr/libexec/coreos-installer.legacy
 # Perform reboot after install unless asked not to.
 ExecStop=/bin/sh -c 'test -f /tmp/skip_reboot || sleep 5 && reboot'
 #StandardInput=tty-force

--- a/dracut/30coreos-installer/module-setup.sh
+++ b/dracut/30coreos-installer/module-setup.sh
@@ -48,7 +48,7 @@ install() {
         inst_multiple -o /lib/s390-tools/stage3.bin
     fi
 
-    inst_simple /usr/libexec/coreos-installer
+    inst_simple /usr/libexec/coreos-installer.legacy
 
     inst_simple "$moddir/coreos-installer-generator" \
         "$systemdutildir/system-generators/coreos-installer-generator"

--- a/dracut/30coreos-installer/parse-coreos.sh
+++ b/dracut/30coreos-installer/parse-coreos.sh
@@ -2,6 +2,11 @@
 
 . /lib/dracut-lib.sh
 
+# Verify we are in the legacy installer initramfs.
+# Requires https://github.com/coreos/coreos-assembler/pull/1389
+if ! [ -f /etc/coreos-legacy-installer-initramfs ] ; then
+  exit 0
+fi
 
 local IMAGE_URL=$(getarg coreos.inst.image_url=)
 if [ ! -z "$IMAGE_URL" ]


### PR DESCRIPTION
For https://github.com/openshift/enhancements/pull/210 I think
we will need at least some transitional period where RHCOS
ships both.  Even ignoring customers, the way our CI works
strongly encourages "ratcheting" changes in a compatible way,
i.e.:

- Introduce new thing, ship it
- Port consumers to new thing
- Remove old thing

And honestly I think this is a good model, because it forces
us to experience some of the pain that customers might feel here.

The basic idea here is:

- Install as `/usr/libexec/coreos-installer.legacy` so there's
  no chance of conflict with the real one
- Test for the presence of the "stamp file' we drop in our live initramfs
  so we know to defer to the real root's coreos-installer

This would be even more robust if we changed coreos-assembler
to inject an explicit stamp file into the legacy initramfs
(and ideally, we don't ship legacy installer in the initramfs
 but that's a bit trickier to do cleanly)