### PR TITLE
blockdev: drop stale comment

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -515,7 +515,6 @@ impl SavedPartitions {
             .file_type()
             .is_block_device()
         {
-            // we're running in a unit test
             return Ok(());
         }
         let disk_sector_size = get_sector_size(&file)?.get() as u64;


### PR DESCRIPTION
We also reach this case in the install() --preserve-on-error error path.