### PR TITLE
ci: compress metal4k image with `--fast`

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -52,7 +52,7 @@ cosaPod(buildroot: true) {
                 shwrap("cd /srv/fcos && cosa buildextend-live --fast")
                 // Test metal with an uncompressed image and metal4k with a
                 // compressed one
-                shwrap("cd /srv/fcos && cosa compress --artifact=metal4k")
+                shwrap("cd /srv/fcos && cosa compress --fast --artifact=metal4k")
             }
             stage("Test ISO") {
                 // No need to run the iso-live-login scenario (in theory, and also right


### PR DESCRIPTION
For some marginal CI testing speed gains.