### PR TITLE
systemd: coreos-installer-service: persist net.ifnames net.naming-scheme kargs

### DIFF
--- a/systemd/coreos-installer-service
+++ b/systemd/coreos-installer-service
@@ -3,7 +3,7 @@
 set -e
 
 # Kernel networking params to persist
-PERSIST_KERNEL_NET_PARAMS=("ipv6.disable")
+PERSIST_KERNEL_NET_PARAMS=("ipv6.disable" "net.ifnames" "net.naming-scheme")
 
 # Dracut networking params to persist
 # Everything other than rd.neednet.


### PR DESCRIPTION
More networking kargs we should probably persist. This came from
some user feedback about RHCOS missing this ability.