### PR TITLE
Release 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.7.3-alpha.0"
+version = "0.8.0-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",
@@ -186,11 +186,11 @@ dependencies = [
  "libc",
  "maplit",
  "mbrman",
- "nix 0.19.1",
+ "nix",
  "openat-ext",
  "openssl",
  "pipe",
- "rand 0.8.1",
+ "rand",
  "regex",
  "reqwest",
  "serde",
@@ -429,7 +429,7 @@ dependencies = [
  "bincode",
  "crc",
  "err-derive",
- "nix 0.18.0",
+ "nix",
  "serde",
 ]
 
@@ -710,18 +710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,9 +745,9 @@ checksum = "3dc1b204f9003fc6974231d2ed60e44206821e63c2cac1c8eccff0d2426e50f9"
 dependencies = [
  "drop_bomb",
  "libc",
- "nix 0.18.0",
+ "nix",
  "openat",
- "rand 0.7.3",
+ "rand",
 ]
 
 [[package]]
@@ -938,21 +926,9 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.14",
  "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
-dependencies = [
- "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.0",
- "rand_hc 0.3.0",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -962,17 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -985,30 +951,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b34ba8cfb21243bd8df91854c830ff0d785fff2e82ebd4434c2644cb9ada18"
-dependencies = [
- "getrandom 0.2.0",
-]
-
-[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core 0.6.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -1277,7 +1225,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand 0.7.3",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.8.0"
+version = "0.8.1-alpha.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "coreos-installer"
-version = "0.8.0-alpha.0"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.8.0-alpha.0"
+version = "0.8.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.8.0"
+version = "0.8.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.7.3-alpha.0"
+version = "0.8.0-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- Add `iso kargs` subcommand for modifying kernel arguments in live ISO images
- Support IBM Z FBA DASD target devices

Minor changes:

- Fix race condition causing `fdasd` failure when formatting ECKD DASD
- Fix sector size selection on unformatted ECKD DASD

Internal changes:

- rdcore: Add `kargs` subcommand for modifying BLS configurations

Packaging changes:

- Add `lazy_static` dependency
- Add `mbrman` and `rand` dependencies on s390x
- Require `regex` &ge; 1.4