### PR TITLE
rdcore/rootmap: also inject rootflags karg

### DIFF
--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -53,6 +53,12 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
     // systemd-fstab-generator, and it defaults to read-only otherwise
     kargs.push("rw".into());
 
+    let rootflags = runcmd_output!("coreos-rootflags", &config.root_mount)?;
+    let rootflags = rootflags.trim();
+    if !rootflags.is_empty() {
+        kargs.push(format!("rootflags={}", rootflags));
+    }
+
     let boot_mount = if let Some(path) = &config.boot_mount {
         Some(Mount::from_existing(path)?)
     } else if let Some(devpath) = &config.boot_device {

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,6 +22,7 @@ use crate::errors::*;
 /// are adequately prefixed with the full command.
 #[macro_export]
 macro_rules! runcmd {
+    ($cmd:expr) => (runcmd!($cmd,));
     ($cmd:expr, $($args:expr),*) => {{
         let mut cmd = Command::new($cmd);
         $( cmd.arg($args); )*
@@ -40,6 +41,7 @@ macro_rules! runcmd {
 /// output. Output is assumed to be UTF-8. Errors are adequately prefixed with the full command.
 #[macro_export]
 macro_rules! runcmd_output {
+    ($cmd:expr) => (runcmd_output!($cmd,));
     ($cmd:expr, $($args:expr),*) => {{
         let mut cmd = Command::new($cmd);
         $( cmd.arg($args); )*


### PR DESCRIPTION
Because we now always inject a `root` karg, it means that it's systemd
which does the mount. But then, systemd doesn't know to use the
`prjquota` flag we want by default for xfs.

Call out to a `coreos-rootflags` helper where the source of truth for
default root mount flags lives and embed its output if any is provided.