### PR TITLE
workflows: bump toolchains; restrict repository access

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-fedora-image:
     name: "Build container image (Fedora)"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTIONS_MSRV_TOOLCHAIN: 1.46.0
+  ACTIONS_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.52.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.53.0
 
 jobs:
   tests-stable:


### PR DESCRIPTION
OCP 4.9 has Rust 1.49.