### PR TITLE
blockdev: use --nodeps when querying single device

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -764,15 +764,14 @@ pub fn lsblk_single(dev: &Path) -> Result<HashMap<String, String>> {
 }
 
 pub fn lsblk(dev: &Path) -> Result<Vec<HashMap<String, String>>> {
+    let mut cmd = Command::new("lsblk");
     // Older lsblk, e.g. in CentOS 7.6, doesn't support PATH, but --paths option
-    let output = runcmd_output!(
-        "lsblk",
-        "--pairs",
-        "--paths",
-        "--output",
-        "NAME,LABEL,FSTYPE,TYPE,MOUNTPOINT,UUID",
-        dev
-    )?;
+    cmd.arg("--pairs")
+        .arg("--paths")
+        .arg("--output")
+        .arg("NAME,LABEL,FSTYPE,TYPE,MOUNTPOINT,UUID")
+        .arg(dev);
+    let output = cmd_output(&mut cmd)?;
     let mut result: Vec<HashMap<String, String>> = Vec::new();
     for line in output.lines() {
         // parse key-value pairs


### PR DESCRIPTION
`lsblk` by default outputs the target device followed by all its reverse
dependencies. But interestingly, when using `--pairs`, the `lsblk` in
RHCOS seems to output the reverse dependency first before the target
device.

We were relying on correct ordering in `lsblk_single`, where all we care
about is the target device. Instead, explicitly use `--nodeps` in that
case so that `lsblk` knows to only print the target device. (The
`lsblk()` helper actually used to support that, but it was removed in
88de4fc.)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1916502
