### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.4.0-alpha.0"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.3.1-alpha.0"
+version = "0.4.0-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.4.0"
+version = "0.4.1-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.3.1-alpha.0"
+version = "0.4.0-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.4.0"
+version = "0.4.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.4.0-alpha.0"
+version = "0.4.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Minor changes:

- install: Support `sha256` hashes in `--ignition-hash`

Internal changes:

- rdcore: Add new program and Dracut module for internal use in the CoreOS initramfs
- rdcore: Add `stream-hash` subcommand for streaming verification of downloads
- osmet: Add `pack --fast` option for use in development builds
- osmet: Fix packing root filesystem wrapped in a `crypto_LUKS` container

Packaging changes:

- Allow `byte-unit` 3.x or 4.x
- Drop `sha2` dependency