### PR TITLE
osmet: drop support for --real-rootdev

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -280,7 +280,7 @@ pub fn parse_args() -> Result<Config> {
                         .number_of_values(1)
                         .multiple(true)
                         // allow "a,b" in one argument
-                        .require_delimiter(true)
+                        .require_delimiter(true),
                 )
                 .arg(
                     Arg::with_name("save-partindex")
@@ -294,7 +294,7 @@ pub fn parse_args() -> Result<Config> {
                         // allow "1-5,7" in one argument
                         .require_delimiter(true)
                         // allow ranges like "-2"
-                        .allow_hyphen_values(true)
+                        .allow_hyphen_values(true),
                 )
                 // obscure options without short names
                 .arg(
@@ -503,168 +503,170 @@ pub fn parse_args() -> Result<Config> {
                                 .takes_value(true),
                         ),
                 )
-            .subcommand(
-                SubCommand::with_name("ignition")
-                    .about("Embed an Ignition config in a CoreOS live ISO image")
-                    .subcommand(
-                        SubCommand::with_name("embed")
-                            .about("Embed an Ignition config in an ISO image")
-                            .arg(
-                                Arg::with_name("force")
-                                    .short("f")
-                                    .long("force")
-                                    .help("Overwrite an existing Ignition config"),
-                            )
-                            .arg(
-                                Arg::with_name("config")
-                                    .short("i")
-                                    .long("ignition-file")
-                                    .value_name("path")
-                                    .help("Ignition config to embed [default: stdin]")
-                                    .takes_value(true),
-                            )
-                            .arg(
-                                Arg::with_name("output")
-                                    .short("o")
-                                    .long("output")
-                                    .value_name("path")
-                                    .help("Write ISO to a new output file")
-                                    .takes_value(true),
-                            )
-                            .arg(
-                                Arg::with_name("input")
-                                    .value_name("ISO")
-                                    .help("ISO image")
-                                    .required(true)
-                                    .takes_value(true),
-                            ),
-                    )
-                    .subcommand(
-                        SubCommand::with_name("show")
-                            .about("Show the embedded Ignition config from an ISO image")
-                            .arg(
-                                Arg::with_name("input")
-                                    .value_name("ISO")
-                                    .help("ISO image")
-                                    .required(true)
-                                    .takes_value(true),
-                            ),
-                    )
-                    .subcommand(
-                        SubCommand::with_name("remove")
-                            .about("Remove an existing embedded Ignition config from an ISO image")
-                            .arg(
-                                Arg::with_name("output")
-                                    .short("o")
-                                    .long("output")
-                                    .value_name("path")
-                                    .help("Write ISO to a new output file")
-                                    .takes_value(true),
-                            )
-                            .arg(
-                                Arg::with_name("input")
-                                    .value_name("ISO")
-                                    .help("ISO image")
-                                    .required(true)
-                                    .takes_value(true),
-                            ),
-                    ),
-            )
-            .subcommand(
-                SubCommand::with_name("kargs")
-                    .about("Modify kernel args in a CoreOS live ISO image")
-                    .subcommand(
-                        SubCommand::with_name("modify")
-                            .about("Modify kernel args in an ISO image")
-                            .arg(
-                                Arg::with_name("append")
-                                    .long("append")
-                                    .short("a")
-                                    .value_name("KARG")
-                                    .help("Kernel argument to append")
-                                    .takes_value(true)
-                                    .number_of_values(1)
-                                    .multiple(true),
-                            )
-                            .arg(
-                                Arg::with_name("delete")
-                                    .long("delete")
-                                    .short("d")
-                                    .value_name("KARG")
-                                    .help("Kernel argument to delete")
-                                    .takes_value(true)
-                                    .number_of_values(1)
-                                    .multiple(true),
-                            )
-                            .arg(
-                                Arg::with_name("replace")
-                                    .long("replace")
-                                    .short("r")
-                                    .value_name("KARG=OLDVAL=NEWVAL")
-                                    .help("Kernel argument to replace")
-                                    .takes_value(true)
-                                    .number_of_values(1)
-                                    .multiple(true),
-                            )
-                            .arg(
-                                Arg::with_name("output")
-                                    .short("o")
-                                    .long("output")
-                                    .value_name("PATH")
-                                    .help("Write ISO to a new output file")
-                                    .takes_value(true),
-                            )
-                            .arg(
-                                Arg::with_name("input")
-                                    .value_name("ISO")
-                                    .help("ISO image")
-                                    .required(true)
-                                    .takes_value(true),
-                            ),
-                    )
-                    .subcommand(
-                        SubCommand::with_name("reset")
-                            .about("Reset kernel args in an ISO image to defaults")
-                            .arg(
-                                Arg::with_name("output")
-                                    .short("o")
-                                    .long("output")
-                                    .value_name("PATH")
-                                    .help("Write ISO to a new output file")
-                                    .takes_value(true),
-                            )
-                            .arg(
-                                Arg::with_name("input")
-                                    .value_name("ISO")
-                                    .help("ISO image")
-                                    .required(true)
-                                    .takes_value(true),
-                            ),
-                    )
-                    .subcommand(
-                        SubCommand::with_name("show")
-                            .about("Show kernel args from an ISO image")
-                            .arg(
-                                Arg::with_name("input")
-                                    .value_name("ISO")
-                                    .help("ISO image")
-                                    .required(true)
-                                    .takes_value(true),
-                            )
-                            .arg(
-                                Arg::with_name("default")
-                                    .short("d")
-                                    .long("default")
-                                    .help("Show default kernel args"),
-                            )
-                            .arg(
-                                Arg::with_name("header")
-                                    .long("header")
-                                    .help("Show ISO header (for debugging/testing only)")
-                                    .hidden(true),
-                            ),
-                    ),
-            ),
+                .subcommand(
+                    SubCommand::with_name("ignition")
+                        .about("Embed an Ignition config in a CoreOS live ISO image")
+                        .subcommand(
+                            SubCommand::with_name("embed")
+                                .about("Embed an Ignition config in an ISO image")
+                                .arg(
+                                    Arg::with_name("force")
+                                        .short("f")
+                                        .long("force")
+                                        .help("Overwrite an existing Ignition config"),
+                                )
+                                .arg(
+                                    Arg::with_name("config")
+                                        .short("i")
+                                        .long("ignition-file")
+                                        .value_name("path")
+                                        .help("Ignition config to embed [default: stdin]")
+                                        .takes_value(true),
+                                )
+                                .arg(
+                                    Arg::with_name("output")
+                                        .short("o")
+                                        .long("output")
+                                        .value_name("path")
+                                        .help("Write ISO to a new output file")
+                                        .takes_value(true),
+                                )
+                                .arg(
+                                    Arg::with_name("input")
+                                        .value_name("ISO")
+                                        .help("ISO image")
+                                        .required(true)
+                                        .takes_value(true),
+                                ),
+                        )
+                        .subcommand(
+                            SubCommand::with_name("show")
+                                .about("Show the embedded Ignition config from an ISO image")
+                                .arg(
+                                    Arg::with_name("input")
+                                        .value_name("ISO")
+                                        .help("ISO image")
+                                        .required(true)
+                                        .takes_value(true),
+                                ),
+                        )
+                        .subcommand(
+                            SubCommand::with_name("remove")
+                                .about(
+                                    "Remove an existing embedded Ignition config from an ISO image",
+                                )
+                                .arg(
+                                    Arg::with_name("output")
+                                        .short("o")
+                                        .long("output")
+                                        .value_name("path")
+                                        .help("Write ISO to a new output file")
+                                        .takes_value(true),
+                                )
+                                .arg(
+                                    Arg::with_name("input")
+                                        .value_name("ISO")
+                                        .help("ISO image")
+                                        .required(true)
+                                        .takes_value(true),
+                                ),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("kargs")
+                        .about("Modify kernel args in a CoreOS live ISO image")
+                        .subcommand(
+                            SubCommand::with_name("modify")
+                                .about("Modify kernel args in an ISO image")
+                                .arg(
+                                    Arg::with_name("append")
+                                        .long("append")
+                                        .short("a")
+                                        .value_name("KARG")
+                                        .help("Kernel argument to append")
+                                        .takes_value(true)
+                                        .number_of_values(1)
+                                        .multiple(true),
+                                )
+                                .arg(
+                                    Arg::with_name("delete")
+                                        .long("delete")
+                                        .short("d")
+                                        .value_name("KARG")
+                                        .help("Kernel argument to delete")
+                                        .takes_value(true)
+                                        .number_of_values(1)
+                                        .multiple(true),
+                                )
+                                .arg(
+                                    Arg::with_name("replace")
+                                        .long("replace")
+                                        .short("r")
+                                        .value_name("KARG=OLDVAL=NEWVAL")
+                                        .help("Kernel argument to replace")
+                                        .takes_value(true)
+                                        .number_of_values(1)
+                                        .multiple(true),
+                                )
+                                .arg(
+                                    Arg::with_name("output")
+                                        .short("o")
+                                        .long("output")
+                                        .value_name("PATH")
+                                        .help("Write ISO to a new output file")
+                                        .takes_value(true),
+                                )
+                                .arg(
+                                    Arg::with_name("input")
+                                        .value_name("ISO")
+                                        .help("ISO image")
+                                        .required(true)
+                                        .takes_value(true),
+                                ),
+                        )
+                        .subcommand(
+                            SubCommand::with_name("reset")
+                                .about("Reset kernel args in an ISO image to defaults")
+                                .arg(
+                                    Arg::with_name("output")
+                                        .short("o")
+                                        .long("output")
+                                        .value_name("PATH")
+                                        .help("Write ISO to a new output file")
+                                        .takes_value(true),
+                                )
+                                .arg(
+                                    Arg::with_name("input")
+                                        .value_name("ISO")
+                                        .help("ISO image")
+                                        .required(true)
+                                        .takes_value(true),
+                                ),
+                        )
+                        .subcommand(
+                            SubCommand::with_name("show")
+                                .about("Show kernel args from an ISO image")
+                                .arg(
+                                    Arg::with_name("input")
+                                        .value_name("ISO")
+                                        .help("ISO image")
+                                        .required(true)
+                                        .takes_value(true),
+                                )
+                                .arg(
+                                    Arg::with_name("default")
+                                        .short("d")
+                                        .long("default")
+                                        .help("Show default kernel args"),
+                                )
+                                .arg(
+                                    Arg::with_name("header")
+                                        .long("header")
+                                        .help("Show ISO header (for debugging/testing only)")
+                                        .hidden(true),
+                                ),
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("pxe")
@@ -674,36 +676,36 @@ pub fn parse_args() -> Result<Config> {
                         .about("Commands to manage a live PXE Ignition config")
                         .subcommand(
                             SubCommand::with_name("wrap")
-                            .about("Wrap an Ignition config in an initrd image")
-                            .arg(
-                                Arg::with_name("ignition")
-                                    .short("i")
-                                    .long("ignition-file")
-                                    .value_name("path")
-                                    .help("Ignition config to wrap [default: stdin]")
-                                    .takes_value(true),
-                            )
-                            .arg(
-                                Arg::with_name("output")
-                                    .short("o")
-                                    .long("output")
-                                    .value_name("path")
-                                    .help("Write to a file instead of stdout")
-                                    .takes_value(true),
-                            )
-                    )
-                    .subcommand(
-                        SubCommand::with_name("unwrap")
-                            .about("Show the wrapped Ignition config in an initrd image")
-                            .arg(
-                                Arg::with_name("input")
-                                    .value_name("initrd")
-                                    .help("initrd image")
-                                    .required(true)
-                                    .takes_value(true),
-                            ),
-                    )
-            )
+                                .about("Wrap an Ignition config in an initrd image")
+                                .arg(
+                                    Arg::with_name("ignition")
+                                        .short("i")
+                                        .long("ignition-file")
+                                        .value_name("path")
+                                        .help("Ignition config to wrap [default: stdin]")
+                                        .takes_value(true),
+                                )
+                                .arg(
+                                    Arg::with_name("output")
+                                        .short("o")
+                                        .long("output")
+                                        .value_name("path")
+                                        .help("Write to a file instead of stdout")
+                                        .takes_value(true),
+                                ),
+                        )
+                        .subcommand(
+                            SubCommand::with_name("unwrap")
+                                .about("Show the wrapped Ignition config in an initrd image")
+                                .arg(
+                                    Arg::with_name("input")
+                                        .value_name("initrd")
+                                        .help("initrd image")
+                                        .required(true)
+                                        .takes_value(true),
+                                ),
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("osmet")
@@ -743,7 +745,7 @@ pub fn parse_args() -> Result<Config> {
                         .arg(
                             Arg::with_name("fast")
                                 .long("fast")
-                                .help("Use worse compression, for development builds")
+                                .help("Use worse compression, for development builds"),
                         )
                         // positional args
                         .arg(

--- a/src/osmet/mod.rs
+++ b/src/osmet/mod.rs
@@ -94,8 +94,7 @@ pub fn osmet_pack(config: &OsmetPackConfig) -> Result<()> {
 
     // generate the primary OSTree object <--> disk block mappings, and also try to match up boot
     // files with OSTree objects
-    let (root_partition, mapped_boot_files) =
-        scan_root_partition(&root, config.rootdev.as_ref(), boot_files)?;
+    let (root_partition, mapped_boot_files) = scan_root_partition(&root, boot_files)?;
 
     let boot_partition = scan_boot_partition(&boot, mapped_boot_files)?;
 
@@ -193,22 +192,10 @@ pub fn find_matching_osmet_in_dir(
 
 fn scan_root_partition(
     root: &Mount,
-    real_dev: Option<&OsmetRootBlkDevReal>,
     mut boot_files: HashMap<u64, PathBuf>,
 ) -> Result<(OsmetPartition, HashMap<PathBuf, Sha256Digest>)> {
     // query the trivial stuff first
-    let ((start_offset, end_offset), offset) = if let Some(real_dev) = real_dev {
-        let (start_offset, end_offset) = Partition::get_offsets(&real_dev.underlying_device)?;
-        let offset = real_dev.offset_sectors.checked_mul(512).chain_err(|| {
-            format!(
-                "Overflow calculating bytes for offset {} (sectors)",
-                real_dev.offset_sectors
-            )
-        })?;
-        ((start_offset, end_offset), Some(offset))
-    } else {
-        (root.get_partition_offsets()?, None)
-    };
+    let (start_offset, end_offset) = root.get_partition_offsets()?;
 
     // we only hash boot files if there's a potential match with an OSTree object, so we keep a
     // cache to avoid recomputing it multiple times
@@ -242,13 +229,7 @@ fn scan_root_partition(
         let object = object_path_to_checksum(entry.path())
             .chain_err(|| format!("invalid object path {:?}", entry.path()))?;
 
-        for mut extent in extents {
-            if let Some(offset) = offset {
-                extent.physical = extent.physical.checked_add(offset.into()).chain_err(|| {
-                    format!("Overflow for extent {:?} with offset {}", extent, offset)
-                })?;
-            }
-
+        for extent in extents {
             mappings.push(Mapping {
                 extent,
                 object: object.clone(),


### PR DESCRIPTION
This is no longer required now that RHCOS has moved to
LUKS-via-Ignition, so we can simplify things.

Goes together with https://github.com/coreos/coreos-assembler/pull/2025.