### PR TITLE
systemd: coreos-installer-service: fix network karg parsing

### DIFF
--- a/systemd/coreos-installer-service
+++ b/systemd/coreos-installer-service
@@ -63,14 +63,15 @@ if [ -n "${ignition_url}" -a "${ignition_url}" != "skip" ]; then
     args+=("--ignition" "${ignition_file}")
 fi
 
-# First-boot kernel arguments
+# First-boot kernel arguments. Filter out any args that aren't in our
+# list of networking arguments to forward and store them in $firstboot_args
 firstboot_args=""
-for param in "${PERSIST_KERNEL_NET_PARAMS[@]}" "${PERSIST_DRACUT_NET_PARAMS[@]}"
-do
-    value=$(karg "${param}")
-    if [ -n "${value}" ]; then
-        firstboot_args+="${param}=${value} "
-    fi
+for item in "${cmdline[@]}"; do
+    for param in "${PERSIST_KERNEL_NET_PARAMS[@]}" "${PERSIST_DRACUT_NET_PARAMS[@]}"; do
+        if [[ $item =~ ^$param(=.*)?$ ]]; then
+            firstboot_args+="${item} "
+        fi
+    done
 done
 # Only pass firstboot-kargs if additional networking options have been
 # specified, since the default in ignition-dracut specifies


### PR DESCRIPTION
This commit fixes two issues with network karg parsing. First,
there are some arguments that can be provided more than once (like
ip=). Second, there are arguments that are boolean args that don't
require a value, which aren't currently getting parsed correctly.

Fixes: https://github.com/coreos/coreos-installer/issues/156
Fixes: https://github.com/coreos/coreos-installer/issues/227