### PR TITLE
blockdev: try rereading partition table up to 5 times

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -300,6 +300,15 @@ impl PartTableKpartx {
 
 impl PartTable for PartTableKpartx {
     fn reread(&mut self) -> Result<()> {
+        let delay = 1;
+        for _ in 0..4 {
+            match self.run_kpartx("-u") {
+                Ok(()) => return Ok(()),
+                Err(e) => eprintln!("Error: {}", e),
+            }
+            eprintln!("Retrying in {} second", delay);
+            sleep(Duration::from_secs(delay));
+        }
         self.run_kpartx("-u")
     }
 }


### PR DESCRIPTION
When we use DeviceMapper disk as `coreos.inst.install_dev=`, it may happen that `kpartx` fails to reread
partition table, and therefore fails the installation. Let's try up to 5 times, before giving up

```
[   16.056589] coreos-installer-service[1333]: device-mapper: resume ioctl on mpatha4  failed: Invalid argument
[   16.057027] coreos-installer-service[1333]: resume failed on mpatha4
[   16.057050] coreos-installer-service[1333]: Error: "kpartx" "-u" "-n" "/dev/dm-0" failed with exit code: 1
[   16.057069] coreos-installer-service[1333]: Retrying in 1 second
[   18.362478] coreos-installer-service[1333]: Read disk 20.3 MiB/3.5 GiB (0%)
[   23.399255] coreos-installer-service[1333]: Read disk 116.7 MiB/3.5 GiB (3%)
[  216.402889] coreos-installer-service[1333]: Read disk 3.5 GiB/3.5 GiB (100%)
[  216.757601] EXT4-fs (dm-1): mounted filesystem with ordered data mode. Opts: (null)
[  216.759492] coreos-installer-service[1333]: Writing Ignition config
[  216.759932] coreos-installer-service[1333]: Writing first-boot kernel arguments
[  216.759957] coreos-installer-service[1333]: Modifying kernel arguments
[  216.761553] coreos-installer-service[1333]: Installing bootloader
[  217.281371] coreos-installer-service[1333]: Updating re-IPL device
[  217.341450] coreos-installer-service[1333]: Install complete.
```

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>