### PR TITLE
s390x: include firstboot kargs in zipl run

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -212,7 +212,11 @@ fn write_disk(
             copy_network_config(mount.mountpoint(), network_config)?;
         }
         #[cfg(target_arch = "s390x")]
-        s390x::install_bootloader(mount.mountpoint(), &config.device)?;
+        s390x::install_bootloader(
+            mount.mountpoint(),
+            &config.device,
+            config.firstboot_kargs.as_ref().map(|s| s.as_str()),
+        )?;
     }
 
     // detect any latent write errors

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -30,14 +30,22 @@ use crate::errors::*;
 /// # Arguments
 /// * `boot` - path to boot partition mountpoint, i.e. smth like /boot
 /// * `disk` - smth like /dev/dasda
-pub fn install_bootloader<P: AsRef<Path>>(boot: P, disk: &str) -> Result<()> {
+pub fn install_bootloader<P: AsRef<Path>>(
+    boot: P,
+    disk: &str,
+    extra_kargs: Option<&str>,
+) -> Result<()> {
     eprintln!("Installing bootloader");
 
     let bls_config_path = get_bls_config_path(&boot)?;
     let kernel_path = get_kernel_path(&boot)?;
     let initramfs_path = get_initramfs_path(&boot)?;
 
-    let kargs = format!("{} ignition.firstboot", get_boot_kargs(bls_config_path)?);
+    let kargs = format!(
+        "{} ignition.firstboot {}",
+        get_boot_kargs(bls_config_path)?,
+        extra_kargs.unwrap_or("")
+    );
 
     let status = Command::new("zipl")
         .arg("-P")


### PR DESCRIPTION
This is necessary for `coreos-installer-service` to capture live boot kargs such as static IP address configs.  `ignition-firstboot-complete.service` will rerun `zipl` during the first boot.

Fixes #364.