### PR TITLE
s390x: simplify zipl installation

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -216,7 +216,8 @@ fn write_disk(
         #[cfg(target_arch = "s390x")]
         s390x::install_bootloader(
             mount.mountpoint(),
-            &config.device,
+            Some(&config.device),
+            true,
             config.firstboot_kargs.as_ref().map(|s| s.as_str()),
         )?;
     }


### PR DESCRIPTION
On s390x this simplifies installation of `zipl`. 
Also could be used for https://github.com/coreos/coreos-installer/pull/533 