### PR TITLE
rdcore/kargs: add `--current` to do a dry run on current kargs

### DIFF
--- a/src/bin/rdcore/kargs.rs
+++ b/src/bin/rdcore/kargs.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use anyhow::{Context, Result};
+use std::fs::read_to_string;
 
 use libcoreinst::install::*;
 #[cfg(target_arch = "s390x")]
@@ -23,6 +24,10 @@ use crate::rootmap::get_boot_mount_from_cmdline_args;
 
 pub fn kargs(config: &KargsConfig) -> Result<()> {
     if let Some(ref orig_options) = config.override_options {
+        modify_and_print(config, orig_options.trim()).context("modifying options")?;
+    } else if config.current {
+        let orig_options =
+            read_to_string("/proc/cmdline").context("reading kernel command line")?;
         modify_and_print(config, orig_options.trim()).context("modifying options")?;
     } else {
         // the unwrap() here is safe because we checked in cmdline that one of them must be provided


### PR DESCRIPTION
In the live ISO/PXE case, Ignition kargs stage has nowhere to write the new kargs, but should still succeed if no changes need to be made.  Add `--current` to apply the kargs changes to the contents of `/proc/cmdline`.  The Ignition kargs wrapper can use this with `--create-if-changed` to decide whether to fail.