### PR TITLE
ci: check line lengths of help text

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -3,20 +3,54 @@
 cosaPod(buildroot: true) {
     checkout scm
 
-    // we don't need the qemu image to test coreos-installer; just the OSTree
-    fcosBuild(make: true, skipKola: true, extraArgs: 'ostree')
+    shwrap("make")
 
-    stage("Build metal+live") {
-        shwrap("cd /srv/fcos && cosa buildextend-metal")
-        shwrap("cd /srv/fcos && cosa buildextend-metal4k")
-        // Compress once
-        shwrap("cd /srv/fcos && cosa buildextend-live")
-        shwrap("cd /srv/fcos && cosa compress --artifact=metal --artifact=metal4k")
-    }
-    stage("Test ISO") {
-        // No need to run the iso-live-login scenario (in theory, and also right
-        // now it's buggy)
-        shwrap("cd /srv/fcos && kola testiso -S --scenarios pxe-install,iso-install,iso-offline-install")
-        shwrap("cd /srv/fcos && kola testiso -S --scenarios iso-install --qemu-native-4k")
-    }
+    parallel(
+        lint: {
+            stage("Lint") {
+                // Check help text maximum line length
+                shwrap('''
+                    fail=0
+                    checklen() {
+                        local length
+                        length=$(target/debug/coreos-installer $* --help | wc -L)
+                        if [ "${length}" -gt 80 ] ; then
+                            echo "$* --help line length ${length} > 80"
+                            fail=1
+                        fi
+                    }
+                    checklen
+                    checklen install
+                    checklen download
+                    checklen list-stream
+                    checklen iso
+                    checklen iso embed
+                    checklen iso show
+                    checklen iso remove
+                    if [ "${fail}" = 1 ]; then
+                        exit 1
+                    fi
+                ''')
+            }
+        },
+        fcos: {
+            // we don't need the qemu image to test coreos-installer; just the OSTree
+            // make: true for install
+            fcosBuild(make: true, skipKola: true, extraArgs: 'ostree')
+
+            stage("Build metal+live") {
+                shwrap("cd /srv/fcos && cosa buildextend-metal")
+                shwrap("cd /srv/fcos && cosa buildextend-metal4k")
+                // Compress once
+                shwrap("cd /srv/fcos && cosa buildextend-live")
+                shwrap("cd /srv/fcos && cosa compress --artifact=metal --artifact=metal4k")
+            }
+            stage("Test ISO") {
+                // No need to run the iso-live-login scenario (in theory, and also right
+                // now it's buggy)
+                shwrap("cd /srv/fcos && kola testiso -S --scenarios pxe-install,iso-install,iso-offline-install")
+                shwrap("cd /srv/fcos && kola testiso -S --scenarios iso-install --qemu-native-4k")
+            }
+        }
+    )
 }


### PR DESCRIPTION
Manually enumerate subcommands, since there doesn't seem to be a great way to do it programmatically.