### PR TITLE
Split out a `libcoreinst` library and add a new `rdcore` binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ pre-release-commit-message = "cargo: coreos-installer release {{version}}"
 post-release-commit-message = "cargo: development version bump"
 tag-message = "coreos-installer v{{version}}"
 
+[lib]
+name = "libcoreinst"
+path = "src/lib.rs"
+
 [[bin]]
 name = "coreos-installer"
 path = "src/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ path = "src/lib.rs"
 name = "coreos-installer"
 path = "src/main.rs"
 
+[[bin]]
+name = "rdcore"
+path = "src/bin/rdcore/main.rs"
+
 [profile.release]
 lto = true
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all:
 	cargo build ${CARGO_ARGS}
 
 .PHONY: install
-install: install-bin install-scripts install-systemd
+install: install-bin install-scripts install-systemd install-dracut
 
 .PHONY: install-bin
 install-bin: all
@@ -27,3 +27,11 @@ install-scripts: all
 install-systemd: all
 	install -D -m 644 -t $(DESTDIR)/usr/lib/systemd/system systemd/*.{service,target}
 	install -D -t $(DESTDIR)/usr/lib/systemd/system-generators systemd/coreos-installer-generator
+
+.PHONY: install-dracut
+install-dracut: all
+	for x in dracut/*; do \
+		bn=$$(basename $$x); \
+		install -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$${bn} $$x/*; \
+	done
+	install -D -t ${DESTDIR}/usr/lib/dracut/modules.d/50rdcore target/${PROFILE}/rdcore

--- a/dracut/50rdcore/module-setup.sh
+++ b/dracut/50rdcore/module-setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+install() {
+    inst_simple "$moddir/rdcore" "/usr/bin/rdcore"
+}

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -1,0 +1,42 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::{crate_version, App, AppSettings};
+use error_chain::bail;
+
+use libcoreinst::errors::*;
+
+pub enum Config {
+}
+
+/// Parse command-line arguments.
+pub fn parse_args() -> Result<Config> {
+    // Args are listed in --help in the order declared here.  Please keep
+    // the entire help text to 80 columns.
+    let app_matches = App::new("rdcore")
+        .version(crate_version!())
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .global_setting(AppSettings::ArgsNegateSubcommands)
+        .global_setting(AppSettings::DeriveDisplayOrder)
+        .global_setting(AppSettings::DisableHelpSubcommand)
+        .global_setting(AppSettings::UnifiedHelpMessage)
+        .global_setting(AppSettings::VersionlessSubcommands)
+        .get_matches();
+
+    // temporarily; until we actually add our first command
+    #[allow(clippy::match_single_binding)]
+    match app_matches.subcommand() {
+        _ => bail!("unrecognized subcommand"),
+    }
+}

--- a/src/bin/rdcore/main.rs
+++ b/src/bin/rdcore/main.rs
@@ -1,0 +1,29 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod cmdline;
+
+use libcoreinst::errors;
+
+use error_chain::quick_main;
+use errors::{Result, ResultExt};
+
+quick_main!(run);
+
+fn run() -> Result<()> {
+    let config = cmdline::parse_args().chain_err(|| "parsing arguments")?;
+
+    match config {
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,26 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod blockdev;
+pub mod cmdline;
+pub mod download;
+pub mod errors;
+pub mod install;
+pub mod io;
+pub mod iso;
+pub mod osmet;
+#[cfg(target_arch = "s390x")]
+pub mod s390x;
+pub mod source;
+pub mod verify;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,22 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod blockdev;
-mod cmdline;
-mod download;
-mod errors;
-mod install;
-mod io;
-mod iso;
-mod osmet;
-#[cfg(target_arch = "s390x")]
-mod s390x;
-mod source;
-mod verify;
+use libcoreinst::{cmdline, download, errors, install, iso, osmet, source};
 
-use crate::cmdline::Config;
-use crate::errors::{Result, ResultExt};
+use cmdline::Config;
 use error_chain::quick_main;
+use errors::{Result, ResultExt};
 
 quick_main!(run);
 


### PR DESCRIPTION
I thought I'd gauge interest in this approach before going too deep into it. My immediate goal here is to re-implement the logic for https://github.com/coreos/fedora-coreos-config/pull/503 into `rdcore`.

```
commit a1592f9a84dd8fa29d5c8be62e739a6af3f5b144
Date:   Mon Jul 20 17:35:20 2020 -0400

    Move logic to `libcoreinst` library

    Create a new `libcoreinst` library which contains all the logic, and
    make `coreos-installer` simply consist of `main.rs` which calls into it.

    This is prep for adding another binary which will reuse code in
    `libcoreinst`. Doing it this way is a bit awkward, because e.g.
    `cmdline` is also in the library, but it allows minimal churn while
    still making it easy to add other binaries.

commit 14016f3bcd49dd84891211add0ed4b3d7e54da55
Date:   Mon Jul 20 17:35:21 2020 -0400

    rdcore: new binary for initrd CoreOS tasks

    By design, FCOS and RHCOS have a lot going on in the initramfs stage and
    the logic there is likely going to keep growing. As a result, we have
    many non-trivial and crucial shell scripts living in the source config
    (https://github.com/coreos/fedora-coreos-config) which (1) have poor
    error-handling, (2) aren't easy to manually test or unit test, and (3)
    have low visibility because they're deeply nested within some dracut
    module.

    I'd like to propose a new `rdcore` binary which will try to address
    these issues simply by virtue of being in a proper programming language.
    This is shamelessly intended to be a "kitchen sink" collection of
    whatever logic is needed in the initramfs.

    Down the line we can split this out into its own package. But for now,
    it's much easier to tag along an existing one for experimenting without
    having to incur too much paperwork. It's an awkward arrangement, but I
    think the pros outweigh the cons overall, and at least
    `coreos-installer` already isn't very distro-agnostic.

    As for why make this a separate binary instead of just extending the
    CLI, a few reasons:
    1. it'll be easier to eventually rip out and move to its own package
    2. thanks to LTO, we only pay for the bits of the library we use
    3. we don't inadvertently add back installer support into the initrd