### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.3.0"
+version = "0.3.1-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.3.0-alpha.0"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.2.2-alpha.0"
+version = "0.3.0-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.2.2-alpha.0"
+version = "0.3.0-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.3.0"
+version = "0.3.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.3.0-alpha.0"
+version = "0.3.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- install: Support remote Ignition configs with `--ignition-url`
- install: Support kernel argument modification with `--append-karg` and `--delete-karg`
- install: Support device-mapper target devices
- install: Support IBM Z DASD target devices

Minor changes:

- install: Deprecate `--firstboot-args`
- install: Report busy partitions if the target device is busy
- install: Correctly clear first MiB of target disk while copy is in progress
- install: Detect unreadable Ignition config before writing disk
- Increase I/O block size when copying data
- systemd: Correctly fail boot on systemd &ge; 245 if install fails
- systemd: Disable activation of MD-RAID and DM devices before install via new `coreos-installer-pre.target`

Packaging changes:

- Update container to Fedora 32
- Require bincode &ge; 1.3
- Require sha2 &ge; 0.9
- Require gptman on s390x
- Relax patchlevel version requirements on dependencies