### PR TITLE
Prep patches for `structopt` conversion

### DIFF
--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -54,6 +54,7 @@ pub fn parse_args() -> Result<Config> {
         .global_setting(AppSettings::ArgsNegateSubcommands)
         .global_setting(AppSettings::DeriveDisplayOrder)
         .global_setting(AppSettings::DisableHelpSubcommand)
+        .global_setting(AppSettings::GlobalVersion)
         .global_setting(AppSettings::UnifiedHelpMessage)
         .global_setting(AppSettings::VersionlessSubcommands)
         .subcommand(

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -163,6 +163,7 @@ pub fn parse_args() -> Result<Config> {
         .global_setting(AppSettings::ArgsNegateSubcommands)
         .global_setting(AppSettings::DeriveDisplayOrder)
         .global_setting(AppSettings::DisableHelpSubcommand)
+        .global_setting(AppSettings::GlobalVersion)
         .global_setting(AppSettings::UnifiedHelpMessage)
         .global_setting(AppSettings::VersionlessSubcommands)
         .subcommand(


### PR DESCRIPTION
Make some configuration changes to match the outcome of the `structopt` PR (https://github.com/coreos/coreos-installer/pull/594).