### PR TITLE
s390x: use recommended blocksize of 4096 bytes for unformatted ECKD DASD disks

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -943,6 +943,13 @@ pub fn detect_formatted_sector_size(buf: &[u8]) -> Option<NonZeroU32> {
     }
 }
 
+/// Checks if underlying device is IBM DASD disk
+pub fn is_dasd(device: &str) -> Result<bool> {
+    let target =
+        canonicalize(device).chain_err(|| format!("getting absolute path to {}", device))?;
+    Ok(target.to_string_lossy().starts_with("/dev/dasd"))
+}
+
 // create unsafe ioctl wrappers
 #[allow(clippy::missing_safety_doc)]
 mod ioctl {


### PR DESCRIPTION
This a  fix for:
https://bugzilla.redhat.com/show_bug.cgi?id=1905159

Unformatted (low-level) ECKD DASD's sector size is 512 bytes by default:
```
$ fdasd -p /dev/dasdb
fdasd error:  Unsupported disk format
$ ioctl_sector_size
/dev/dasdb: 512
```
So `coreos-installer` chooses 512 bytes-sector `osmet` image.

After formatting (`dasdfmt`) we end up with 4096 bytes sector size, and therefore `coreos-installer` cannot install previously selected `osmet` image