### PR TITLE
s390x: add FBA-DASD disks support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +107,12 @@ name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
+name = "case"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88b166b48e29667f5443df64df3c61dc07dc2b1a0b0d231800e07f09a33ecc1"
 
 [[package]]
 name = "cc"
@@ -160,10 +178,12 @@ dependencies = [
  "hex",
  "libc",
  "maplit",
+ "mbrman",
  "nix 0.19.1",
  "openat-ext",
  "openssl",
  "pipe",
+ "rand",
  "regex",
  "reqwest",
  "serde",
@@ -221,6 +241,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-error"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec098440b29ea3b1ece3e641bac424c19cf996779b623c9e0f2171495425c2c8"
+dependencies = [
+ "case",
+ "quote 0.3.15",
+ "syn 0.11.11",
+]
+
+[[package]]
 name = "drop_bomb"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,9 +274,9 @@ checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.3",
  "rustversion",
- "syn",
+ "syn 1.0.33",
  "synstructure",
 ]
 
@@ -316,6 +347,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
 name = "futures-channel"
@@ -597,6 +634,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "mbrman"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14931c7d5ec55fd5187785ad90db80dfeaa35d69093e5dd957a200508ff1911c"
+dependencies = [
+ "bincode",
+ "bitvec",
+ "derive-error",
+ "serde",
+]
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,8 +847,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.3",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -849,8 +898,8 @@ checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.3",
+ "syn 1.0.33",
  "version_check",
 ]
 
@@ -861,8 +910,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.3",
+ "syn 1.0.33",
  "syn-mid",
  "version_check",
 ]
@@ -873,8 +922,14 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.0",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -884,6 +939,12 @@ checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -1001,8 +1062,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.3",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -1069,8 +1130,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.3",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -1116,13 +1177,24 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
- "quote",
- "unicode-xid",
+ "quote 1.0.3",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
@@ -1132,8 +1204,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.3",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -1143,10 +1224,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "quote 1.0.3",
+ "syn 1.0.33",
+ "unicode-xid 0.2.0",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tempfile"
@@ -1280,6 +1367,12 @@ checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
@@ -1378,8 +1471,8 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.3",
+ "syn 1.0.33",
  "wasm-bindgen-shared",
 ]
 
@@ -1401,7 +1494,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
- "quote",
+ "quote 1.0.3",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1412,8 +1505,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.3",
+ "syn 1.0.33",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1495,6 +1588,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,7 @@ xz2 = "^0.1"
 
 [dev-dependencies]
 maplit = "^1.0"
+
+[target.'cfg(target_arch = "s390x")'.dependencies]
+mbrman = { version = "^0.3", default-features = false }
+rand = "^0.7"

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -24,7 +24,7 @@ use crate::download::*;
 use crate::errors::*;
 use crate::io::IgnitionHash;
 #[cfg(target_arch = "s390x")]
-use crate::s390x::dasd::dasd_try_get_sector_size;
+use crate::s390x::dasd_try_get_sector_size;
 use crate::source::*;
 
 pub enum Config {

--- a/src/s390x/dasd.rs
+++ b/src/s390x/dasd.rs
@@ -13,42 +13,26 @@
 // limitations under the License.
 
 use error_chain::bail;
-use gptman::GPT;
-use std::fs::{read_to_string, File};
-use std::io::{self, copy, BufWriter, Cursor, Read, Seek, SeekFrom, Write};
-use std::num::NonZeroU32;
-use std::os::unix::io::AsRawFd;
+use std::fs::File;
+use std::io::{self, copy, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
 
-use crate::blockdev::{get_sector_size, udev_settle, SavedPartitions};
+use crate::blockdev::SavedPartitions;
 use crate::errors::*;
 use crate::io::{copy_exactly_n, BUFFER_SIZE};
-use crate::util::*;
-
-use crate::runcmd;
+use crate::s390x::eckd::{
+    default_format, is_invalid, low_level_format, make_partitions, partition_ranges,
+};
 
 /////////////////////////////////////////////////////////////////////////////
 // IBM DASD Support
 /////////////////////////////////////////////////////////////////////////////
 
-const ECKD_DASD_BLOCKSIZE: u32 = 4096;
-
 #[derive(Debug)]
-struct Range {
-    in_offset: u64,
-    out_offset: u64,
-    length: u64,
-}
-
-/// Returns expected sector size if this is a DASD we'll format later,
-/// or None if the caller should use get_sector_size()
-pub fn dasd_try_get_sector_size(device: &str) -> Result<Option<NonZeroU32>> {
-    if is_formatted(device)? {
-        Ok(None)
-    } else {
-        Ok(Some(NonZeroU32::new(ECKD_DASD_BLOCKSIZE).unwrap()))
-    }
+pub(crate) struct Range {
+    pub in_offset: u64,
+    pub out_offset: u64,
+    pub length: u64,
 }
 
 pub fn prepare_dasd(device: &str) -> Result<()> {
@@ -110,213 +94,4 @@ pub fn image_copy_s390x(
     dest.flush().chain_err(|| "flushing data to disk")?;
 
     Ok(())
-}
-
-/// Generate partition table entries and byte ranges to copy
-fn partition_ranges(header: &[u8], device: &mut File) -> Result<(Vec<Range>, Vec<String>)> {
-    let bytes_per_block: u64 = get_sector_size(device)?.get().into();
-    let blocks_per_track: u64 = get_sectors_per_track(device)?.get().into();
-
-    let gpt = GPT::read_from(&mut Cursor::new(header), bytes_per_block)
-        .chain_err(|| "reading GPT of source image")?;
-
-    let mut ranges = Vec::new();
-    let mut partitions = Vec::new();
-    let mut start_track: u64 = 2; // the first 2 tracks of the ECKD DASD are reserved
-    let entries = || gpt.iter().filter(|(_, pt)| pt.is_used());
-    let (last_partition, _) = entries()
-        .last()
-        .chain_err(|| "source image has no partitions")?;
-
-    for (i, pt) in entries() {
-        let blocks = pt.ending_lba - pt.starting_lba + 1;
-        let end_track = start_track + (blocks + blocks_per_track - 1) / blocks_per_track - 1;
-
-        ranges.push(Range {
-            in_offset: pt.starting_lba * bytes_per_block,
-            out_offset: start_track * blocks_per_track * bytes_per_block,
-            length: blocks * bytes_per_block,
-        });
-
-        if i == last_partition {
-            partitions.push(format!("[{}, last, native]", start_track));
-        } else {
-            partitions.push(format!("[{}, {}, native]", start_track, end_track));
-        };
-        start_track = end_track + 1;
-    }
-    // partitions should be in offset order, but just to be sure
-    ranges.sort_unstable_by_key(|r| r.in_offset);
-    Ok((ranges, partitions))
-}
-
-/// Get disk bus id
-///
-/// # Arguments
-/// * `dasd` - dasd device, i.e. smth like /dev/dasda
-fn bus_id(dasd: &str) -> Result<String> {
-    let cmd = Command::new("lszdev")
-        .arg("-n")
-        .arg("-c")
-        .arg("ID")
-        .arg("--by-node")
-        .arg(dasd)
-        .stderr(Stdio::inherit())
-        .output()
-        .chain_err(|| format!("executing lszdev on {}", dasd))?;
-    if !cmd.status.success() {
-        bail!("lszdev on {} failed", dasd);
-    }
-    Ok(std::str::from_utf8(&cmd.stdout)
-        .chain_err(|| "decoding lszdev output")?
-        .trim_end()
-        .to_string())
-}
-
-/// Check if disk is already formatted or not
-///
-/// # Arguments
-/// * `dasd` - dasd device, i.e. smth like /dev/dasda
-fn is_formatted(dasd: &str) -> Result<bool> {
-    let id = bus_id(dasd)?;
-    let path = format!("/sys/bus/ccw/devices/{}/status", id);
-    let contents = read_to_string(&path).chain_err(|| format!("reading {}", path))?;
-    Ok(!contents.contains("unformatted"))
-}
-
-/// Check if disk is valid or not
-///
-/// # Arguments
-/// * `dasd` - dasd device, i.e. smth like /dev/dasda
-fn is_invalid(dasd: &str) -> Result<bool> {
-    let mut cmd = Command::new("fdasd");
-    // we're looking for a hardcoded string in the output
-    cmd.env("LC_ALL", "C").arg("-p").arg(dasd);
-    let invalid = cmd_output(&mut cmd)?.contains("disk label block is invalid");
-    // Older versions of `fdasd` open the device O_RDWR, which causes udev
-    // to re-probe the device node.  This can cause the fdasd call in
-    // default_format() to fail on 'Error while rereading partition table' or
-    // 'Disk in use'.  To avoid this, wait for udev to settle.
-    // https://bugzilla.redhat.com/1900699
-    // Fixed by https://github.com/ibm-s390-tools/s390-tools/commit/3d74c53
-    udev_settle()?;
-    Ok(invalid)
-}
-
-/// Perform low-level format. This step is necessary before any further disk usage
-///
-/// # Arguments
-/// * `dasd` - dasd device, i.e. smth like /dev/dasda
-fn low_level_format(dasd: &str) -> Result<()> {
-    if is_formatted(dasd)? {
-        eprintln!("Skipping low-level format for {}", dasd);
-        return Ok(());
-    }
-    eprintln!("Performing low-level format for {}", dasd);
-    runcmd!(
-        "dasdfmt",
-        "--blocksize",
-        ECKD_DASD_BLOCKSIZE.to_string(),
-        "--disk_layout",
-        "cdl",
-        "--mode",
-        "full",
-        "-y",
-        "-p",
-        dasd
-    )?;
-    udev_settle()?;
-    Ok(())
-}
-
-/// Format disk and create partitions
-///
-/// # Arguments
-/// * `dasd` - dasd device, i.e. smth like /dev/dasda
-/// * `partitions` - configuration strings
-fn make_partitions(dasd: &str, partitions: &[String]) -> Result<()> {
-    if partitions.len() > 3 {
-        // fdasd silently ignores partitions after the first 3
-        bail!("Can't create {} partitions, maximum 3", partitions.len());
-    }
-    let mut config = partitions.join("\n");
-    config.push('\n');
-    if try_format(dasd, &config).is_err() {
-        default_format(dasd)?;
-        try_format(dasd, &config)?;
-    }
-    Ok(())
-}
-
-/// If config-based format fails, then we have to perform
-/// an auto-format on the whole disk
-///
-/// # Arguments
-/// * `dasd` - dasd device, i.e. smth like /dev/dasda
-fn default_format(dasd: &str) -> Result<()> {
-    eprintln!("Auto-partitioning {}", dasd);
-    runcmd!("fdasd", "-a", "-s", dasd).chain_err(|| format!("auto-formatting {} failed", dasd))?;
-    udev_settle()?;
-    Ok(())
-}
-
-/// Format disk using a config file
-///
-/// # Arguments
-/// * `dasd` - dasd device, i.e. smth like /dev/dasda
-/// * `config` - configuration file contents
-fn try_format(dasd: &str, config: &str) -> Result<()> {
-    eprintln!("Partitioning {}", dasd);
-    let mut child = Command::new("fdasd")
-        .arg("-s")
-        .arg("--config")
-        .arg("/dev/stdin")
-        .arg(dasd)
-        .stdin(Stdio::piped())
-        .spawn()
-        .chain_err(|| "failed to execute fdasd")?;
-    child
-        .stdin
-        .as_mut()
-        .chain_err(|| "couldn't open fdasd stdin")?
-        .write_all(config.as_bytes())
-        .chain_err(|| "couldn't write fdasd stdin")?;
-    if !child
-        .wait()
-        .chain_err(|| "couldn't wait on fdasd")?
-        .success()
-    {
-        bail!("couldn't format {} based on:\n{}", dasd, config);
-    }
-    udev_settle()?;
-    Ok(())
-}
-
-/// Get the number of sectors per track of a block device.
-fn get_sectors_per_track(file: &File) -> Result<NonZeroU32> {
-    let fd = file.as_raw_fd();
-    let mut geo: ioctl::hd_geometry = Default::default();
-    match unsafe { ioctl::hdio_getgeo(fd, &mut geo) } {
-        Ok(_) => {
-            NonZeroU32::new(geo.sectors.into()).ok_or_else(|| "found sectors/track of zero".into())
-        }
-        Err(e) => Err(Error::with_chain(e, "getting disk geometry")),
-    }
-}
-
-// create unsafe ioctl wrappers
-mod ioctl {
-    use nix::ioctl_read_bad;
-    use std::os::raw::{c_uchar, c_ulong, c_ushort};
-
-    #[repr(C)]
-    #[derive(Debug, Default)]
-    pub struct hd_geometry {
-        pub heads: c_uchar,
-        pub sectors: c_uchar,
-        pub cylinders: c_ushort,
-        pub start: c_ulong,
-    }
-
-    ioctl_read_bad!(hdio_getgeo, 0x0301, hd_geometry);
 }

--- a/src/s390x/dasd.rs
+++ b/src/s390x/dasd.rs
@@ -23,6 +23,7 @@ use crate::blockdev::SavedPartitions;
 use crate::errors::*;
 use crate::io::{copy_exactly_n, BUFFER_SIZE};
 use crate::s390x::eckd::*;
+use crate::s390x::fba::*;
 
 /////////////////////////////////////////////////////////////////////////////
 // IBM DASD Support
@@ -88,7 +89,7 @@ pub fn image_copy_s390x(
 ) -> Result<()> {
     let ranges = match get_dasd_type(dest_path)? {
         DasdType::Eckd => eckd_make_partitions(&dest_path.to_string_lossy(), dest_file, first_mb)?,
-        DasdType::Fba => bail!("FBA DASD is not supported"),
+        DasdType::Fba => fba_make_partitions(&dest_path.to_string_lossy(), dest_file, first_mb)?,
     };
 
     // copy each partition

--- a/src/s390x/eckd.rs
+++ b/src/s390x/eckd.rs
@@ -1,0 +1,248 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use error_chain::bail;
+use gptman::GPT;
+use std::fs::{read_to_string, File};
+use std::io::{Cursor, Write};
+use std::num::NonZeroU32;
+use std::os::unix::io::AsRawFd;
+use std::process::{Command, Stdio};
+
+use crate::blockdev::{get_sector_size, udev_settle};
+use crate::errors::*;
+use crate::runcmd;
+use crate::s390x::dasd::Range;
+use crate::util::*;
+
+const ECKD_DASD_BLOCKSIZE: u32 = 4096;
+
+/// Returns expected sector size if this is a DASD we'll format later,
+/// or None if the caller should use get_sector_size()
+pub fn dasd_try_get_sector_size(device: &str) -> Result<Option<NonZeroU32>> {
+    if is_formatted(device)? {
+        Ok(None)
+    } else {
+        Ok(Some(NonZeroU32::new(ECKD_DASD_BLOCKSIZE).unwrap()))
+    }
+}
+
+/// Generate partition table entries and byte ranges to copy
+pub(crate) fn partition_ranges(header: &[u8], device: &mut File) -> Result<(Vec<Range>, Vec<String>)> {
+    let bytes_per_block: u64 = get_sector_size(device)?.get().into();
+    let blocks_per_track: u64 = get_sectors_per_track(device)?.get().into();
+
+    let gpt = GPT::read_from(&mut Cursor::new(header), bytes_per_block)
+        .chain_err(|| "reading GPT of source image")?;
+
+    let mut ranges = Vec::new();
+    let mut partitions = Vec::new();
+    let mut start_track: u64 = 2; // the first 2 tracks of the ECKD DASD are reserved
+    let entries = || gpt.iter().filter(|(_, pt)| pt.is_used());
+    let (last_partition, _) = entries()
+        .last()
+        .chain_err(|| "source image has no partitions")?;
+
+    for (i, pt) in entries() {
+        let blocks = pt.ending_lba - pt.starting_lba + 1;
+        let end_track = start_track + (blocks + blocks_per_track - 1) / blocks_per_track - 1;
+
+        ranges.push(Range {
+            in_offset: pt.starting_lba * bytes_per_block,
+            out_offset: start_track * blocks_per_track * bytes_per_block,
+            length: blocks * bytes_per_block,
+        });
+
+        if i == last_partition {
+            partitions.push(format!("[{}, last, native]", start_track));
+        } else {
+            partitions.push(format!("[{}, {}, native]", start_track, end_track));
+        };
+        start_track = end_track + 1;
+    }
+    // partitions should be in offset order, but just to be sure
+    ranges.sort_unstable_by_key(|r| r.in_offset);
+    Ok((ranges, partitions))
+}
+
+/// Get disk bus id
+///
+/// # Arguments
+/// * `dasd` - dasd device, i.e. smth like /dev/dasda
+fn bus_id(dasd: &str) -> Result<String> {
+    let cmd = Command::new("lszdev")
+        .arg("-n")
+        .arg("-c")
+        .arg("ID")
+        .arg("--by-node")
+        .arg(dasd)
+        .stderr(Stdio::inherit())
+        .output()
+        .chain_err(|| format!("executing lszdev on {}", dasd))?;
+    if !cmd.status.success() {
+        bail!("lszdev on {} failed", dasd);
+    }
+    Ok(std::str::from_utf8(&cmd.stdout)
+        .chain_err(|| "decoding lszdev output")?
+        .trim_end()
+        .to_string())
+}
+
+/// Check if disk is already formatted or not
+///
+/// # Arguments
+/// * `dasd` - dasd device, i.e. smth like /dev/dasda
+fn is_formatted(dasd: &str) -> Result<bool> {
+    let id = bus_id(dasd)?;
+    let path = format!("/sys/bus/ccw/devices/{}/status", id);
+    let contents = read_to_string(&path).chain_err(|| format!("reading {}", path))?;
+    Ok(!contents.contains("unformatted"))
+}
+
+/// Check if disk is valid or not
+///
+/// # Arguments
+/// * `dasd` - dasd device, i.e. smth like /dev/dasda
+pub(crate) fn is_invalid(dasd: &str) -> Result<bool> {
+    let mut cmd = Command::new("fdasd");
+    // we're looking for a hardcoded string in the output
+    cmd.env("LC_ALL", "C").arg("-p").arg(dasd);
+    let invalid = cmd_output(&mut cmd)?.contains("disk label block is invalid");
+    // Older versions of `fdasd` open the device O_RDWR, which causes udev
+    // to re-probe the device node.  This can cause the fdasd call in
+    // default_format() to fail on 'Error while rereading partition table' or
+    // 'Disk in use'.  To avoid this, wait for udev to settle.
+    // https://bugzilla.redhat.com/1900699
+    // Fixed by https://github.com/ibm-s390-tools/s390-tools/commit/3d74c53
+    udev_settle()?;
+    Ok(invalid)
+}
+
+/// Perform low-level format. This step is necessary before any further disk usage
+///
+/// # Arguments
+/// * `dasd` - dasd device, i.e. smth like /dev/dasda
+pub(crate) fn low_level_format(dasd: &str) -> Result<()> {
+    if is_formatted(dasd)? {
+        eprintln!("Skipping low-level format for {}", dasd);
+        return Ok(());
+    }
+    eprintln!("Performing low-level format for {}", dasd);
+    runcmd!(
+        "dasdfmt",
+        "--blocksize",
+        ECKD_DASD_BLOCKSIZE.to_string(),
+        "--disk_layout",
+        "cdl",
+        "--mode",
+        "full",
+        "-y",
+        "-p",
+        dasd
+    )?;
+    udev_settle()?;
+    Ok(())
+}
+
+/// Format disk and create partitions
+///
+/// # Arguments
+/// * `dasd` - dasd device, i.e. smth like /dev/dasda
+/// * `partitions` - configuration strings
+pub(crate) fn make_partitions(dasd: &str, partitions: &[String]) -> Result<()> {
+    if partitions.len() > 3 {
+        // fdasd silently ignores partitions after the first 3
+        bail!("Can't create {} partitions, maximum 3", partitions.len());
+    }
+    let mut config = partitions.join("\n");
+    config.push('\n');
+    if try_format(dasd, &config).is_err() {
+        default_format(dasd)?;
+        try_format(dasd, &config)?;
+    }
+    Ok(())
+}
+
+/// If config-based format fails, then we have to perform
+/// an auto-format on the whole disk
+///
+/// # Arguments
+/// * `dasd` - dasd device, i.e. smth like /dev/dasda
+pub(crate) fn default_format(dasd: &str) -> Result<()> {
+    eprintln!("Auto-partitioning {}", dasd);
+    runcmd!("fdasd", "-a", "-s", dasd).chain_err(|| format!("auto-formatting {} failed", dasd))?;
+    udev_settle()?;
+    Ok(())
+}
+
+/// Format disk using a config file
+///
+/// # Arguments
+/// * `dasd` - dasd device, i.e. smth like /dev/dasda
+/// * `config` - configuration file contents
+fn try_format(dasd: &str, config: &str) -> Result<()> {
+    eprintln!("Partitioning {}", dasd);
+    let mut child = Command::new("fdasd")
+        .arg("-s")
+        .arg("--config")
+        .arg("/dev/stdin")
+        .arg(dasd)
+        .stdin(Stdio::piped())
+        .spawn()
+        .chain_err(|| "failed to execute fdasd")?;
+    child
+        .stdin
+        .as_mut()
+        .chain_err(|| "couldn't open fdasd stdin")?
+        .write_all(config.as_bytes())
+        .chain_err(|| "couldn't write fdasd stdin")?;
+    if !child
+        .wait()
+        .chain_err(|| "couldn't wait on fdasd")?
+        .success()
+    {
+        bail!("couldn't format {} based on:\n{}", dasd, config);
+    }
+    udev_settle()?;
+    Ok(())
+}
+
+/// Get the number of sectors per track of a block device.
+fn get_sectors_per_track(file: &File) -> Result<NonZeroU32> {
+    let fd = file.as_raw_fd();
+    let mut geo: ioctl::hd_geometry = Default::default();
+    match unsafe { ioctl::hdio_getgeo(fd, &mut geo) } {
+        Ok(_) => {
+            NonZeroU32::new(geo.sectors.into()).ok_or_else(|| "found sectors/track of zero".into())
+        }
+        Err(e) => Err(Error::with_chain(e, "getting disk geometry")),
+    }
+}
+
+// create unsafe ioctl wrappers
+mod ioctl {
+    use nix::ioctl_read_bad;
+    use std::os::raw::{c_uchar, c_ulong, c_ushort};
+
+    #[repr(C)]
+    #[derive(Debug, Default)]
+    pub struct hd_geometry {
+        pub heads: c_uchar,
+        pub sectors: c_uchar,
+        pub cylinders: c_ushort,
+        pub start: c_ulong,
+    }
+
+    ioctl_read_bad!(hdio_getgeo, 0x0301, hd_geometry);
+}

--- a/src/s390x/fba.rs
+++ b/src/s390x/fba.rs
@@ -1,0 +1,62 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use mbrman::{MBRPartitionEntry, CHS, MBR};
+use std::convert::TryInto;
+use std::fs::File;
+
+use crate::blockdev::get_sector_size;
+use crate::errors::*;
+use crate::s390x::dasd::{partitions_from_gpt_header, Range};
+
+pub(crate) fn fba_make_partitions(
+    dasd: &str,
+    device: &mut File,
+    first_mb: &[u8],
+) -> Result<Vec<Range>> {
+    let bytes_per_block = get_sector_size(&device)?.get();
+    let partitions = partitions_from_gpt_header(bytes_per_block as u64, first_mb)?;
+    let mut ranges = Vec::new();
+    let mut mbr = MBR::new_from(device, bytes_per_block, rand::random())
+        .chain_err(|| format!("creating new partition table for {}", dasd))?;
+
+    for (idx, pt) in partitions.iter().enumerate() {
+        let blocks = pt.ending_lba - pt.starting_lba + 1;
+        let offset = pt.starting_lba * bytes_per_block as u64;
+        ranges.push(Range {
+            in_offset: offset,
+            out_offset: offset,
+            length: blocks * bytes_per_block as u64,
+        });
+        mbr[idx + 1] = MBRPartitionEntry {
+            boot: false,
+            first_chs: CHS::empty(),
+            sys: 0x83, // MBR_LINUX_DATA_PARTITION
+            last_chs: CHS::empty(),
+            starting_lba: pt.starting_lba.try_into().chain_err(|| {
+                format!(
+                    "malformed image: pt #{} starting lba is {}",
+                    idx + 1,
+                    pt.starting_lba
+                )
+            })?,
+            sectors: blocks
+                .try_into()
+                .chain_err(|| format!("malformed image: pt #{} blocks: {}", idx + 1, blocks))?,
+        };
+    }
+    mbr.write_into(device)
+        .chain_err(|| format!("writing partition table to {}", dasd))?;
+    Ok(ranges)
+}

--- a/src/s390x/mod.rs
+++ b/src/s390x/mod.rs
@@ -16,4 +16,6 @@ pub mod dasd;
 pub mod zipl;
 
 pub use dasd::{image_copy_s390x, prepare_dasd};
+pub use eckd::dasd_try_get_sector_size;
 pub use zipl::install_bootloader;
+mod eckd;

--- a/src/s390x/mod.rs
+++ b/src/s390x/mod.rs
@@ -15,7 +15,6 @@
 pub mod dasd;
 pub mod zipl;
 
-pub use dasd::{image_copy_s390x, prepare_dasd};
-pub use eckd::dasd_try_get_sector_size;
+pub use dasd::{dasd_try_get_sector_size, image_copy_s390x, prepare_dasd};
 pub use zipl::install_bootloader;
 mod eckd;

--- a/src/s390x/mod.rs
+++ b/src/s390x/mod.rs
@@ -18,3 +18,4 @@ pub mod zipl;
 pub use dasd::{dasd_try_get_sector_size, image_copy_s390x, prepare_dasd};
 pub use zipl::install_bootloader;
 mod eckd;
+mod fba;


### PR DESCRIPTION
There are 2 types of DASD devices:
- ECKD (Extended Count Key Data) - is regular DASD of type 3390
- FBA (Fixed Block Access) - is used for emulated device that represents a real SCSI device

Only ECKD-DASD disks require `dasdfmt, fdasd` linux tools to be configured.

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>