### PR TITLE
install: make platform-specific bootloader changes when `-p` specified

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -538,10 +538,10 @@ fn write_platform(mountpoint: &Path, platform: &str) -> Result<()> {
 /// bootloader configs will always set ignition.platform.id.  Fail if those assumptions change.
 /// This is deliberately simplistic.
 fn bls_entry_options_write_platform(orig_options: &str, platform: &str) -> Result<Option<String>> {
-    let new_options = orig_options.replace(
-        "ignition.platform.id=metal",
-        &format!("ignition.platform.id={}", platform),
-    );
+    let new_options = KargsEditor::new()
+        .replace(&[format!("ignition.platform.id=metal={}", platform)])
+        .apply_to(orig_options)
+        .context("updating platform ID")?;
     if orig_options == new_options {
         bail!("Couldn't locate platform ID");
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -402,6 +402,9 @@ fn write_disk(
             write_ignition(mount.mountpoint(), &config.ignition_hash, ignition)
                 .context("writing Ignition configuration")?;
         }
+        if let Some(platform) = config.platform.as_ref() {
+            write_platform(mount.mountpoint(), platform).context("writing platform ID")?;
+        }
         if let Some(firstboot_args) = config.firstboot_args.as_ref() {
             write_firstboot_kargs(mount.mountpoint(), firstboot_args)
                 .context("writing firstboot kargs")?;
@@ -416,9 +419,6 @@ fn write_disk(
                     .maybe_apply_to(orig_options)
             })
             .context("deleting and appending kargs")?;
-        }
-        if let Some(platform) = config.platform.as_ref() {
-            write_platform(mount.mountpoint(), platform).context("writing platform ID")?;
         }
         if let Some(network_config) = network_config.as_ref() {
             copy_network_config(mount.mountpoint(), network_config)?;


### PR DESCRIPTION
If `-p` is specified and `/boot/coreos/platforms.json` exists, look up the specified platform and the `metal` platform in that file.  Remove any metal-specific kernel arguments or GRUB commands specified there, and inject any kargs/commands for the new platform.  This allows us to apply a platform-specific console configuration at install time.

Set the platform before performing kargs modification to allow the latter to change a platform-specific default console.

When installing via `coreos.inst` kargs, persist any `console=` kargs to the destination system, as suggested in https://github.com/coreos/fedora-coreos-tracker/issues/567#issuecomment-901801590.