### PR TITLE
ci: fix building metal image

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -3,10 +3,11 @@
 cosaPod(buildroot: true) {
     checkout scm
 
-    fcosBuild(make: true)
+    // we don't need the qemu image to test coreos-installer; just the OSTree
+    fcosBuild(make: true, skipKola: true, extraArgs: 'ostree')
 
     stage("Build metal+live") {
-        shwrap("cd /srv/fcos && cosa build metal")
+        shwrap("cd /srv/fcos && cosa buildextend-metal")
         shwrap("cd /srv/fcos && cosa buildextend-metal4k")
         // Compress once
         shwrap("cd /srv/fcos && cosa buildextend-live")


### PR DESCRIPTION
We were doing `cosa build metal` instead of `cosa buildextend-metal`.
And since `fcosBuild` itself already builds a qemu image, we were
essentially doing `create_disk.sh` twice.

Instead, just make the initial `fcosBuild` only build the metal image
since we don't need the QEMU image for our tests. And also skip the
regular kola tests since those don't really test coreos-installer
anyway (and they'd need the QEMU image).