### PR TITLE
Release 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.10.0"
+version = "0.10.1-alpha.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.9.2-alpha.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.10.0"
+version = "0.10.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.9.2-alpha.0"
+version = "0.10.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:
- install: Support IBM Z virtio DASD target devices
- install, download: Support retrying fetches with new `--fetch-retries` option

Minor changes:
- install: Restrict access permissions on `/boot/ignition`
- install: Retry reading partition table on device mapper target devices
- systemd: Persist `coreos.force_persist_ip` kernel argument when installing with `coreos.inst.*`
- List subcommands of a command even without `-h`
- Mount filesystems in a separate mount namespace
- Refactor bootloader installation on s390x
- Enable optimization for gzip code in dev builds to speed up testing
- docs: Document `coreos-installer iso kargs` commands

Internal changes:
- kargs: Run `zipl` if necessary on s390x
- kargs: Don't fail `--create-if-changed` if the file already exists

Packaging changes:
- Require Rust &ge; 1.49.0
- Support OpenSSL 3.0