### PR TITLE
ci: move help text line length test to GitHub Actions

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -7,43 +7,6 @@ buildPod {
         shwrap("make && make install DESTDIR=install")
         stash name: 'build', includes: 'install/**'
     }
-
-    stage("Lint") {
-        // Check help text maximum line length
-        shwrap('''
-            fail=0
-            checklen() {
-                local length
-                length=$(target/debug/coreos-installer $* --help | wc -L)
-                if [ "${length}" -gt 80 ] ; then
-                    echo "$* --help line length ${length} > 80"
-                    fail=1
-                fi
-            }
-            checklen
-            checklen install
-            checklen download
-            checklen list-stream
-            checklen iso
-            checklen iso embed
-            checklen iso show
-            checklen iso remove
-            checklen iso ignition
-            checklen iso ignition embed
-            checklen iso ignition show
-            checklen iso ignition remove
-            checklen iso kargs modify
-            checklen iso kargs reset
-            checklen iso kargs show
-            checklen pxe
-            checklen pxe ignition
-            checklen pxe ignition wrap
-            checklen pxe ignition unwrap
-            if [ "${fail}" = 1 ]; then
-                exit 1
-            fi
-        ''')
-    }
 }
 
 cosaPod(buildroot: true, runAsUser: 0) {

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,10 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: cargo clippy (rdcore, warnings)
         run: cargo clippy --features rdcore -- -D warnings
+      - name: cargo build
+        run: cargo build
+      - name: Help text line length
+        run: tests/help.sh
   tests-other-channels:
     name: "Tests, unstable toolchain"
     runs-on: ubuntu-latest

--- a/tests/help.sh
+++ b/tests/help.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Check help text maximum line length
+
+set -euo pipefail
+
+fail=0
+checklen() {
+    local length
+    length=$(target/debug/coreos-installer $* --help | wc -L)
+    if [ "${length}" -gt 80 ] ; then
+        echo "$* --help line length ${length} > 80"
+        fail=1
+    fi
+}
+
+checklen
+checklen install
+checklen download
+checklen list-stream
+checklen iso
+checklen iso embed
+checklen iso show
+checklen iso remove
+checklen iso ignition
+checklen iso ignition embed
+checklen iso ignition show
+checklen iso ignition remove
+checklen iso kargs modify
+checklen iso kargs reset
+checklen iso kargs show
+checklen pxe
+checklen pxe ignition
+checklen pxe ignition wrap
+checklen pxe ignition unwrap
+
+if [ "${fail}" = 1 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Add a shell script so developers can run the check by hand.  Move the CI test into GitHub Actions to make it more accessible to downstream forks.