### PR TITLE
installer-service: add 'coreos.inst.mpath' boolean option to turn on multipath for the firstboot

### DIFF
--- a/scripts/coreos-installer-service
+++ b/scripts/coreos-installer-service
@@ -97,6 +97,10 @@ if karg_bool coreos.inst.insecure; then
     args+=("--insecure")
 fi
 
+if karg_bool coreos.inst.mpath; then
+   args+=("--append-karg" "rd.multipath=default" "--append-karg" "root=/dev/disk/by-label/dm-mpath-root" "--append-karg" "rw")
+fi
+
 # Ensure device nodes have been created
 udevadm settle
 


### PR DESCRIPTION
During installation on s390x/zVM we cannot just pass extra commandline arguments to the installer,
but we can use a special karg which is later processed by `coreos-installer-service`.

