### PR TITLE
Release 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.9.1"
+version = "0.9.2-alpha.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.9.1-alpha.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -179,7 +179,7 @@ dependencies = [
  "libc",
  "maplit",
  "mbrman",
- "nix 0.20.0",
+ "nix 0.18.0",
  "openat-ext",
  "openssl",
  "pipe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.9.1-alpha.0"
+version = "0.9.1"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.9.1"
+version = "0.9.2-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:
- Add Fedora 35 signing key; drop Fedora 32 signing key
- Rename `master` branch to `main`

Minor changes:
- blockdev: Fix symlink disk paths when creating disk objects
- blockdev: Ignore corrupt GPT in `SavedPartitions` without filters