### PR TITLE
github: update the release instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -31,7 +31,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `RELEASE_VER=x.y.z`
   - [ ] `UPSTREAM_REMOTE=origin`
 
-:warning:: `UPSTREAM_REMOTE` should reference the locally configured remote that points to the upstream git repository.
+:warning:: `UPSTREAM_REMOTE` should reference the locally configured remote that points to the upstream git repository i.e. `git@github.com:coreos/coreos-installer.git`.
 
 - create release commits on a dedicated branch and tag it:
   - [ ] `git checkout -b release-${RELEASE_VER}`
@@ -56,7 +56,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `tar -czf target/coreos-installer-${RELEASE_VER}-vendor.tar.gz vendor`
 
 - publish this release on GitHub:
-  - [ ] open a web browser and [create a GitHub Release](https://github.com/coreos/coreos-installer/releases/new) for the tag above
+  - [ ] find the new tag in the [GitHub tag list](https://github.com/coreos/coreos-installer/tags) and click the triple dots menu, and create a release for it
   - [ ] write a short changelog (i.e. re-use the PR content)
   - [ ] upload `target/coreos-installer-${RELEASE_VER}-vendor.tar.gz`
   - [ ] record digests of local artifacts:


### PR DESCRIPTION
This will update the release instructions to clarify the step while publishing a release and the `UPSTREAM_REMOTE` keyword.