### PR TITLE
Prep patches for modifying kargs

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -187,7 +187,11 @@ pub fn parse_args() -> Result<Config> {
                         .long("firstboot-args")
                         .value_name("args")
                         .help("Additional kernel args for the first boot")
-                        .takes_value(true),
+                        .takes_value(true)
+                        // This used to be for configuring networking from the cmdline, but it has
+                        // been obsoleted by the nicer `--copy-network` approach. We still need it
+                        // for now though. It's used at least by `coreos-installer.service`.
+                        .hidden(true),
                 )
                 .arg(
                     Arg::with_name("copy-network")


### PR DESCRIPTION
```
commit b7e7a01b6d308fe7b85751cefc1f31cd3793db17
Date:   Thu Jun 11 11:41:59 2020 -0400

    install: factor out function to walk BLS configs

    Prep for next patch.

commit 25c71d62f937d52970f85be2294b4f166983d908
Date:   Tue Jun 16 16:38:46 2020 -0400

    install: rename --firstboot-args to --append-firstboot-kargs

    Let's use a more precise name for this switch. First, specify that it
    *appends* to the list of firstboot arguments. Second, use `kargs`
    instead of just `args` to be more clear.

    This is prep for new switches which will use the same naming convention.

commit 70371c47ab76b78f522e4469906e05e1edd05c6d
Date:   Tue Jun 16 17:15:41 2020 -0400

    install: test platform ID restamping bits

    Factor out the closure and add some basic unit tests.
```