### PR TITLE
osmet: successfully mount RHCOS root filesystem for packing

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -214,7 +214,7 @@ fn write_disk(
         || cfg!(target_arch = "s390x")
     {
         let mount =
-            Disk::new(&config.device).mount_partition_by_label("boot", mount::MsFlags::empty())?;
+            Disk::new(&config.device).mount_partition_by_label("boot", false, mount::MsFlags::empty())?;
         if let Some(ignition) = config.ignition.as_ref() {
             write_ignition(mount.mountpoint(), &config.ignition_hash, ignition)
                 .chain_err(|| "writing Ignition configuration")?;

--- a/src/osmet/mod.rs
+++ b/src/osmet/mod.rs
@@ -83,9 +83,11 @@ pub fn osmet_fiemap(config: &OsmetFiemapConfig) -> Result<()> {
 pub fn osmet_pack(config: &OsmetPackConfig) -> Result<()> {
     // First, mount the two main partitions we want to suck out data from: / and /boot. Note
     // MS_RDONLY; this also ensures that the partition isn't already mounted rw elsewhere.
+    // Allow the root partition to be in a child holder device to allow for the RHCOS
+    // crypto_LUKS partition.
     let disk = Disk::new(&config.device);
-    let boot = disk.mount_partition_by_label("boot", mount::MsFlags::MS_RDONLY)?;
-    let root = disk.mount_partition_by_label("root", mount::MsFlags::MS_RDONLY)?;
+    let boot = disk.mount_partition_by_label("boot", false, mount::MsFlags::MS_RDONLY)?;
+    let root = disk.mount_partition_by_label("root", true, mount::MsFlags::MS_RDONLY)?;
 
     // now, we do a first scan of the boot partition and pick up files over a certain size
     let boot_files = prescan_boot_partition(&boot)?;


### PR DESCRIPTION
The partition itself is a `crypto_LUKS` volume; we want the DM device attached to it.  Relax the holders filter in this case.

Fixes 87d2c72cc5c7.