### PR TITLE
systemd: sequence reboot/noreboot services after primary target

### DIFF
--- a/systemd/coreos-installer-noreboot.service
+++ b/systemd/coreos-installer-noreboot.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Give Login Shell After CoreOS Installer
-After=coreos-installer.service
+After=coreos-installer.target
 ConditionPathExists=!/run/coreos-installer-reboot
 
 [Service]

--- a/systemd/coreos-installer-reboot.service
+++ b/systemd/coreos-installer-reboot.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Reboot after CoreOS Installer
-After=coreos-installer.service
+After=coreos-installer.target
 OnFailure=emergency.target
 OnFailureJobMode=replace-irreversibly
 ConditionPathExists=/run/coreos-installer-reboot


### PR DESCRIPTION
The names of the services should be an implementation detail.  Currently, any user-injected post-install units need to sequence

    After=coreos-installer.service
    Before=coreos-installer-reboot.service
    Before=coreos-installer-noreboot.service

This way, they can just sequence

    After=coreos-installer.service
    Before=coreos-installer.target