### PR TITLE
io: use std::fs::canonicalize instead of resolve_symlink

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -18,7 +18,10 @@ use nix::{errno::Errno, mount};
 use regex::Regex;
 use std::collections::HashMap;
 use std::convert::TryInto;
-use std::fs::{metadata, read_dir, read_to_string, remove_dir, File, OpenOptions};
+use std::fs::{
+    canonicalize, metadata, read_dir, read_to_string, remove_dir, symlink_metadata, File,
+    OpenOptions,
+};
 use std::num::{NonZeroU32, NonZeroU64};
 use std::os::linux::fs::MetadataExt;
 use std::os::raw::c_int;
@@ -30,7 +33,6 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use crate::errors::*;
-use crate::io::resolve_link;
 
 #[derive(Debug)]
 pub struct Disk {
@@ -388,8 +390,13 @@ impl Partition {
         // Now assume a kpartx "partition", where the path is a symlink to
         // an unpartitioned DM device node.
         // /sys/block/dm-1
-        let (target, is_link) = resolve_link(&self.path)?;
+        let is_link = symlink_metadata(&self.path)
+            .chain_err(|| format!("reading metadata for {}", self.path))?
+            .file_type()
+            .is_symlink();
         if is_link {
+            let target = canonicalize(&self.path)
+                .chain_err(|| format!("getting absolute path to {}", self.path))?;
             let devdir = basedir.join(
                 target
                     .file_name()

--- a/src/install.rs
+++ b/src/install.rs
@@ -14,7 +14,7 @@
 
 use error_chain::{bail, ChainedError};
 use nix::mount;
-use std::fs::{copy as fscopy, create_dir_all, read_dir, File, OpenOptions};
+use std::fs::{canonicalize, copy as fscopy, create_dir_all, read_dir, File, OpenOptions};
 use std::io::{copy, Read, Seek, SeekFrom, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
@@ -428,7 +428,8 @@ fn clear_partition_table(dest: &mut File, table: &mut dyn PartTable) -> Result<(
 }
 
 fn is_dasd(config: &InstallConfig) -> Result<bool> {
-    let (target, _) = resolve_link(&config.device)?;
+    let target = canonicalize(&config.device)
+        .chain_err(|| format!("getting absolute path to {}", config.device))?;
     Ok(target.to_string_lossy().starts_with("/dev/dasd"))
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -14,9 +14,7 @@
 
 use error_chain::{bail, ensure};
 use openssl::sha;
-use std::fs::read_link;
 use std::io::{self, ErrorKind, Read, Write};
-use std::path::{Path, PathBuf};
 
 use crate::errors::*;
 
@@ -75,17 +73,6 @@ pub fn copy_exactly_n(
         );
     }
     Ok(n)
-}
-
-// If path is a symlink, resolve it and return (target, true)
-// If not, return (path, false)
-pub fn resolve_link<P: AsRef<Path>>(path: P) -> Result<(PathBuf, bool)> {
-    let path = path.as_ref();
-    match read_link(path) {
-        Ok(target) => Ok((target, true)),
-        Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => Ok((path.to_path_buf(), false)),
-        Err(e) => Err(e).chain_err(|| format!("reading link {}", path.display())),
-    }
 }
 
 /// Ignition-style message digests


### PR DESCRIPTION
resolve_symlink doesn't return an absolute path, so we can get as result smth like `../../devname`. For s390x
with DASD it breaks the installation, becase we use `/dev/dasd` as pattern in `is_dasd()`