### PR TITLE
Release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.6.0-alpha.0"
+version = "0.6.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.6.0"
+version = "0.6.1-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.5.1-alpha.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.6.0"
+version = "0.6.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.5.1-alpha.0"
+version = "0.6.0-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.6.0-alpha.0"
+version = "0.6.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- Add `pxe ignition` subcommands to generate or show an Ignition config wrapped in an appendable initrd
- iso: Move `iso` subcommands to `iso ignition` and deprecate the former
- iso: Rename `iso ignition embed -c`/`--config` to `-i`/`--ignition-file`

Minor changes:

- install: Fix kernel ignoring saved partitions after install failure
- install: Fix loss of saved partitions if original partition table is invalid
- install: Retain saved partitions in partition table at all times during install
- install: Clear partition table on failure by writing empty GPT rather than zeroes, except on DASD
- install: Reread kernel partition table after restoring partitions on failure
- install: Make `--preserve-on-error` saved partition stash file the same size as the target disk
- install: Properly activate first-boot kernel arguments on s390x
- install: Avoid segfault due to miscompilation in s390x release build
- iso: Compress Ignition config with XZ to increase capacity
- systemd: Suppress reboot after failure of a hook unit
- Document hooking install via an Ignition config

Internal changes:

- rootmap: Fix failure on unmodified rootfs
- rootmap: Inject `rootflags` kernel argument

Packaging changes:

- Require `gptman` &ge; 0.7

SHA-256 digests:

- crate: ``
- vendor: ``