### PR TITLE
systemd: start coreos-installer service after systemd-resolved

### DIFF
--- a/systemd/coreos-installer.service
+++ b/systemd/coreos-installer.service
@@ -3,6 +3,7 @@ Description=CoreOS Installer
 Before=coreos-installer.target
 After=network-online.target
 Wants=network-online.target
+After=systemd-resolved.service
 ConditionKernelCommandLine=coreos.inst.install_dev
 OnFailure=emergency.target
 OnFailureJobMode=replace-irreversibly


### PR DESCRIPTION
If the system is configured to use systemd-resolved (i.e.
systemd-resolved is enabled) then start coreos-installer after
systemd-resolved. Otherwise we get race conditions where
coreos-installer starts before resolved is up and we get errors like:

```
         Starting Network Name Resolution...
[  OK  ] Finished Network Manager Wait Online.
[  OK  ] Reached target Network is Online.
         Starting CoreOS Installer...
[   12.949935] coreos-installer-service[889]: coreos-installer install /dev/sda --ignition-url https://dustymabe.fedorapeople.org/user-systemd.ign --insecure-ignition
[   13.007728] coreos-installer-service[907]: Error: parsing arguments
[   13.008549] coreos-installer-service[907]: Caused by: downloading source Ignition config https://dustymabe.fedorapeople.org/user-systemd.ign
[   13.009746] coreos-installer-service[907]: Caused by: sending request for 'https://dustymabe.fedorapeople.org/user-systemd.ign'                                                                                                           [   13.011136] coreos-installer-service[907]: Caused by: error sending request for url (https://dustymabe.fedorapeople.org/user-systemd.ign): error trying to connect: dns error: failed to lookup address information: Temporary failure in
name resolution                                                                                                                                                                                                                              [   13.013407] coreos-installer-service[907]: Caused by: error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
[   13.015006] coreos-installer-service[907]: Caused by: dns error: failed to lookup address information: Temporary failure in name resolution
[   13.016399] coreos-installer-service[907]: Caused by: failed to lookup address information: Temporary failure in name resolution
[FAILED] Failed to start CoreOS Installer.
```