### PR TITLE
ci/travis: various changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - 1.44.0  # pinned toolchain for clippy
-  - 1.41.0  # minimum supported toolchain
+  - 1.44.1  # minimum supported toolchain
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 rust:
-  - 1.44.0  # pinned toolchain for clippy
-  - 1.44.1  # minimum supported toolchain
+  - 1.44.1  # minimum supported toolchain; used for clippy as well
   - stable
   - beta
   - nightly
@@ -19,17 +18,17 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=1.44.0
+    - MSRV=1.44.1
 
 before_script:
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$MSRV" ]]; then
       rustup component add clippy;
     fi'
 
 script:
   - cargo test
   - cargo test --features rdcore
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$MSRV" ]]; then
       cargo clippy -- -D warnings;
       cargo clippy --features rdcore -- -D warnings;
     fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.44.1  # minimum supported toolchain; used for clippy as well
+  - 1.44.1  # minimum supported toolchain; used for clippy/rustfmt as well
   - stable
   - beta
   - nightly
@@ -22,7 +22,7 @@ env:
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$MSRV" ]]; then
-      rustup component add clippy;
+      rustup component add clippy rustfmt;
     fi'
 
 script:
@@ -31,4 +31,5 @@ script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$MSRV" ]]; then
       cargo clippy -- -D warnings;
       cargo clippy --features rdcore -- -D warnings;
+      cargo fmt -- --check;
     fi'


### PR DESCRIPTION
```
commit 163d0a37e7ff1af97de36458a39172d6bfdeedec
Date:   Wed Aug 5 09:38:27 2020 -0400

    ci/travis: bump MSRV to 1.44.1

    This is in the el8 buildroot now.

commit df8224c979b66a4d954c0624db21709e5b56e924
Date:   Wed Aug 5 09:39:27 2020 -0400

    ci/travis: use MSRV for clippy

    It's not helpful to developers to have to keep around two separate
    toolchain versions for hacking on this codebase. Let's just use the MSRV
    for clippy too. It moves fast enough nowadays too.

commit 92de71b3befe8d71998066f35fdb84461ba66652
Date:   Wed Aug 5 09:42:52 2020 -0400

    ci/travis: also run `rustfmt --check`

```