### PR TITLE
rdcore/rootmap: ignore multipath devices

### DIFF
--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -105,7 +105,7 @@ fn device_to_kargs(root: &Mount, device: PathBuf) -> Result<Option<Vec<String>>>
         Ok(Some(get_raid_kargs(&device)?))
     } else if blktype == "crypt" {
         Ok(Some(get_luks_kargs(root, &device)?))
-    } else if blktype == "part" || blktype == "disk" {
+    } else if blktype == "part" || blktype == "disk" || blktype == "mpath" {
         Ok(None)
     } else {
         bail!("unknown block device type {}", blktype)


### PR DESCRIPTION
Teach the rootmap to ignore multipath devices since they don't need any
special handling.

Normally, in multipath mode, one doesn't hit the rootmap code because
users have to specify `root=`, which skips rootmap injection. But we do
encounter it in the LUKS-on-multipath case where we still want rootmap
to inject e.g. `root=/dev/mapper/myluksdev`.

(In the future, one could imagine multipath being Ignition-driven rather
than something getting enabled behind Ignition's back. Then, rootmap
here would indeed add e.g. `rd.multipath=1` to the kargs cmdline. For
now, this is all done "out-of-band".)