### PR TITLE
legacy: include additional kargs when running zipl for firstboot

### DIFF
--- a/coreos-installer
+++ b/coreos-installer
@@ -702,7 +702,7 @@ write_zipl_bootloader() {
         options="$(grep options $blsfile | cut -d' ' -f2-) $(cat /tmp/s390x_opts)"
         sed -i -e "s@^options.*@options $options@g" $blsfile
         # And also keep networking parameters for first boot
-        echo "$options $(cat /tmp/networking_opts) ignition.firstboot" > /tmp/zipl_prm
+        echo "$options $(cat /tmp/networking_opts) $(cat /tmp/additional_opts) ignition.firstboot" > /tmp/zipl_prm
         zipl --verbose -p /tmp/zipl_prm -i $(ls ${boot_partition}/ostree/*/*vmlinuz*) -r $(ls ${boot_partition}/ostree/*/*initramfs*) --target "$boot_partition"
         if [[ $? -ne 0 ]]; then
             log "failed updating bootloder"


### PR DESCRIPTION
When playing around with some additional arguments noticed that they were not being propagated
on first boot for s390x. Included that to the list of args when running zipl.