### PR TITLE
blockdev: use loop instead of iterator

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -621,13 +621,17 @@ impl SavedPartitions {
         if !p.is_used() {
             return false;
         }
-        filters.iter().any(|f| match f {
-            Index(Some(first), _) if first.get() > i => false,
-            Index(_, Some(last)) if last.get() < i => false,
-            Index(_, _) => true,
-            Label(glob) if glob.matches(p.partition_name.as_str()) => true,
-            _ => false,
-        })
+
+        for f in filters {
+            match f {
+                Index(Some(first), _) if first.get() > i => continue,
+                Index(_, Some(last)) if last.get() < i => continue,
+                Index(_, _) => return true,
+                Label(glob) if glob.matches(p.partition_name.as_str()) => return true,
+                _ => continue,
+            }
+        }
+        false
     }
 
     /// Unconditionally write the saved partitions, and only the saved


### PR DESCRIPTION
on s390x optimized (release) code with iter().any() fails with coredump:

```
(gdb) bt
#0  libcoreinst::blockdev::SavedPartitions::matches_filters::{{closure}} (f=0x8) at src/blockdev.rs:625
#1  <core::slice::Iter<T> as core::iter::traits::iterator::Iterator>::any (self=<optimized out>, f=...) at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/libcore/slice/mod.rs:3392
#2  libcoreinst::blockdev::SavedPartitions::matches_filters (i=1, p=0x2aa34720120, filters=...) at src/blockdev.rs:624
#3  libcoreinst::blockdev::SavedPartitions::new (disk=0x3ffd367e3ec, sector_size=512, filters=...) at src/blockdev.rs:557
#4  libcoreinst::blockdev::SavedPartitions::new_from_disk (disk=0x3ffd367e3ec, filters=...) at src/blockdev.rs:510
#5  libcoreinst::install::install (config=0x3ffd377ecd8) at src/install.rs:78
#6  0x000002aa335e9b8e in coreos_installer::main () at src/main.rs:29
```

Looks like we have some compiler issue for s390x, until it's understood and fixed let's use `for` loop as it works as expected

