### PR TITLE
cargo: allow byte-unit major 3 or 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ gptman = { version = "^0.6", default-features = false }
 
 [dependencies]
 bincode = "^1.3"
-byte-unit = "^4.0"
+byte-unit = ">= 3.1.0, < 5.0.0"
 clap = "^2.33"
 cpio = "^0.2"
 error-chain = { version = "^0.12", default-features = false }


### PR DESCRIPTION
The bump to major 4 just adds serde support, which we don't need.  Ease downstream packaging.