### PR TITLE
blockdev: mount filesystems into private namespace

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -15,10 +15,11 @@
 use anyhow::{anyhow, bail, Context, Result};
 use gptman::{GPTPartitionEntry, GPT};
 use nix::sys::stat::{major, minor};
-use nix::{errno::Errno, mount};
+use nix::{errno::Errno, mount, sched};
 use regex::Regex;
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::env;
 use std::fs::{
     canonicalize, metadata, read_dir, read_to_string, remove_dir, symlink_metadata, File,
     OpenOptions,
@@ -31,6 +32,7 @@ use std::os::unix::fs::FileTypeExt;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Once;
 use std::thread::sleep;
 use std::time::Duration;
 use uuid::Uuid;
@@ -430,6 +432,28 @@ impl Mount {
         // avoid auto-cleanup of tempdir, which could recursively remove
         // the partition contents if umount failed
         let mountpoint = tempdir.into_path();
+
+        // Ensure we're in a private mount namespace so the mount isn't
+        // visible to the rest of the system.  Multiple unshare calls
+        // should be safe.  For now, skip the unshare if the
+        // COREOS_INSTALLER_NO_MOUNT_NAMESPACE environment variable is set,
+        // in case there are use cases where the unshare call fails.
+        // https://github.com/coreos/coreos-installer/issues/557
+        match env::var("COREOS_INSTALLER_NO_MOUNT_NAMESPACE")
+            .as_ref()
+            .map(|v| v as &str)
+        {
+            Ok("") | Err(env::VarError::NotPresent) => {
+                sched::unshare(sched::CloneFlags::CLONE_NEWNS)
+                    .context("unsharing mount namespace")?
+            }
+            _ => {
+                static WARNED: Once = Once::new();
+                WARNED.call_once(|| {
+                    eprintln!("\nMounting filesystems in parent namespace because\nCOREOS_INSTALLER_NO_MOUNT_NAMESPACE is set.  If you need this, file a bug at\nhttps://github.com/coreos/coreos-installer/issues/new/choose.\n");
+                });
+            }
+        }
 
         mount::mount::<str, Path, str, str>(Some(device), &mountpoint, Some(fstype), flags, None)
             .with_context(|| format!("mounting device {} on {}", device, mountpoint.display()))?;


### PR DESCRIPTION
This ensures that other processes on the system can't get file descriptors to files in our mounts, which would impede unmount.  It also guarantees that our mounts are unmounted even if we crash hard (though `kpartx` wouldn't be undone, if applicable).

In contrast to the discussion in #208, we hard-fail if unshare fails.  `CAP_SYS_ADMIN` is required for both `mount()` and `unshare(CLONE_NEWNS)`, and we recommend running containers privileged, so there shouldn't be any expected unshare failures.  This avoids accidentally depending on private namespace semantics while not necessarily getting them.

Fixes #208.

cc @jlebon @dustymabe @nikita-dubrovskii 