### PR TITLE
*: derive Eq, not just PartialEq

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -52,7 +52,7 @@ pub struct InstallConfig {
     pub save_partitions: Vec<PartitionFilter>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum PartitionFilter {
     Label(glob::Pattern),
     Index(Option<NonZeroU32>, Option<NonZeroU32>),

--- a/src/osmet/io_helpers.rs
+++ b/src/osmet/io_helpers.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use super::*;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct Sha256Digest([u8; 32]);
 
 impl TryFrom<Hasher> for Sha256Digest {


### PR DESCRIPTION
The affected structs have no fields which can sometimes fail to compare equal to themselves.

Minor cleanup.