### PR TITLE
systemd: add context to systemd-resolved unit order

### DIFF
--- a/systemd/coreos-installer.service
+++ b/systemd/coreos-installer.service
@@ -3,6 +3,9 @@ Description=CoreOS Installer
 Before=coreos-installer.target
 After=network-online.target
 Wants=network-online.target
+# Until we retry HTTP requests let's wait here until
+# systemd-resolved comes up if enabled.
+# https://github.com/coreos/coreos-installer/issues/283
 After=systemd-resolved.service
 ConditionKernelCommandLine=coreos.inst.install_dev
 OnFailure=emergency.target


### PR DESCRIPTION
Follow up to 139c2db. Add a comment to the open issue for retrying
HTTP requests in coreos-installer.