### PR TITLE
install: support Ignition sha256- hash type; switch from sha2 crate to OpenSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,15 +64,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,7 +161,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
  "tempfile",
  "url",
  "walkdir",
@@ -182,12 +172,6 @@ name = "cpio"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00177cda1bb5c5b0a05b1b506125c776411cdfc6a41085126881266e0cdc242"
-
-[[package]]
-name = "cpuid-bool"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
 
 [[package]]
 name = "crc"
@@ -226,15 +210,6 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "lazy_static",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -369,16 +344,6 @@ dependencies = [
  "memchr",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -721,12 +686,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -1081,19 +1040,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
-dependencies = [
- "block-buffer",
- "cfg-if",
- "cpuid-bool",
- "digest",
- "opaque-debug",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,12 +1187,6 @@ name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
-
-[[package]]
-name = "typenum"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ regex = "^1.3"
 reqwest = { version = "^0.10", features = ["blocking"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-sha2 = "^0.9"
 tempfile = "^3.1"
 url = "^2.1"
 walkdir = "^2.3"

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -44,7 +44,12 @@ impl Disk {
         }
     }
 
-    pub fn mount_partition_by_label(&self, label: &str, allow_holder: bool, flags: mount::MsFlags) -> Result<Mount> {
+    pub fn mount_partition_by_label(
+        &self,
+        label: &str,
+        allow_holder: bool,
+        flags: mount::MsFlags,
+    ) -> Result<Mount> {
         // get partition list
         let partitions = self.get_partitions(allow_holder)?;
         if partitions.is_empty() {

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use crate::blockdev::*;
 use crate::download::*;
 use crate::errors::*;
-use crate::install::IgnitionHash;
+use crate::io::IgnitionHash;
 use crate::source::*;
 
 pub enum Config {

--- a/src/install.rs
+++ b/src/install.rs
@@ -213,8 +213,11 @@ fn write_disk(
         || config.network_config.is_some()
         || cfg!(target_arch = "s390x")
     {
-        let mount =
-            Disk::new(&config.device).mount_partition_by_label("boot", false, mount::MsFlags::empty())?;
+        let mount = Disk::new(&config.device).mount_partition_by_label(
+            "boot",
+            false,
+            mount::MsFlags::empty(),
+        )?;
         if let Some(ignition) = config.ignition.as_ref() {
             write_ignition(mount.mountpoint(), &config.ignition_hash, ignition)
                 .chain_err(|| "writing Ignition configuration")?;

--- a/src/install.rs
+++ b/src/install.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use error_chain::{bail, ensure, ChainedError};
+use error_chain::{bail, ChainedError};
 use nix::mount;
 use std::fs::{copy as fscopy, create_dir_all, read_dir, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -27,63 +27,6 @@ use crate::io::*;
 #[cfg(target_arch = "s390x")]
 use crate::s390x;
 use crate::source::*;
-
-/// Integrity verification hash for an Ignition config.
-#[derive(Debug)]
-pub enum IgnitionHash {
-    /// SHA-512 digest.
-    Sha512(Vec<u8>),
-}
-
-impl IgnitionHash {
-    /// Try to parse an hash-digest argument.
-    ///
-    /// This expects an input value following the `ignition.config.verification.hash`
-    /// spec, i.e. `<type>-<value>` format.
-    pub fn try_parse(input: &str) -> Result<Self> {
-        let parts: Vec<_> = input.splitn(2, '-').collect();
-        if parts.len() != 2 {
-            bail!("failed to detect hash-type and digest in '{}'", input);
-        }
-        let (hash_kind, hex_digest) = (parts[0], parts[1]);
-
-        let hash = match hash_kind {
-            "sha512" => {
-                let digest = hex::decode(hex_digest).chain_err(|| "decoding hex digest")?;
-                ensure!(
-                    digest.len().saturating_mul(8) == 512,
-                    "wrong digest length ({})",
-                    digest.len().saturating_mul(8)
-                );
-                IgnitionHash::Sha512(digest)
-            }
-            x => bail!("unknown hash type '{}'", x),
-        };
-
-        Ok(hash)
-    }
-
-    /// Digest and validate input data.
-    pub fn validate(&self, input: &mut impl Read) -> Result<()> {
-        use sha2::digest::Digest;
-
-        let (mut hasher, digest) = match self {
-            IgnitionHash::Sha512(val) => (sha2::Sha512::new(), val),
-        };
-        copy(input, &mut hasher).chain_err(|| "copying input to hasher")?;
-        let computed = hasher.finalize();
-
-        if computed.as_slice() != digest.as_slice() {
-            bail!(
-                "hash mismatch, computed '{}' but expected '{}'",
-                hex::encode(computed),
-                hex::encode(digest),
-            );
-        }
-
-        Ok(())
-    }
-}
 
 pub fn install(config: &InstallConfig) -> Result<()> {
     // set up image source
@@ -492,26 +435,6 @@ fn is_dasd(config: &InstallConfig) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_ignition_hash_cli_parse() {
-        let err_cases = vec!["", "foo-bar", "-bar", "sha512", "sha512-", "sha512-00"];
-        for arg in err_cases {
-            IgnitionHash::try_parse(arg).expect_err(&format!("input: {}", arg));
-        }
-
-        let null_digest = "sha512-cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
-        IgnitionHash::try_parse(null_digest).unwrap();
-    }
-
-    #[test]
-    fn test_ignition_hash_validate() {
-        let input = vec![b'a', b'b', b'c'];
-        let hash_arg = "sha512-ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f";
-        let hasher = IgnitionHash::try_parse(&hash_arg).unwrap();
-        let mut rd = std::io::Cursor::new(input);
-        hasher.validate(&mut rd).unwrap();
-    }
 
     #[test]
     fn test_platform_id() {

--- a/src/io.rs
+++ b/src/io.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use error_chain::bail;
+use error_chain::{bail, ensure};
 use std::fs::read_link;
 use std::io::{ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
@@ -87,5 +87,87 @@ pub fn resolve_link<P: AsRef<Path>>(path: P) -> Result<(PathBuf, bool)> {
         Ok(target) => Ok((target, true)),
         Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => Ok((path.to_path_buf(), false)),
         Err(e) => Err(e).chain_err(|| format!("reading link {}", path.display())),
+    }
+}
+
+/// Ignition-style message digests
+#[derive(Debug)]
+pub enum IgnitionHash {
+    /// SHA-512 digest.
+    Sha512(Vec<u8>),
+}
+
+impl IgnitionHash {
+    /// Try to parse an hash-digest argument.
+    ///
+    /// This expects an input value following the `ignition.config.verification.hash`
+    /// spec, i.e. `<type>-<value>` format.
+    pub fn try_parse(input: &str) -> Result<Self> {
+        let parts: Vec<_> = input.splitn(2, '-').collect();
+        if parts.len() != 2 {
+            bail!("failed to detect hash-type and digest in '{}'", input);
+        }
+        let (hash_kind, hex_digest) = (parts[0], parts[1]);
+
+        let hash = match hash_kind {
+            "sha512" => {
+                let digest = hex::decode(hex_digest).chain_err(|| "decoding hex digest")?;
+                ensure!(
+                    digest.len().saturating_mul(8) == 512,
+                    "wrong digest length ({})",
+                    digest.len().saturating_mul(8)
+                );
+                IgnitionHash::Sha512(digest)
+            }
+            x => bail!("unknown hash type '{}'", x),
+        };
+
+        Ok(hash)
+    }
+
+    /// Digest and validate input data.
+    pub fn validate(&self, input: &mut impl Read) -> Result<()> {
+        use sha2::digest::Digest;
+
+        let (mut hasher, digest) = match self {
+            IgnitionHash::Sha512(val) => (sha2::Sha512::new(), val),
+        };
+        copy(input, &mut hasher).chain_err(|| "copying input to hasher")?;
+        let computed = hasher.finalize();
+
+        if computed.as_slice() != digest.as_slice() {
+            bail!(
+                "hash mismatch, computed '{}' but expected '{}'",
+                hex::encode(computed),
+                hex::encode(digest),
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ignition_hash_cli_parse() {
+        let err_cases = vec!["", "foo-bar", "-bar", "sha512", "sha512-", "sha512-00"];
+        for arg in err_cases {
+            IgnitionHash::try_parse(arg).expect_err(&format!("input: {}", arg));
+        }
+
+        let null_digest = "sha512-cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+        IgnitionHash::try_parse(null_digest).unwrap();
+    }
+
+    #[test]
+    fn test_ignition_hash_validate() {
+        let input = vec![b'a', b'b', b'c'];
+        let hash_arg = "sha512-ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f";
+        let hasher = IgnitionHash::try_parse(&hash_arg).unwrap();
+        let mut rd = std::io::Cursor::new(input);
+        hasher.validate(&mut rd).unwrap();
     }
 }


### PR DESCRIPTION
The API of `openssl::sha` is _not good_, but it's faster than `sha2` and we're already using it in osmet.