### PR TITLE
Release 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.7.2"
+version = "0.7.3-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.7.2-alpha.0"
+version = "0.7.2"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.7.2-alpha.0"
+version = "0.7.2"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.7.2"
+version = "0.7.3-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:
- Add Fedora 33 and 34 signing keys; drop Fedora 30 signing key

Minor changes:
- systemd: Start coreos-installer service after systemd-resolved

Packaging changes:
- Update container to Fedora 33

SHA-256 digests:  
- crate: ``
- vendor: ``