### PR TITLE
rdcore/kargs: don't fail if --create-if-changed file already exists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,13 @@ maplit = "^1.0"
 [target.'cfg(target_arch = "s390x")'.dependencies]
 mbrman = { version = ">= 0.3, < 0.5", default-features = false }
 rand = ">= 0.7, < 0.9"
+
+# In CoreOS CI we test installation from a compressed image created with
+# `cosa compress --fast`.  This is unacceptably slow if the gunzip inner
+# loops are compiled unoptimized.
+[profile.dev.package.adler]
+opt-level = 3
+[profile.dev.package.crc32fast]
+opt-level = 3
+[profile.dev.package.miniz_oxide]
+opt-level = 3

--- a/src/bin/rdcore/kargs.rs
+++ b/src/bin/rdcore/kargs.rs
@@ -50,7 +50,7 @@ fn modify_and_print(config: &KargsConfig, orig_options: &str) -> Result<Option<S
             if let Some(ref path) = config.create_if_changed {
                 std::fs::OpenOptions::new()
                     .write(true)
-                    .create_new(true)
+                    .create(true)
                     .open(path)
                     .with_context(|| format!("creating {}", path))?;
             }

--- a/src/bin/rdcore/stream_hash.rs
+++ b/src/bin/rdcore/stream_hash.rs
@@ -152,7 +152,7 @@ mod tests {
             hash_file: &'static str,
             input: &'static str,
             err: Option<&'static str>,
-        };
+        }
         let tests = vec![
             Test {
                 hash_file: "",


### PR DESCRIPTION
Other services in the initrd may want to use the same flag file to coordinate reboots.  See discussion in https://github.com/openshift/os/pull/574#discussion_r675688876.

Requires https://github.com/coreos/coreos-installer/pull/579 to fix CI.