### PR TITLE
systemd: move OnFailure into coreos-installer.service

### DIFF
--- a/systemd/coreos-installer.service
+++ b/systemd/coreos-installer.service
@@ -4,6 +4,8 @@ Before=coreos-installer.target
 After=network-online.target
 Wants=network-online.target
 ConditionKernelCommandLine=coreos.inst.install_dev
+OnFailure=emergency.target
+OnFailureJobMode=replace-irreversibly
 
 [Service]
 Type=oneshot

--- a/systemd/coreos-installer.target
+++ b/systemd/coreos-installer.target
@@ -1,7 +1,5 @@
 [Unit]
 Description=CoreOS Installer Target
-OnFailure=emergency.target
-OnFailureJobMode=replace-irreversibly
 AllowIsolate=yes
 
 Requires=coreos-installer.service


### PR DESCRIPTION
On Fedora 32, an `OnFailure` directive in a target unit [no longer does anything](https://github.com/systemd/systemd/issues/14142#issuecomment-634946368).

Reported by @nikita-dubrovskii.