### PR TITLE
Continuously maintain saved partitions in GPT

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -897,24 +897,14 @@ pub fn udev_settle() -> Result<()> {
 
 /// Inspect a buffer from the start of a disk image and return its formatted
 /// sector size, if any can be determined.
-pub fn detect_formatted_sector_size_start(buf: &[u8]) -> Option<NonZeroU32> {
-    detect_formatted_sector_size(buf, 512, 4096)
-}
-
-/// Inspect a buffer 4 KiB from the end of a disk image and return its
-/// formatted sector size, if any can be determined.
-pub fn detect_formatted_sector_size_end(buf: &[u8]) -> Option<NonZeroU32> {
-    detect_formatted_sector_size(buf, 4096 - 512, 0)
-}
-
-fn detect_formatted_sector_size(buf: &[u8], gpt_512: usize, gpt_4096: usize) -> Option<NonZeroU32> {
+pub fn detect_formatted_sector_size(buf: &[u8]) -> Option<NonZeroU32> {
     let gpt_magic: &[u8; 8] = b"EFI PART";
 
-    if buf.len() >= gpt_512 + 8 && buf[gpt_512..gpt_512 + 8] == gpt_magic[..] {
-        // 512-byte GPT
+    if buf.len() >= 520 && buf[512..520] == gpt_magic[..] {
+        // GPT at offset 512
         NonZeroU32::new(512)
-    } else if buf.len() >= gpt_4096 + 8 && buf[gpt_4096..gpt_4096 + 8] == gpt_magic[..] {
-        // 4096-byte GPT
+    } else if buf.len() >= 4104 && buf[4096..4104] == gpt_magic[..] {
+        // GPT at offset 4096
         NonZeroU32::new(4096)
     } else {
         // Unknown
@@ -1019,10 +1009,12 @@ mod tests {
             } else {
                 test.data.to_vec()
             };
-            let result = detect_formatted_sector_size_start(&data);
-            assert_eq!(result, test.result, "{}", test.name);
-            let result = detect_formatted_sector_size_end(&data[data.len().saturating_sub(4096)..]);
-            assert_eq!(result, test.result, "{}", test.name);
+            assert_eq!(
+                detect_formatted_sector_size(&data),
+                test.result,
+                "{}",
+                test.name
+            );
         }
     }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use std::result;
 use std::time::{Duration, Instant};
 
-use crate::blockdev::detect_formatted_sector_size_start;
+use crate::blockdev::detect_formatted_sector_size;
 use crate::cmdline::*;
 use crate::errors::*;
 use crate::io::*;
@@ -225,7 +225,7 @@ where
     // Were we asked to check sector size?
     if let Some(expected) = expected_sector_size {
         // Can we derive one from source data?
-        if let Some(actual) = detect_formatted_sector_size_start(&first_mb) {
+        if let Some(actual) = detect_formatted_sector_size(&first_mb) {
             // Do they match?
             if expected != actual {
                 bail!(

--- a/src/download.rs
+++ b/src/download.rs
@@ -466,8 +466,9 @@ mod tests {
             .into_parts();
         dest.set_len(8 * 1024 * 1024).unwrap();
         partition(&mut dest, Some(4));
-        let saved = SavedPartitions::new(
+        let saved = SavedPartitions::new_from_file(
             &mut dest,
+            512,
             &vec![PartitionFilter::Label(glob::Pattern::new("*").unwrap())],
         )
         .unwrap();
@@ -529,7 +530,7 @@ mod tests {
         // gptman requires a fixed disk length
         dest.set_len(len as u64).unwrap();
         // create saved
-        let saved = SavedPartitions::new(&mut dest, &vec![]).unwrap();
+        let saved = SavedPartitions::new_from_file(&mut dest, 512, &vec![]).unwrap();
         assert!(!saved.is_saved());
         // copy
         source.seek(SeekFrom::Start(mb as u64)).unwrap();
@@ -559,8 +560,9 @@ mod tests {
         // create partition to save
         partition(&mut dest, Some(2));
         // create saved
-        let saved = SavedPartitions::new(
+        let saved = SavedPartitions::new_from_file(
             &mut dest,
+            512,
             &vec![PartitionFilter::Label(glob::Pattern::new("bovik").unwrap())],
         )
         .unwrap();

--- a/src/install.rs
+++ b/src/install.rs
@@ -174,7 +174,7 @@ fn write_disk(
 
     // restore saved partitions, if any, and reread table
     saved
-        .write(dest)
+        .merge(dest)
         .chain_err(|| format!("restoring saved partitions to {}", config.device))?;
     table.reread()?;
 
@@ -494,7 +494,7 @@ fn reset_partition_table(
 
     // Restore saved partitions.
     saved
-        .write(dest)
+        .overwrite(dest)
         .chain_err(|| "restoring saved partitions")?;
 
     // Finish writeback and reread the partition table.
@@ -520,7 +520,7 @@ fn stash_saved_partitions(disk: &mut File, saved: &SavedPartitions) -> Result<()
         .set_len(len)
         .chain_err(|| format!("extending partition stash file {}", path.display()))?;
     saved
-        .write(stash.as_file_mut())
+        .overwrite(stash.as_file_mut())
         .chain_err(|| format!("stashing saved partitions to {}", path.display()))?;
     stash
         .keep()

--- a/src/install.rs
+++ b/src/install.rs
@@ -166,6 +166,7 @@ fn write_disk(
         Path::new(&config.device),
         image_copy,
         true,
+        Some(&saved),
         saved
             .get_offset()?
             .map(|(offset, desc)| (offset, format!("collision with {}", desc))),

--- a/src/install.rs
+++ b/src/install.rs
@@ -172,11 +172,6 @@ fn write_disk(
             .map(|(offset, desc)| (offset, format!("collision with {}", desc))),
         Some(sector_size),
     )?;
-
-    // restore saved partitions, if any, and reread table
-    saved
-        .merge(dest)
-        .chain_err(|| format!("restoring saved partitions to {}", config.device))?;
     table.reread()?;
 
     // postprocess

--- a/src/install.rs
+++ b/src/install.rs
@@ -75,7 +75,7 @@ pub fn install(config: &InstallConfig) -> Result<()> {
         .chain_err(|| format!("checking for exclusive access to {}", &config.device))?;
 
     // save partitions that we plan to keep
-    let saved = SavedPartitions::new(&mut dest, &config.save_partitions)
+    let saved = SavedPartitions::new_from_disk(&mut dest, &config.save_partitions)
         .chain_err(|| format!("saving partitions from {}", config.device))?;
 
     // get reference to partition table

--- a/src/install.rs
+++ b/src/install.rs
@@ -167,9 +167,6 @@ fn write_disk(
         image_copy,
         true,
         Some(&saved),
-        saved
-            .get_offset()?
-            .map(|(offset, desc)| (offset, format!("collision with {}", desc))),
         Some(sector_size),
     )?;
     table.reread()?;

--- a/src/s390x/dasd.rs
+++ b/src/s390x/dasd.rs
@@ -21,7 +21,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use crate::blockdev::{get_sector_size, udev_settle};
+use crate::blockdev::{get_sector_size, udev_settle, SavedPartitions};
 use crate::cmdline::*;
 use crate::errors::*;
 use crate::io::{copy_exactly_n, BUFFER_SIZE};
@@ -54,6 +54,7 @@ pub fn image_copy_s390x(
     source: &mut dyn Read,
     dest_file: &mut File,
     dest_path: &Path,
+    _saved: Option<&SavedPartitions>,
 ) -> Result<()> {
     let (ranges, partitions) = partition_ranges(first_mb, dest_file)?;
     make_partitions(


### PR DESCRIPTION
Suppose, by way of example, that Ignition injection fails during an install with saved partitions.  The primary GPT has the following contents over time:

1.  zeroed while performing the download,
2.  image partitions after the download,
3.  image partitions plus saved partitions before mounting Ignition configs,
4.  zeroed after Ignition injection fails,
5.  saved partitions.

Thus, if we fail during a phase where the saved partitions are not on disk, it's important to recover from the failure and rewrite the GPT.  We have good unit tests on the low-level pieces, but the high-level error paths in `install.rs` will rot and there have already been bugs.  Also, there are circumstances we don't handle, such as power loss (of course) and Unix signals.

This happened because partition saving was bolted on, rather than integrated into the core logic.  If we use `SavedPartitions` more broadly, we can ensure the GPT never omits the saved partitions.  In the above example, the GPT now has:

1.  saved partitions while performing the download,
2.  image partitions plus saved partitions after the download,
3.  saved partitions after the Ignition injection fails.

The resulting code is arguably cleaner, even though it has to plumb `SavedPartitions` into the download code.  DASDs use their own download callback, so the only case where we have to bypass `SavedPartitions` for DASDs is in the failure path.

If there are no saved partitions, we still go out of our way not to modify the image's GPT, so in that case we'll continue to leave a stale backup GPT until the OS fixes it on first boot.