### PR TITLE
Resolve symlink disk paths when creating `Disk` objects

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -46,10 +46,23 @@ pub struct Disk {
 }
 
 impl Disk {
-    pub fn new(path: &str) -> Self {
-        Disk {
-            path: path.to_string(),
-        }
+    pub fn new(path: &str) -> Result<Self> {
+        let canon_path = Path::new(path)
+            .canonicalize()
+            .with_context(|| format!("canonicalizing {}", path))?;
+
+        let canon_path = canon_path
+            .to_str()
+            .with_context(|| {
+                format!(
+                    "path {} canonicalized from {} is not UTF-8",
+                    canon_path.display(),
+                    path
+                )
+            })?
+            .to_string();
+
+        Ok(Disk { path: canon_path })
     }
 
     pub fn mount_partition_by_label(

--- a/src/install.rs
+++ b/src/install.rs
@@ -82,7 +82,7 @@ pub fn install(config: &InstallConfig) -> Result<()> {
     // get reference to partition table
     // For kpartx partitioning, this will conditionally call kpartx -d
     // when dropped
-    let mut table = Disk::new(&config.device)
+    let mut table = Disk::new(&config.device)?
         .get_partition_table()
         .with_context(|| format!("getting partition table for {}", &config.device))?;
 
@@ -121,7 +121,7 @@ pub fn install(config: &InstallConfig) -> Result<()> {
 }
 
 fn ensure_exclusive_access(device: &str) -> Result<()> {
-    let mut parts = Disk::new(device).get_busy_partitions()?;
+    let mut parts = Disk::new(device)?.get_busy_partitions()?;
     if parts.is_empty() {
         return Ok(());
     }
@@ -181,7 +181,7 @@ fn write_disk(
         || config.network_config.is_some()
         || cfg!(target_arch = "s390x")
     {
-        let mount = Disk::new(&config.device).mount_partition_by_label(
+        let mount = Disk::new(&config.device)?.mount_partition_by_label(
             "boot",
             false,
             mount::MsFlags::empty(),

--- a/src/osmet/mod.rs
+++ b/src/osmet/mod.rs
@@ -84,7 +84,7 @@ pub fn osmet_pack(config: &OsmetPackConfig) -> Result<()> {
     // MS_RDONLY; this also ensures that the partition isn't already mounted rw elsewhere.
     // Allow the root partition to be in a child holder device to allow for the RHCOS
     // crypto_LUKS partition.
-    let disk = Disk::new(&config.device);
+    let disk = Disk::new(&config.device)?;
     let boot = disk.mount_partition_by_label("boot", false, mount::MsFlags::MS_RDONLY)?;
     let root = disk.mount_partition_by_label("root", true, mount::MsFlags::MS_RDONLY)?;
 


### PR DESCRIPTION
Proposed solution for #512

Sometimes disks may be given by a path that looks something
like `/dev/disk/by-id/wwn-0x5555555555555555`. This path is
a symlink to the actual `/dev/*` device.

This commit prevents a confusing error message from showing
when the installer is given a busy disk that is a symlink to
a `/dev/*` device and not an actual `/dev/*` directly.

The solution used here is simply resolving the symlink before
creating a `Disk` object. This is done because code later down
the line assumes that the path is going to have a `/dev/*` format.
