### PR TITLE
cargo: relax osmet dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ cpio = "^0.2"
 error-chain = { version = "^0.12", default-features = false }
 flate2 = "^1.0"
 hex = "^0.4"
-libc = "0.2.71"
+libc = "^0.2"
 nix = "^0.17"
-openssl = "^0.10.29"
-pipe = "^0.3.0"
+openssl = "^0.10"
+pipe = "^0.3"
 progress-streams = "^1.1"
 regex = "^1.3"
 reqwest = { version = "^0.10", features = ["blocking"] }


### PR DESCRIPTION
Make life easier for packagers.

cc @lucab @jlebon 