### PR TITLE
iso: use copy_file_range to copy the ISO if possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,8 @@ dependencies = [
  "hex",
  "libc",
  "maplit",
- "nix",
+ "nix 0.18.0",
+ "openat-ext",
  "openssl",
  "pipe",
  "regex",
@@ -373,7 +374,7 @@ dependencies = [
  "bincode",
  "crc",
  "err-derive",
- "nix",
+ "nix 0.18.0",
  "serde",
  "serde_derive",
 ]
@@ -679,6 +680,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "nix"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
@@ -697,6 +711,26 @@ checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "openat"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eff876e3964841fd6067ecf1d040e0315879c1a1cce2a0f162828e82f04d1ce"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "openat-ext"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc422059d181116b39e3358041fc595ef0424321c5675ee38cb704ce2cce7e8"
+dependencies = [
+ "libc",
+ "nix 0.17.0",
+ "openat",
 ]
 
 [[package]]
@@ -1277,6 +1311,12 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ gptman = { version = "^0.7", default-features = false }
 hex = "^0.4"
 libc = "^0.2"
 nix = ">= 0.17, < 0.19"
+openat-ext = "^0.1.4"
 openssl = "^0.10"
 pipe = "^0.3"
 regex = "^1.3"


### PR DESCRIPTION
On filesystems and kernels that support it, use `copy_file_range` to
copy the ISO file. CoW semantics is a good fit here because the
transformations we do on the output file are minimal anyway, so there
isn't really a question of balancing against delayed copy costs.

This brings down the time to inject an Ignition config from 4s to 50ms
on my computer.

To do this, use `openat-ext`'s `FileExt` trait which supports doing
`copy_file_range` on `File` objects. (`std::fs::copy()` also knows
`copy_file_range`, but it only takes file paths, so we'd lose the
`O_EXCL | O_CREAT` semantics we want here).