### PR TITLE
iso-embed: Add `--disable-initramfs-networking`

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -63,6 +63,7 @@ pub struct IsoEmbedConfig {
     pub output: Option<String>,
     pub ignition: Option<String>,
     pub force: bool,
+    pub disable_initramfs_networking: bool,
 }
 
 pub struct IsoShowConfig {
@@ -327,6 +328,11 @@ pub fn parse_args() -> Result<Config> {
                                 .value_name("path")
                                 .help("Ignition config to embed [default: stdin]")
                                 .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("disable-initramfs-networking")
+                                .long("disable-initramfs-networking")
+                                .help("Turn off networking in the initramfs")
                         )
                         .arg(
                             Arg::with_name("force")
@@ -647,6 +653,7 @@ fn parse_iso_embed(matches: &ArgMatches) -> Result<Config> {
         output: matches.value_of("output").map(String::from),
         ignition: matches.value_of("config").map(String::from),
         force: matches.is_present("force"),
+        disable_initramfs_networking: matches.is_present("disable-initramfs-networking"),
     }))
 }
 


### PR DESCRIPTION
We want people to be able to take our ISO and inject
Ignition so they can fully automate installs - all that
should be needed is to e.g. attach the ISO via an IMPI system,
or written to a USB stick etc.

Today though, we enable the default DHCP if Ignition is
provided, which breaks automating static IP installs.

We've debated a lot of approaches for this, and general
consensus is that the best is probably "conditional networking"
in Ignition.  However that's a much larger amount of work that
also touches every artifact type.  This approach is
small and targeted and only affects the Live ISO path.

We also discussed generalizing this into arbitrary kernel
arguments, but the problem with that is that today we can only
inject into the initramfs, so e.g. one can't enable SMT
that way.  To fix that we probably need to enhance our ISO
model to be able to actually modify the kernel config too.
That would be another potential good future enhancement.