### PR TITLE
*: fix clippy::unnecessary_wraps lint on 1.50; use newer clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Minimum and linting toolchain
-  ACTIONS_PINNED_TOOLCHAIN: 1.44.1
+  # Minimum supported Rust version (MSRV)
+  ACTIONS_MSRV_TOOLCHAIN: 1.44.1
+  # Pinned toolchain for linting
+  ACTIONS_LINTS_TOOLCHAIN: 1.50.0
 
 jobs:
   tests-stable:
@@ -31,6 +33,25 @@ jobs:
         run: cargo build --features rdcore
       - name: cargo test (rdcore)
         run: cargo test --features rdcore
+  tests-msrv:
+    name: "Tests, minimum supported toolchain"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env['ACTIONS_MSRV_TOOLCHAIN']  }}
+          default: true
+      - name: cargo build
+        run: cargo build
+      - name: cargo test
+        run: cargo test
+      - name: cargo build (rdcore)
+        run: cargo build --features rdcore
+      - name: cargo test (rdcore)
+        run: cargo test --features rdcore
   lints:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest
@@ -40,7 +61,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTIONS_PINNED_TOOLCHAIN']  }}
+          toolchain: ${{ env['ACTIONS_LINTS_TOOLCHAIN']  }}
           default: true
           components: rustfmt, clippy
       - name: cargo fmt (check)

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// For consistency, have all parse_*() functions return Result.
+#![allow(clippy::unnecessary_wraps)]
+
 use anyhow::{bail, Result};
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// For consistency, have all parse_*() functions return Result.
+#![allow(clippy::unnecessary_wraps)]
+
 use anyhow::{bail, Context, Result};
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
 use reqwest::Url;

--- a/src/download.rs
+++ b/src/download.rs
@@ -195,7 +195,7 @@ where
         &mut verify_reader,
         source.length_hint,
         &source.artifact_type,
-    )?;
+    );
 
     // Wrap in a BufReader so DecompressReader can peek at the first few
     // bytes for format sniffing, and to amortize read overhead.  Don't
@@ -368,7 +368,7 @@ struct ProgressReader<'a, R: Read> {
 }
 
 impl<'a, R: Read> ProgressReader<'a, R> {
-    fn new(source: R, length: Option<u64>, artifact_type: &'a str) -> Result<Self> {
+    fn new(source: R, length: Option<u64>, artifact_type: &'a str) -> Self {
         let tty = isatty(stderr().as_raw_fd()).unwrap_or_else(|e| {
             eprintln!("checking if stderr is a TTY: {}", e);
             false
@@ -376,7 +376,7 @@ impl<'a, R: Read> ProgressReader<'a, R> {
         // disable percentage reporting for zero-length files to avoid
         // division by zero
         let length = length.map(NonZeroU64::new).flatten();
-        Ok(ProgressReader {
+        ProgressReader {
             source,
             length: length.map(|l| (l, Self::format_bytes(l.get()))),
             artifact_type,
@@ -396,7 +396,7 @@ impl<'a, R: Read> ProgressReader<'a, R> {
             // lines.
             prologue: if tty { "> " } else { "" },
             epilogue: if tty { "   \r" } else { "\n" },
-        })
+        }
     }
 
     /// Format a size in bytes.

--- a/src/osmet/unpacker.rs
+++ b/src/osmet/unpacker.rs
@@ -38,19 +38,19 @@ pub struct OsmetUnpacker {
 impl OsmetUnpacker {
     pub fn new(osmet: &Path, repo: &Path) -> Result<Self> {
         let (_, osmet, xzpacked_image) = osmet_file_read(&osmet)?;
-        Self::new_impl(osmet, xzpacked_image, repo)
+        Ok(Self::new_impl(osmet, xzpacked_image, repo))
     }
 
     pub fn new_from_sysroot(osmet: &Path) -> Result<Self> {
         let (_, osmet, xzpacked_image) = osmet_file_read(&osmet)?;
-        Self::new_impl(osmet, xzpacked_image, Path::new(SYSROOT_OSTREE_REPO))
+        Ok(Self::new_impl(
+            osmet,
+            xzpacked_image,
+            Path::new(SYSROOT_OSTREE_REPO),
+        ))
     }
 
-    fn new_impl(
-        osmet: Osmet,
-        packed_image: impl Read + Send + 'static,
-        repo: &Path,
-    ) -> Result<Self> {
+    fn new_impl(osmet: Osmet, packed_image: impl Read + Send + 'static, repo: &Path) -> Self {
         let (reader, writer) = pipe::pipe();
 
         let length = osmet.size;
@@ -59,11 +59,11 @@ impl OsmetUnpacker {
             osmet_unpack_to_writer(osmet, packed_image, repo, writer)
         }));
 
-        Ok(Self {
+        Self {
             thread_handle,
             reader,
             length,
-        })
+        }
     }
 
     pub fn length(&self) -> u64 {


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps