### PR TITLE
Properly update MBR when installing with saved partitions

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -710,6 +710,11 @@ impl SavedPartitions {
         Ok(())
     }
 
+    /// Get the sector size in use for this partition table.
+    pub fn get_sector_size(&self) -> u64 {
+        self.sector_size
+    }
+
     /// Get the byte offset of the first byte not to be overwritten, if any,
     /// plus a description of the partition at that offset.
     pub fn get_offset(&self) -> Result<Option<(u64, String)>> {

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -937,7 +937,7 @@ mod tests {
     use super::*;
     use error_chain::ChainedError;
     use maplit::hashmap;
-    use std::io::{copy, Read};
+    use std::io::copy;
     use tempfile::tempfile;
     use xz2::read::XzDecoder;
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -588,7 +588,8 @@ mod tests {
         let mut result = vec![0u8; len];
         dest.read_exact(&mut result).unwrap();
         assert_eq!(detect_formatted_sector_size(&result), NonZeroU32::new(512));
-        assert_eq!(data_partitioned[0..512], result[0..512]);
+        // boot code must match install data; partition table will not
+        assert_eq!(data_partitioned[0..446], result[0..446]);
         let gpt_size = get_gpt_size(&mut dest).unwrap();
         assert!(gpt_size < 24576);
         assert_eq!(

--- a/src/download.rs
+++ b/src/download.rs
@@ -295,6 +295,12 @@ pub fn image_copy_default(
     // verify_reader has now checked the signature, so fill in the first MiB
     let offset = match saved {
         Some(saved) if saved.is_saved() => {
+            // copy MBR
+            dest.seek(SeekFrom::Start(0))
+                .chain_err(|| "seeking disk to MBR")?;
+            dest.write_all(&first_mb[0..saved.get_sector_size() as usize])
+                .chain_err(|| "writing MBR")?;
+
             // write merged GPT
             let mut cursor = Cursor::new(first_mb);
             saved
@@ -582,6 +588,7 @@ mod tests {
         let mut result = vec![0u8; len];
         dest.read_exact(&mut result).unwrap();
         assert_eq!(detect_formatted_sector_size(&result), NonZeroU32::new(512));
+        assert_eq!(data_partitioned[0..512], result[0..512]);
         let gpt_size = get_gpt_size(&mut dest).unwrap();
         assert!(gpt_size < 24576);
         assert_eq!(


### PR DESCRIPTION
When installing with saved partitions, we were failing to clear the MBR boot code during install and on error, and failing to write the new boot code afterward.  Fixes regressions in #340.

Also update the size of the protective MBR partition after install, for consistency with the GPT.

https://bugzilla.redhat.com/show_bug.cgi?id=1879690