### PR TITLE
Revert container to F33 to fix quay.io build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.fedoraproject.org/fedora:34 AS builder
+FROM registry.fedoraproject.org/fedora:33 AS builder
 RUN dnf install -y cargo openssl-devel
 WORKDIR /build
 COPY Cargo.* ./
 COPY src src/
 RUN cargo build --release
 
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:33
 RUN dnf install -y /usr/bin/gpg /usr/sbin/kpartx /usr/bin/lsblk \
     /usr/sbin/udevadm && \
     dnf clean all


### PR DESCRIPTION
Fedora 34 includes glibc 2.33, which tries to opportunistically implement `faccessat()` using `faccessat2()`, which is blocked on quay.io builders by a seccomp policy, which returns `-EPERM` instead of `-ENOSYS`, which glibc treats as a fatal error.

https://issues.redhat.com/browse/PROJQUAY-2006

This reverts commit 64d0ee4208ec01b14a6022b0aab1d3b978d08b27.