### PR TITLE
fix coreos-installer dracut module

### DIFF
--- a/dracut/30coreos-installer/parse-coreos.sh
+++ b/dracut/30coreos-installer/parse-coreos.sh
@@ -5,7 +5,7 @@
 # Verify we are in the legacy installer initramfs.
 # Requires https://github.com/coreos/coreos-assembler/pull/1389
 if ! [ -f /etc/coreos-legacy-installer-initramfs ] ; then
-  exit 0
+  return 0 # not exit 0, because dracut hooks are "sourced"
 fi
 
 local IMAGE_URL=$(getarg coreos.inst.image_url=)


### PR DESCRIPTION
dracut hooks are sourced which means if we exit 0 here then we'll
stop parsing the rest of the hooks (after 90).