### PR TITLE
blockdev: support installing to DM devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ COPY src src/
 RUN cargo build --release
 
 FROM registry.fedoraproject.org/fedora:32
-RUN dnf install -y /usr/bin/gpg /usr/bin/lsblk /usr/sbin/udevadm && \
+RUN dnf install -y /usr/bin/gpg /usr/sbin/kpartx /usr/bin/lsblk \
+    /usr/sbin/udevadm && \
     dnf clean all
 COPY --from=builder /build/target/release/coreos-installer /usr/sbin
 ENTRYPOINT ["/usr/sbin/coreos-installer"]

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -161,8 +161,144 @@ impl Disk {
         Ok(Vec::new())
     }
 
+    /// Get a handle to the set of device nodes for individual partitions
+    /// of the device.
+    pub fn get_partition_table(&self) -> Result<Box<dyn PartTable>> {
+        if self.is_dm_device() {
+            Ok(Box::new(PartTableKpartx::new(&self.path)?))
+        } else {
+            Ok(Box::new(PartTableKernel::new(&self.path)?))
+        }
+    }
+
     fn is_dm_device(&self) -> bool {
         self.path.starts_with("/dev/mapper/") || self.path.starts_with("/dev/dm-")
+    }
+}
+
+/// A handle to the set of device nodes for individual partitions of a
+/// device.  Must be held as long as the device nodes are needed; they might
+/// be removed upon drop.
+pub trait PartTable {
+    /// Update device nodes for the current state of the partition table
+    fn reread(&mut self) -> Result<()>;
+}
+
+/// Device nodes for partitionable kernel devices, managed by the kernel.
+#[derive(Debug)]
+pub struct PartTableKernel {
+    path: String,
+    file: File,
+}
+
+impl PartTableKernel {
+    fn new(path: &str) -> Result<Self> {
+        let file = OpenOptions::new()
+            .write(true)
+            .open(path)
+            .chain_err(|| format!("opening {}", path))?;
+        Ok(Self {
+            path: path.to_string(),
+            file,
+        })
+    }
+}
+
+impl PartTable for PartTableKernel {
+    fn reread(&mut self) -> Result<()> {
+        reread_partition_table(&mut self.file)?;
+        udev_settle()
+    }
+}
+
+/// Device nodes for non-partitionable kernel devices, managed by running
+/// kpartx to parse the partition table and create device-mapper devices for
+/// each partition.
+#[derive(Debug)]
+pub struct PartTableKpartx {
+    path: String,
+    need_teardown: bool,
+}
+
+impl PartTableKpartx {
+    fn new(path: &str) -> Result<Self> {
+        let mut table = Self {
+            path: path.to_string(),
+            need_teardown: !Self::already_set_up(path)?,
+        };
+        // create/sync partition devices if missing
+        table.reread()?;
+        Ok(table)
+    }
+
+    // We only want to kpartx -d on drop if we're the one initially
+    // creating the partition devices.  There's no good way to detect
+    // this.
+    fn already_set_up(path: &str) -> Result<bool> {
+        let re = Regex::new(r"^p[0-9]+$").expect("compiling RE");
+        let expected = Path::new(path)
+            .file_name()
+            .chain_err(|| format!("getting filename of {}", path))?
+            .to_os_string()
+            .into_string()
+            .map_err(|_| format!("converting filename of {}", path))?;
+        for ent in read_dir("/dev/mapper").chain_err(|| "listing /dev/mapper")? {
+            let ent = ent.chain_err(|| "reading /dev/mapper entry")?;
+            let found = ent.file_name().into_string().map_err(|_| {
+                format!(
+                    "converting filename of {}",
+                    Path::new(&ent.file_name()).display()
+                )
+            })?;
+            if found.starts_with(&expected) && re.is_match(&found[expected.len()..]) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn run_kpartx(&self, flag: &str) -> Result<()> {
+        // Swallow stderr on success.  Avoids spurious warnings:
+        //   GPT:Primary header thinks Alt. header is not at the end of the disk.
+        //   GPT:Alternate GPT header not at the end of the disk.
+        //   GPT: Use GNU Parted to correct GPT errors.
+        //
+        // By default, kpartx waits for udev to settle before returning,
+        // but this blocks indefinitely inside a container.  See e.g.
+        //   https://github.com/moby/moby/issues/22025
+        // Use -n to skip blocking on udev, and then manually settle.
+        let result = Command::new("kpartx")
+            .arg(flag)
+            .arg("-n")
+            .arg(&self.path)
+            .output()
+            .chain_err(|| format!("running kpartx {} {}", flag, self.path))?;
+        if !result.status.success() {
+            // copy out its stderr
+            eprint!("{}", String::from_utf8_lossy(&*result.stderr));
+            bail!("kpartx {} {} failed: {}", flag, self.path, result.status);
+        }
+        udev_settle()?;
+        Ok(())
+    }
+}
+
+impl PartTable for PartTableKpartx {
+    fn reread(&mut self) -> Result<()> {
+        self.run_kpartx("-u")
+    }
+}
+
+impl Drop for PartTableKpartx {
+    /// If we created the partition devices (rather than finding them
+    /// already existing), delete them afterward so we don't leave DM
+    /// devices attached to the specified disk.
+    fn drop(&mut self) {
+        if self.need_teardown {
+            if let Err(e) = self.run_kpartx("-d") {
+                eprintln!("{}", e)
+            }
+        }
     }
 }
 
@@ -352,7 +488,7 @@ impl Drop for Mount {
     }
 }
 
-pub fn reread_partition_table(file: &mut File) -> Result<()> {
+fn reread_partition_table(file: &mut File) -> Result<()> {
     let fd = file.as_raw_fd();
     // Reread sometimes fails inexplicably.  Retry several times before
     // giving up.
@@ -436,7 +572,7 @@ mod ioctl {
     ioctl_read!(blkgetsize64, 0x12, 114, libc::size_t);
 }
 
-pub fn udev_settle() -> Result<()> {
+fn udev_settle() -> Result<()> {
     // "udevadm settle" silently no-ops if the udev socket is missing, and
     // then lsblk can't find partition labels.  Catch this early.
     if !Path::new("/run/udev/control").exists() {


### PR DESCRIPTION
Handle partitioning with `kpartx`, and rely on the `lsblk` + `holders` busy-partition check to ensure exclusivity.

Fixes #91.  Alternative to #211.