### PR TITLE
rdcore: add `kargs` subcommand

### DIFF
--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -26,8 +26,8 @@ pub enum Config {
 pub struct KargsConfig {
     pub boot_device: Option<String>,
     pub boot_mount: Option<String>,
-    pub append_kargs: Option<Vec<String>>,
-    pub delete_kargs: Option<Vec<String>>,
+    pub append_kargs: Vec<String>,
+    pub delete_kargs: Vec<String>,
 }
 
 pub struct RootMapConfig {
@@ -153,10 +153,12 @@ fn parse_kargs(matches: &ArgMatches) -> Result<Config> {
         boot_mount: matches.value_of("boot-mount").map(String::from),
         append_kargs: matches
             .values_of("append")
-            .map(|v| v.map(String::from).collect()),
+            .map(|v| v.map(String::from).collect())
+            .unwrap_or_else(Vec::new),
         delete_kargs: matches
             .values_of("delete")
-            .map(|v| v.map(String::from).collect()),
+            .map(|v| v.map(String::from).collect())
+            .unwrap_or_else(Vec::new),
     }))
 }
 

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -18,8 +18,16 @@ use error_chain::bail;
 use libcoreinst::errors::*;
 
 pub enum Config {
+    Kargs(KargsConfig),
     RootMap(RootMapConfig),
     StreamHash(StreamHashConfig),
+}
+
+pub struct KargsConfig {
+    pub boot_device: Option<String>,
+    pub boot_mount: Option<String>,
+    pub append_kargs: Option<Vec<String>>,
+    pub delete_kargs: Option<Vec<String>>,
 }
 
 pub struct RootMapConfig {
@@ -76,6 +84,45 @@ pub fn parse_args() -> Result<Config> {
                 ),
         )
         .subcommand(
+            SubCommand::with_name("kargs")
+                .about("Modify kargs in BLS configs")
+                // see comment block in rootmap command above
+                .arg(
+                    Arg::with_name("boot-device")
+                        .long("boot-device")
+                        .help("Boot device containing BLS entries to modify")
+                        .conflicts_with("boot-mount")
+                        .value_name("DEVPATH")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("boot-mount")
+                        .long("boot-mount")
+                        .help("Boot mount containing BLS entries to modify")
+                        .conflicts_with("boot-device")
+                        .value_name("BOOT_MOUNT")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("append")
+                        .long("append")
+                        .value_name("ARG")
+                        .help("Append kernel arg")
+                        .takes_value(true)
+                        .number_of_values(1)
+                        .multiple(true),
+                )
+                .arg(
+                    Arg::with_name("delete")
+                        .long("delete")
+                        .value_name("ARG")
+                        .help("Delete kernel arg")
+                        .takes_value(true)
+                        .number_of_values(1)
+                        .multiple(true),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("stream-hash")
                 .about("Copy data from stdin to stdout, checking piecewise hashes")
                 .arg(
@@ -89,10 +136,28 @@ pub fn parse_args() -> Result<Config> {
         .get_matches();
 
     match app_matches.subcommand() {
+        ("kargs", Some(matches)) => parse_kargs(&matches),
         ("rootmap", Some(matches)) => parse_rootmap(&matches),
         ("stream-hash", Some(matches)) => parse_stream_hash(&matches),
         _ => bail!("unrecognized subcommand"),
     }
+}
+
+fn parse_kargs(matches: &ArgMatches) -> Result<Config> {
+    // we could enforce these via clap's ArgGroup, but I don't like how the --help text looks
+    if !(matches.is_present("boot-device") || matches.is_present("boot-mount")) {
+        bail!("at least one of --boot-device or --boot-mount required");
+    }
+    Ok(Config::Kargs(KargsConfig {
+        boot_device: matches.value_of("boot-device").map(String::from),
+        boot_mount: matches.value_of("boot-mount").map(String::from),
+        append_kargs: matches
+            .values_of("append")
+            .map(|v| v.map(String::from).collect()),
+        delete_kargs: matches
+            .values_of("delete")
+            .map(|v| v.map(String::from).collect()),
+    }))
 }
 
 fn parse_rootmap(matches: &ArgMatches) -> Result<Config> {

--- a/src/bin/rdcore/kargs.rs
+++ b/src/bin/rdcore/kargs.rs
@@ -1,0 +1,43 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use libcoreinst::errors::*;
+use libcoreinst::install::*;
+
+use crate::cmdline::*;
+use crate::rootmap::get_boot_mount_from_cmdline_args;
+
+pub fn kargs(config: &KargsConfig) -> Result<()> {
+    // the unwrap() here is safe because we checked in cmdline that one of them must be provided
+    let mount = get_boot_mount_from_cmdline_args(&config.boot_mount, &config.boot_device)?.unwrap();
+    visit_bls_entry_options(mount.mountpoint(), |orig_options: &str| {
+        let new_options = bls_entry_delete_and_append_kargs(
+            orig_options,
+            config.delete_kargs.as_ref(),
+            config.append_kargs.as_ref(),
+        )?;
+
+        // we always print the final kargs
+        if let Some(ref options) = new_options {
+            println!("{}", options);
+        } else {
+            println!("{}", orig_options);
+        }
+
+        Ok(new_options)
+    })
+    .chain_err(|| "visiting BLS options")?;
+
+    Ok(())
+}

--- a/src/bin/rdcore/kargs.rs
+++ b/src/bin/rdcore/kargs.rs
@@ -24,8 +24,8 @@ pub fn kargs(config: &KargsConfig) -> Result<()> {
     visit_bls_entry_options(mount.mountpoint(), |orig_options: &str| {
         let new_options = bls_entry_delete_and_append_kargs(
             orig_options,
-            config.delete_kargs.as_ref(),
-            config.append_kargs.as_ref(),
+            config.delete_kargs.as_slice(),
+            config.append_kargs.as_slice(),
         )?;
 
         // we always print the final kargs

--- a/src/bin/rdcore/kargs.rs
+++ b/src/bin/rdcore/kargs.rs
@@ -22,7 +22,7 @@ pub fn kargs(config: &KargsConfig) -> Result<()> {
     // the unwrap() here is safe because we checked in cmdline that one of them must be provided
     let mount = get_boot_mount_from_cmdline_args(&config.boot_mount, &config.boot_device)?.unwrap();
     visit_bls_entry_options(mount.mountpoint(), |orig_options: &str| {
-        let new_options = bls_entry_delete_and_append_kargs(
+        let new_options = bls_entry_options_delete_and_append_kargs(
             orig_options,
             config.delete_kargs.as_slice(),
             config.append_kargs.as_slice(),

--- a/src/bin/rdcore/main.rs
+++ b/src/bin/rdcore/main.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod cmdline;
+mod kargs;
 mod rootmap;
 mod stream_hash;
 
@@ -29,6 +30,7 @@ fn run() -> Result<()> {
     let config = cmdline::parse_args().chain_err(|| "parsing arguments")?;
 
     match config {
+        Config::Kargs(c) => kargs::kargs(&c),
         Config::RootMap(c) => rootmap::rootmap(&c),
         Config::StreamHash(c) => stream_hash::stream_hash(&c),
     }

--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -72,7 +72,7 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
     };
 
     if let Some(boot_mount) = boot_mount {
-        edit_bls_entries(boot_mount.mountpoint(), |orig_contents: &str| {
+        edit_bls_entry(boot_mount.mountpoint(), |orig_contents: &str| {
             bls_entry_delete_and_append_kargs(orig_contents, None, Some(&kargs))
         })
         .chain_err(|| "appending rootmap kargs")?;

--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -62,7 +62,7 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
     let boot_mount = get_boot_mount_from_cmdline_args(&config.boot_mount, &config.boot_device)?;
     if let Some(mount) = boot_mount {
         visit_bls_entry_options(mount.mountpoint(), |orig_options: &str| {
-            bls_entry_delete_and_append_kargs(orig_options, None, Some(&kargs))
+            bls_entry_delete_and_append_kargs(orig_options, &[], &kargs)
         })
         .chain_err(|| "appending rootmap kargs")?;
         eprintln!("Injected kernel arguments into BLS: {}", kargs.join(" "));

--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -74,7 +74,8 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
     Ok(())
 }
 
-fn get_boot_mount_from_cmdline_args(
+// This is shared with the kargs code -- might move this to a helper file eventually
+pub fn get_boot_mount_from_cmdline_args(
     boot_mount: &Option<String>,
     boot_device: &Option<String>,
 ) -> Result<Option<Mount>> {

--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -72,7 +72,7 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
     };
 
     if let Some(boot_mount) = boot_mount {
-        edit_bls_entry(boot_mount.mountpoint(), |orig_contents: &str| {
+        visit_bls_entry(boot_mount.mountpoint(), |orig_contents: &str| {
             bls_entry_delete_and_append_kargs(orig_contents, None, Some(&kargs))
         })
         .chain_err(|| "appending rootmap kargs")?;

--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -59,20 +59,9 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
         kargs.push(format!("rootflags={}", rootflags));
     }
 
-    let boot_mount = if let Some(path) = &config.boot_mount {
-        Some(Mount::from_existing(path)?)
-    } else if let Some(devpath) = &config.boot_device {
-        let devinfo = lsblk_single(Path::new(devpath))?;
-        let fs = devinfo
-            .get("FSTYPE")
-            .chain_err(|| format!("failed to query filesystem for {}", devpath))?;
-        Some(Mount::try_mount(devpath, fs, mount::MsFlags::empty())?)
-    } else {
-        None
-    };
-
-    if let Some(boot_mount) = boot_mount {
-        visit_bls_entry_options(boot_mount.mountpoint(), |orig_options: &str| {
+    let boot_mount = get_boot_mount_from_cmdline_args(&config.boot_mount, &config.boot_device)?;
+    if let Some(mount) = boot_mount {
+        visit_bls_entry_options(mount.mountpoint(), |orig_options: &str| {
             bls_entry_delete_and_append_kargs(orig_options, None, Some(&kargs))
         })
         .chain_err(|| "appending rootmap kargs")?;
@@ -83,6 +72,27 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn get_boot_mount_from_cmdline_args(
+    boot_mount: &Option<String>,
+    boot_device: &Option<String>,
+) -> Result<Option<Mount>> {
+    if let Some(path) = boot_mount {
+        Ok(Some(Mount::from_existing(path)?))
+    } else if let Some(devpath) = boot_device {
+        let devinfo = lsblk_single(Path::new(devpath))?;
+        let fs = devinfo
+            .get("FSTYPE")
+            .chain_err(|| format!("failed to query filesystem for {}", devpath))?;
+        Ok(Some(Mount::try_mount(
+            devpath,
+            fs,
+            mount::MsFlags::empty(),
+        )?))
+    } else {
+        Ok(None)
+    }
 }
 
 fn device_to_kargs(root: &Mount, device: PathBuf) -> Result<Option<Vec<String>>> {

--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -62,7 +62,7 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
     let boot_mount = get_boot_mount_from_cmdline_args(&config.boot_mount, &config.boot_device)?;
     if let Some(mount) = boot_mount {
         visit_bls_entry_options(mount.mountpoint(), |orig_options: &str| {
-            bls_entry_delete_and_append_kargs(orig_options, &[], &kargs)
+            bls_entry_options_delete_and_append_kargs(orig_options, &[], &kargs)
         })
         .chain_err(|| "appending rootmap kargs")?;
         eprintln!("Injected kernel arguments into BLS: {}", kargs.join(" "));

--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -72,8 +72,8 @@ pub fn rootmap(config: &RootMapConfig) -> Result<()> {
     };
 
     if let Some(boot_mount) = boot_mount {
-        visit_bls_entry(boot_mount.mountpoint(), |orig_contents: &str| {
-            bls_entry_delete_and_append_kargs(orig_contents, None, Some(&kargs))
+        visit_bls_entry_options(boot_mount.mountpoint(), |orig_options: &str| {
+            bls_entry_delete_and_append_kargs(orig_options, None, Some(&kargs))
         })
         .chain_err(|| "appending rootmap kargs")?;
         eprintln!("Injected kernel arguments into BLS: {}", kargs.join(" "));

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -49,8 +49,8 @@ pub struct InstallConfig {
     pub ignition_hash: Option<IgnitionHash>,
     pub platform: Option<String>,
     pub firstboot_kargs: Option<String>,
-    pub append_kargs: Option<Vec<String>>,
-    pub delete_kargs: Option<Vec<String>>,
+    pub append_kargs: Vec<String>,
+    pub delete_kargs: Vec<String>,
     pub insecure: bool,
     pub preserve_on_error: bool,
     pub network_config: Option<String>,
@@ -843,10 +843,12 @@ fn parse_install(matches: &ArgMatches) -> Result<Config> {
         firstboot_kargs: matches.value_of("firstboot-kargs").map(String::from),
         append_kargs: matches
             .values_of("append-karg")
-            .map(|v| v.map(String::from).collect()),
+            .map(|v| v.map(String::from).collect())
+            .unwrap_or_else(Vec::new),
         delete_kargs: matches
             .values_of("delete-karg")
-            .map(|v| v.map(String::from).collect()),
+            .map(|v| v.map(String::from).collect())
+            .unwrap_or_else(Vec::new),
         insecure: matches.is_present("insecure"),
         preserve_on_error: matches.is_present("preserve-on-error"),
         network_config,

--- a/src/install.rs
+++ b/src/install.rs
@@ -286,7 +286,8 @@ fn write_firstboot_kargs(mountpoint: &Path, args: &str) -> Result<()> {
     Ok(())
 }
 
-// This is split out so that we can unit test it.
+/// To be used with `edit_bls_entries()`. Modifies the BLS config as instructed by `delete_args`
+/// and `append_args`.
 pub fn bls_entry_delete_and_append_kargs(
     orig_contents: &str,
     delete_args: Option<&Vec<String>>,
@@ -352,9 +353,10 @@ fn write_platform(mountpoint: &Path, platform: &str) -> Result<()> {
     Ok(())
 }
 
-/// Modifies the BLS config, only changing the `ignition.platform.id`. This assumes that we will
-/// only install from metal images and that the bootloader configs will always set
-/// ignition.platform.id.  Fail if those assumptions change.  This is deliberately simplistic.
+/// To be used with `edit_bls_entries()`. Modifies the BLS config, only changing the
+/// `ignition.platform.id`. This assumes that we will only install from metal images and that the
+/// bootloader configs will always set ignition.platform.id.  Fail if those assumptions change.
+/// This is deliberately simplistic.
 fn bls_entry_write_platform(orig_contents: &str, platform: &str) -> Result<String> {
     let new_contents = orig_contents.replace(
         "ignition.platform.id=metal",

--- a/src/install.rs
+++ b/src/install.rs
@@ -293,6 +293,12 @@ pub fn bls_entry_delete_and_append_kargs(
     delete_args: Option<&Vec<String>>,
     append_args: Option<&Vec<String>>,
 ) -> Result<Option<String>> {
+    if (delete_args.is_none() || delete_args.unwrap().is_empty())
+        && (append_args.is_none() || append_args.unwrap().is_empty())
+    {
+        return Ok(None);
+    }
+
     // XXX: Need a proper parser here and share it with afterburn. The approach we use here
     // is to just do a dumb substring search and replace. This is naive (e.g. doesn't
     // handle occurrences in quoted args) but will work for now (one thing that saves us is

--- a/src/install.rs
+++ b/src/install.rs
@@ -379,35 +379,37 @@ pub fn edit_bls_entries(mountpoint: &Path, f: impl Fn(&str) -> Result<String>) -
         let path = entry
             .chain_err(|| format!("reading directory {}", config_path.display()))?
             .path();
-        if path.extension().unwrap_or_default() == "conf" {
-            // slurp in the file
-            let mut config = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(&path)
-                .chain_err(|| format!("opening bootloader config {}", path.display()))?;
-            let orig_contents = {
-                let mut s = String::new();
-                config
-                    .read_to_string(&mut s)
-                    .chain_err(|| format!("reading {}", path.display()))?;
-                s
-            };
-
-            let new_contents =
-                f(&orig_contents).chain_err(|| format!("modifying {}", path.display()))?;
-
-            // write out the modified data
-            config
-                .seek(SeekFrom::Start(0))
-                .chain_err(|| format!("seeking {}", path.display()))?;
-            config
-                .set_len(0)
-                .chain_err(|| format!("truncating {}", path.display()))?;
-            config
-                .write(new_contents.as_bytes())
-                .chain_err(|| format!("writing {}", path.display()))?;
+        if path.extension().unwrap_or_default() != "conf" {
+            continue;
         }
+
+        // slurp in the file
+        let mut config = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .chain_err(|| format!("opening bootloader config {}", path.display()))?;
+        let orig_contents = {
+            let mut s = String::new();
+            config
+                .read_to_string(&mut s)
+                .chain_err(|| format!("reading {}", path.display()))?;
+            s
+        };
+
+        let new_contents =
+            f(&orig_contents).chain_err(|| format!("modifying {}", path.display()))?;
+
+        // write out the modified data
+        config
+            .seek(SeekFrom::Start(0))
+            .chain_err(|| format!("seeking {}", path.display()))?;
+        config
+            .set_len(0)
+            .chain_err(|| format!("truncating {}", path.display()))?;
+        config
+            .write(new_contents.as_bytes())
+            .chain_err(|| format!("writing {}", path.display()))?;
     }
 
     Ok(())


### PR DESCRIPTION
We already have the code for modifying kargs in BLS configs. This
command just exposes it.

It's useful generally, but the motivation right now is for the root
filesystem migration script in RHCOS 4.7 which will use this once moved
to the initramfs for openshift/os#448.