### PR TITLE
Release 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.2.1-alpha.0"
+version = "0.2.1"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.2.1"
+version = "0.2.2-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.2.1-alpha.0"
+version = "0.2.1"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.2.1"
+version = "0.2.2-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- Add Fedora 32 signing key; drop Fedora 30 signing key

Minor changes:

- Support creating offline image from RHCOS LUKS volume
- Add `coreos.inst` forwarding of `net.ifnames` and `net.naming-scheme` kargs