### PR TITLE
systemd: fix intermittent failure disabling device auto-activation

### DIFF
--- a/systemd/coreos-installer-disable-device-auto-activation.service
+++ b/systemd/coreos-installer-disable-device-auto-activation.service
@@ -3,6 +3,8 @@ Description=Disable Device Auto-Activation for CoreOS Installer
 DefaultDependencies=no
 Before=systemd-udevd.service
 Before=dm-event.service
+# bash requires a writable /tmp for here-documents
+RequiresMountsFor=/tmp
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The service was racing with `tmp.mount` because bash here-documents will fail if `/tmp` isn't writable.