### PR TITLE
Release 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.5.0"
+version = "0.5.1-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.4.1-alpha.0"
+version = "0.5.0-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",
@@ -154,7 +154,7 @@ dependencies = [
  "hex",
  "libc",
  "maplit",
- "nix 0.18.0",
+ "nix",
  "openssl",
  "pipe",
  "regex",
@@ -373,7 +373,7 @@ dependencies = [
  "bincode",
  "crc",
  "err-derive",
- "nix 0.17.0",
+ "nix",
  "serde",
  "serde_derive",
 ]
@@ -688,18 +688,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "void",
-]
-
-[[package]]
-name = "nix"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.5.0-alpha.0"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.5.0-alpha.0"
+version = "0.5.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.5.0"
+version = "0.5.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.4.1-alpha.0"
+version = "0.5.0-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- install: Add `--save-partlabel` and `--save-partindex` options to preserve specified partitions
- systemd: Add `coreos.inst.save_partlabel` and `coreos.inst.save_partindex` kargs

Minor changes:

- install: Fix installing to DASD via symlink
- systemd: Fix intermittent failure disabling MD-RAID and DM device activation
- systemd: Sequence `reboot`/`noreboot` services after `coreos-installer.target`
- Increase I/O block size when copying data, correctly

Internal changes:

- rdcore: Add `rootmap` subcommand to generate kargs for root device dependencies

Packaging changes:

- Don't build `rdcore` binary unless `rdcore` feature is enabled
- Add `glob` and `uuid` dependencies
- Drop `progress-streams` dependency
- Depend on `gptman` on all CPU architectures