### PR TITLE
 download: correctly zero first MiB of disk during initial write

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -249,7 +249,7 @@ pub fn write_image(
 
     // Read the first MiB of input and, if requested, check it against the
     // image's formatted sector size.
-    let mut first_mb: [u8; 1024 * 1024] = [0; 1024 * 1024];
+    let mut first_mb = [0u8; 1024 * 1024];
     decompress_reader
         .read_exact(&mut first_mb)
         .chain_err(|| "decoding first MiB of image")?;

--- a/src/download.rs
+++ b/src/download.rs
@@ -271,7 +271,7 @@ pub fn write_image(
     // Cache the first MiB and write zeroes to dest instead.  This ensures
     // that the disk image can't be used accidentally before its GPG signature
     // is verified.
-    dest.write_all(&first_mb)
+    dest.write_all(&[0u8; 1024 * 1024])
         .chain_err(|| "clearing first MiB of disk")?;
 
     // do the rest of the copy


### PR DESCRIPTION
We were accidentally writing out the real data, and then going back afterward and writing it again.

Fixes #167.