### PR TITLE
cargo: optimize gunzip inner loops in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,13 @@ maplit = "^1.0"
 [target.'cfg(target_arch = "s390x")'.dependencies]
 mbrman = { version = ">= 0.3, < 0.5", default-features = false }
 rand = ">= 0.7, < 0.9"
+
+# In CoreOS CI we test installation from a compressed image created with
+# `cosa compress --fast`.  This is unacceptably slow if the gunzip inner
+# loops are compiled unoptimized.
+[profile.dev.package.adler]
+opt-level = 3
+[profile.dev.package.crc32fast]
+opt-level = 3
+[profile.dev.package.miniz_oxide]
+opt-level = 3


### PR DESCRIPTION
On my system, running a dev build, this reduces install time of an image compressed with `gzip -1` from 6m45s to 9.5s.

This should fix CoreOS CI timeouts on the metal4k image.

I don't think this is related to #184, but linking it here for completeness.