### PR TITLE
systemd: add logging to systemd generator

### DIFF
--- a/systemd/coreos-installer-generator
+++ b/systemd/coreos-installer-generator
@@ -4,6 +4,10 @@
 
 set -e
 
+# Generators don't have logging right now
+# https://github.com/systemd/systemd/issues/15638
+exec 1>/dev/kmsg; exec 2>&1
+
 UNIT_DIR="${1:-/tmp}"
 
 cmdline=( $(</proc/cmdline) )


### PR DESCRIPTION
Outputting stdout and stderr to /dev/kmsg is the only option for
logging for generators for now. Let's start using it so we can at
least get some messages if we ever have problems with one of our
generators.