### PR TITLE
docs: fix "Edit this page on GitHub" links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,6 +28,7 @@ gh_edit_link: true
 gh_edit_link_text: "Edit this page on GitHub"
 gh_edit_repository: "https://github.com/coreos/coreos-installer"
 gh_edit_branch: "master"
+gh_edit_source: docs
 gh_edit_view_mode: "tree"
 
 compress_html:


### PR DESCRIPTION
Requires https://github.com/coreos/just-the-docs/pull/1.