### PR TITLE
Add partition preservation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "cpio",
  "error-chain",
  "flate2",
+ "glob",
  "gptman",
  "hex",
  "libc",
@@ -162,6 +163,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "url",
+ "uuid",
  "walkdir",
  "xz2",
 ]
@@ -355,6 +357,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gptman"
@@ -1255,6 +1263,15 @@ name = "utf8-width"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f2c54fe5e8d6907c60dc6fba532cc8529245d97ff4e26cb490cb462de114ba4"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,6 @@ required-features = ["rdcore"]
 [profile.release]
 lto = true
 
-[target.'cfg(target_arch = "s390x")'.dependencies]
-gptman = { version = "^0.6", default-features = false }
-
 [dependencies]
 bincode = "^1.3"
 byte-unit = ">= 3.1.0, < 5.0.0"
@@ -46,6 +43,8 @@ clap = "^2.33"
 cpio = "^0.2"
 error-chain = { version = "^0.12", default-features = false }
 flate2 = "^1.0"
+glob = "^0.3"
+gptman = { version = "^0.6", default-features = false }
 hex = "^0.4"
 libc = "^0.2"
 nix = ">= 0.17, < 0.19"
@@ -57,6 +56,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tempfile = "^3.1"
 url = "^2.1"
+uuid = { version = "^0.8", features = ["v4"] }
 walkdir = "^2.3"
 xz2 = "^0.1"
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ line.
   CoreOS image is being installed on.  Optional; defaults to `metal`.
   Normally this should be specified only if installing inside a virtual
   machine.
+* `coreos.inst.save_partlabel` - Comma-separated labels of partitions to
+  preserve during the install.  Glob-style wildcards are permitted.  The
+  specified partitions need not exist.  Optional.
+* `coreos.inst.save_partindex` - Comma-separated indexes of partitions to
+  preserve during the install.  Ranges (`m-n`) are permitted, and either `m`
+  or `n` can be omitted.  The specified partitions need not exist.
+  Optional.
 * `coreos.inst.insecure` - Permit the OS image to be unsigned.  Optional.
 * `coreos.inst.skip_reboot` - Don't reboot after installing.  Optional.
 

--- a/scripts/coreos-installer-service
+++ b/scripts/coreos-installer-service
@@ -89,6 +89,8 @@ fi
 copy_arg coreos.inst.image_url       --image-url
 copy_arg coreos.inst.platform_id     --platform
 copy_arg coreos.inst.stream          --stream
+copy_arg coreos.inst.save_partlabel  --save-partlabel
+copy_arg coreos.inst.save_partindex  --save-partindex
 
 # Insecure boolean
 if karg_bool coreos.inst.insecure; then

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ use error_chain::error_chain;
 
 error_chain! {
     foreign_links {
+        GptMan(gptman::Error);
         HexDecode(hex::FromHexError);
         Io(std::io::Error);
         Reqwest(reqwest::Error);


### PR DESCRIPTION
Add `--save-partlabel <glob>` and `--save-partindex <range>` options, which save partition table metadata for existing data partitions and then restore those partitions after writing the image.  `--save-partlabel` takes a glob pattern matching the partition label, and `--save-partindex` takes a partition number or range of partition numbers (possibly single-ended).  For example, to save all partitions with indexes greater than 4, specify `--save-partindex 5-`.  The specified partitions need not exist.  If no `--save-*` options are specified, no partitions are saved.

Multiples of each option can be specified, and/or multiple filters can be specified within a single option argument by separating them with commas.  There are corresponding kargs `coreos.inst.save_partlabel` and `coreos.inst.save_partindex`, which cannot be repeated but which accept comma-separated patterns.

Upon restore, try to reuse the original partition number.  If it's not available, renumber the partition to one more than the highest number used so far.  For simplicity, never backfill entries earlier in the partition table, even if the corresponding slot is unused.

If a saved partition overlaps with the image contents, fail.  This can't be detected in advance, so detect the overrun during fetch and stop before the saved partition is clobbered.  Also fail if the install image has a partition extending past the end of the image that overlaps with a saved partition.

On any failure, after clearing the partition table, restore any saved partitions.  In addition, augment partition-table clearing to clear the backup GPT, since some tools may otherwise hallucinate partitions that were overwritten during the install.

All of this assumes GPT partitioning both in the image and on disk, so if `--save-*` options are specified for a DASD target, fail.

Fixes https://github.com/coreos/coreos-installer/issues/190.