### PR TITLE
live: add pxe ignition {wrap|unwrap} subcommands

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -30,6 +30,8 @@ cosaPod(buildroot: true) {
                     checklen iso ignition embed
                     checklen iso ignition show
                     checklen iso ignition remove
+                    checklen pxe ignition wrap
+                    checklen pxe ignition unwrap
                     if [ "${fail}" = 1 ]; then
                         exit 1
                     fi

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,5 +24,6 @@ error_chain! {
         Nix(nix::Error);
         WalkDir(walkdir::Error);
         Parse(std::num::ParseIntError);
+        Xz(xz2::stream::Error);
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use error_chain::{bail, ensure};
+use flate2::read::GzDecoder;
 use openssl::sha;
-use std::io::{self, ErrorKind, Read, Write};
+use std::io::{self, BufRead, ErrorKind, Read, Write};
 use std::result;
+use xz2::read::XzDecoder;
 
 use crate::errors::*;
 
@@ -164,6 +166,43 @@ impl IgnitionHash {
     }
 }
 
+enum CompressDecoder<R: BufRead> {
+    Uncompressed(R),
+    Gzip(GzDecoder<R>),
+    Xz(XzDecoder<R>),
+}
+
+pub struct DecompressReader<R: BufRead> {
+    decoder: CompressDecoder<R>,
+}
+
+/// Format-sniffing decompressor
+impl<R: BufRead> DecompressReader<R> {
+    pub fn new(mut source: R) -> Result<Self> {
+        use CompressDecoder::*;
+        let sniff = source.fill_buf().chain_err(|| "sniffing input")?;
+        let decoder = if sniff.len() > 2 && &sniff[0..2] == b"\x1f\x8b" {
+            Gzip(GzDecoder::new(source))
+        } else if sniff.len() > 6 && &sniff[0..6] == b"\xfd7zXZ\x00" {
+            Xz(XzDecoder::new(source))
+        } else {
+            Uncompressed(source)
+        };
+        Ok(Self { decoder })
+    }
+}
+
+impl<R: BufRead> Read for DecompressReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> result::Result<usize, io::Error> {
+        use CompressDecoder::*;
+        match &mut self.decoder {
+            Uncompressed(d) => d.read(buf),
+            Gzip(d) => d.read(buf),
+            Xz(d) => d.read(buf),
+        }
+    }
+}
+
 pub struct LimitReader<R: Read> {
     source: R,
     length: u64,
@@ -173,7 +212,7 @@ pub struct LimitReader<R: Read> {
 
 impl<R: Read> LimitReader<R> {
     pub fn new(source: R, length: u64, limit_cause: String) -> Self {
-        LimitReader {
+        Self {
             source,
             length,
             remaining: length,

--- a/src/live.rs
+++ b/src/live.rs
@@ -14,9 +14,11 @@
 
 use cpio::{write_cpio, NewcBuilder, NewcReader};
 use error_chain::bail;
+use nix::unistd::isatty;
 use std::convert::TryInto;
-use std::fs::{read, remove_file, File, OpenOptions};
+use std::fs::{read, remove_file, write, File, OpenOptions};
 use std::io::{copy, stdin, stdout, BufReader, BufWriter, Cursor, Read, Seek, SeekFrom, Write};
+use std::os::unix::io::AsRawFd;
 
 use crate::cmdline::*;
 use crate::errors::*;
@@ -109,6 +111,49 @@ pub fn iso_ignition_remove(config: &IsoIgnitionRemoveConfig) -> Result<()> {
     let mut embed = EmbedArea::for_file(&mut holder.file)?;
     embed.clear()?;
     holder.complete();
+    Ok(())
+}
+
+pub fn pxe_ignition_wrap(config: &PxeIgnitionWrapConfig) -> Result<()> {
+    if config.output.is_none()
+        && isatty(stdout().as_raw_fd()).chain_err(|| "checking if stdout is a TTY")?
+    {
+        bail!("Refusing to write binary data to terminal");
+    }
+
+    let ignition = match config.ignition {
+        Some(ref ignition_path) => {
+            read(ignition_path).chain_err(|| format!("reading {}", ignition_path))?
+        }
+        None => {
+            let mut data = Vec::new();
+            stdin()
+                .read_to_end(&mut data)
+                .chain_err(|| "reading stdin")?;
+            data
+        }
+    };
+
+    let cpio = make_cpio(&ignition)?;
+
+    match &config.output {
+        Some(output_path) => {
+            write(output_path, cpio).chain_err(|| format!("writing {}", output_path))?
+        }
+        None => {
+            stdout().write_all(&cpio).chain_err(|| "writing output")?;
+            stdout().flush().chain_err(|| "flushing output")?;
+        }
+    }
+    Ok(())
+}
+
+pub fn pxe_ignition_unwrap(config: &PxeIgnitionUnwrapConfig) -> Result<()> {
+    let buf = read(&config.input).chain_err(|| format!("reading {}", config.input))?;
+    stdout()
+        .write_all(&extract_cpio(&buf)?)
+        .chain_err(|| "writing output")?;
+    stdout().flush().chain_err(|| "flushing output")?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,5 +36,7 @@ fn run() -> Result<()> {
         Config::OsmetFiemap(c) => osmet::osmet_fiemap(&c),
         Config::OsmetPack(c) => osmet::osmet_pack(&c),
         Config::OsmetUnpack(c) => osmet::osmet_unpack(&c),
+        Config::PxeIgnitionWrap(c) => live::pxe_ignition_wrap(&c),
+        Config::PxeIgnitionUnwrap(c) => live::pxe_ignition_unwrap(&c),
     }
 }


### PR DESCRIPTION
Add subcommands to generate or show a cpio.xz-wrapped Ignition config for appending to a PXE initrd.

Also switch `iso ignition embed` to using xz (and `iso ignition show` to accepting either gz or xz); it uses storage more efficiently and is supported by both FCOS and RHCOS.

Requires #343.  Fixes #322.