### PR TITLE
Drop copy() reimplementation; use buffered I/O with larger buffers

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -246,14 +246,11 @@ where
     let mut buf_reader = BufReader::new(&mut progress_reader);
     let mut decompress_reader: Box<dyn Read> = {
         let sniff = buf_reader.fill_buf().chain_err(|| "sniffing input")?;
-        // verify default buffer size >= the largest magic number we might
-        // care about
-        assert!(sniff.len() >= 8);
         if !decompress {
             Box::new(buf_reader)
-        } else if &sniff[0..2] == b"\x1f\x8b" {
+        } else if sniff.len() > 2 && &sniff[0..2] == b"\x1f\x8b" {
             Box::new(GzDecoder::new(buf_reader))
-        } else if &sniff[0..6] == b"\xfd7zXZ\x00" {
+        } else if sniff.len() > 6 && &sniff[0..6] == b"\xfd7zXZ\x00" {
             Box::new(XzDecoder::new(buf_reader))
         } else {
             Box::new(buf_reader)

--- a/src/install.rs
+++ b/src/install.rs
@@ -15,7 +15,7 @@
 use error_chain::{bail, ChainedError};
 use nix::mount;
 use std::fs::{copy as fscopy, create_dir_all, read_dir, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{copy, Read, Seek, SeekFrom, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -26,13 +26,6 @@ use crate::errors::*;
 // https://github.com/coreutils/coreutils/blob/6a3d2883/src/ioblksize.h
 pub const BUFFER_SIZE: usize = 256 * 1024;
 
-/// This is like `std::io:copy()`, but uses a buffer larger than 8 KiB
-/// to amortize syscall overhead.
-pub fn copy(reader: &mut (impl Read + ?Sized), writer: &mut (impl Write + ?Sized)) -> Result<u64> {
-    let mut buf = [0u8; BUFFER_SIZE];
-    copy_n(reader, writer, std::u64::MAX, &mut buf)
-}
-
 /// This is like `std::io:copy()`, but limits the number of bytes copied over. The `Read` trait has
 /// `take()`, but that takes ownership of the reader. We also take a buf to avoid re-initializing a
 /// block each time (std::io::copy() gets around this by using MaybeUninit, but that requires using

--- a/src/io.rs
+++ b/src/io.rs
@@ -20,12 +20,16 @@ use std::path::{Path, PathBuf};
 
 use crate::errors::*;
 
+// The default BufReader/BufWriter buffer size is 8 KiB, which isn't large
+// enough to fully amortize system call overhead.
+// https://github.com/rust-lang/rust/issues/49921
+// https://github.com/coreutils/coreutils/blob/6a3d2883/src/ioblksize.h
+pub const BUFFER_SIZE: usize = 256 * 1024;
+
 /// This is like `std::io:copy()`, but uses a buffer larger than 8 KiB
 /// to amortize syscall overhead.
 pub fn copy(reader: &mut (impl Read + ?Sized), writer: &mut (impl Write + ?Sized)) -> Result<u64> {
-    // https://github.com/rust-lang/rust/issues/49921
-    // https://github.com/coreutils/coreutils/blob/6a3d2883/src/ioblksize.h
-    let mut buf = [0u8; 256 * 1024];
+    let mut buf = [0u8; BUFFER_SIZE];
     copy_n(reader, writer, std::u64::MAX, &mut buf)
 }
 

--- a/src/osmet/file.rs
+++ b/src/osmet/file.rs
@@ -22,6 +22,8 @@ use error_chain::bail;
 use serde::{Deserialize, Serialize};
 use xz2::read::XzDecoder;
 
+use crate::io::BUFFER_SIZE;
+
 use super::*;
 
 /// Magic header value for osmet binary.
@@ -75,7 +77,8 @@ pub(super) fn osmet_file_write(
 
     // would be nice to opportunistically do open(O_TMPFILE) then linkat here, but the tempfile API
     // doesn't provide that API: https://github.com/Stebalien/tempfile/pull/31
-    let mut f = BufWriter::new(
+    let mut f = BufWriter::with_capacity(
+        BUFFER_SIZE,
         tempfile::Builder::new()
             .prefix("coreos-installer-osmet")
             .suffix(".partial")
@@ -117,7 +120,7 @@ fn read_and_check_header(mut f: &mut impl Read) -> Result<OsmetFileHeader> {
 
 pub(super) fn osmet_file_read_header(path: &Path) -> Result<OsmetFileHeader> {
     let mut f = BufReader::with_capacity(
-        8192,
+        BUFFER_SIZE,
         OpenOptions::new()
             .read(true)
             .open(path)
@@ -129,7 +132,7 @@ pub(super) fn osmet_file_read_header(path: &Path) -> Result<OsmetFileHeader> {
 
 pub(super) fn osmet_file_read(path: &Path) -> Result<(OsmetFileHeader, Osmet, impl Read + Send)> {
     let mut f = BufReader::with_capacity(
-        8192,
+        BUFFER_SIZE,
         OpenOptions::new()
             .read(true)
             .open(path)

--- a/src/osmet/mod.rs
+++ b/src/osmet/mod.rs
@@ -24,7 +24,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::{File, OpenOptions};
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{copy, Seek, SeekFrom, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
 

--- a/src/osmet/unpacker.rs
+++ b/src/osmet/unpacker.rs
@@ -15,7 +15,7 @@
 use std::convert::{TryFrom, TryInto};
 use std::ffi::OsStr;
 use std::fs::{File, OpenOptions};
-use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::io::{self, copy, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 use std::thread;

--- a/src/s390x/dasd.rs
+++ b/src/s390x/dasd.rs
@@ -15,7 +15,7 @@
 use error_chain::bail;
 use gptman::GPT;
 use std::fs::{read_to_string, File};
-use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{self, BufWriter, Cursor, Read, Seek, SeekFrom, Write};
 use std::num::NonZeroU32;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
@@ -24,7 +24,7 @@ use std::process::{Command, Stdio};
 use crate::blockdev::{get_sector_size, udev_settle};
 use crate::cmdline::*;
 use crate::errors::*;
-use crate::io::{copy, copy_exactly_n};
+use crate::io::{copy, copy_exactly_n, BUFFER_SIZE};
 
 /////////////////////////////////////////////////////////////////////////////
 // IBM DASD Support
@@ -49,10 +49,10 @@ pub fn prepare_dasd(config: &InstallConfig) -> Result<()> {
 pub fn image_copy_s390x(
     first_mb: &[u8],
     source: &mut dyn Read,
-    dest: &mut File,
+    dest_file: &mut File,
     dest_path: &Path,
 ) -> Result<()> {
-    let (ranges, partitions) = partition_ranges(first_mb, dest)?;
+    let (ranges, partitions) = partition_ranges(first_mb, dest_file)?;
     make_partitions(
         dest_path
             .to_str()
@@ -66,6 +66,9 @@ pub fn image_copy_s390x(
     // there shouldn't be any partition data in the first MiB, so don't
     // worry about copying first_mb
     let mut cursor: u64 = 1024 * 1024;
+    // amortize write overhead; the decompressor will produce bytes in
+    // whatever chunk size it chooses
+    let mut dest = BufWriter::with_capacity(BUFFER_SIZE, dest_file);
     let sink = &mut io::sink();
     for range in ranges.iter() {
         if range.in_offset < cursor {
@@ -82,12 +85,14 @@ pub fn image_copy_s390x(
         }
         dest.seek(SeekFrom::Start(range.out_offset))
             .chain_err(|| "seeking output")?;
-        copy_exactly_n(source, dest, range.length, &mut buf).chain_err(|| "copying partition")?;
+        copy_exactly_n(source, &mut dest, range.length, &mut buf)
+            .chain_err(|| "copying partition")?;
         cursor += range.length;
     }
 
     // close out the stream
     copy(source, sink).chain_err(|| "reading remainder of stream")?;
+    dest.flush().chain_err(|| "flushing data to disk")?;
 
     Ok(())
 }

--- a/src/s390x/dasd.rs
+++ b/src/s390x/dasd.rs
@@ -15,7 +15,7 @@
 use error_chain::bail;
 use gptman::GPT;
 use std::fs::{read_to_string, File};
-use std::io::{self, BufWriter, Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{self, copy, BufWriter, Cursor, Read, Seek, SeekFrom, Write};
 use std::num::NonZeroU32;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
@@ -24,7 +24,7 @@ use std::process::{Command, Stdio};
 use crate::blockdev::{get_sector_size, udev_settle};
 use crate::cmdline::*;
 use crate::errors::*;
-use crate::io::{copy, copy_exactly_n, BUFFER_SIZE};
+use crate::io::{copy_exactly_n, BUFFER_SIZE};
 
 /////////////////////////////////////////////////////////////////////////////
 // IBM DASD Support


### PR DESCRIPTION
The current image pipeline is:

- local file or HTTP response →
- [some Readers that don't affect I/O size] →
- `BufReader` with 8 KiB buffer →
- decompressor →
- `copy()` with 256 KiB buffer →
- disk.

`copy()`'s large buffer doesn't matter here.  The decompressor will read data in whatever chunk size it wants, which will be aggregated only up to 8 KiB.  The decompressor will also produce data in whatever chunk size it wants, depending on the compressed stream, and those chunks won't be aggregated at all.

Upgrade the `BufReader` to a 256 KiB buffer and add 256 KiB `BufWriter`s.  This doesn't seem to affect performance much in my local tests, but it's still the right thing to do.  Switch back to `std::io::copy`, since our reimplementation was misguided; add buffers in notable places instead.