### PR TITLE
dracut: also ship zipl_helper.device-mapper on s390x

### DIFF
--- a/dracut/50rdcore/module-setup.sh
+++ b/dracut/50rdcore/module-setup.sh
@@ -9,5 +9,6 @@ install() {
     if [[ "$_arch" == "s390x" ]]; then
         inst_multiple zipl
         inst /lib/s390-tools/stage3.bin
+        inst /lib/s390-tools/zipl_helper.device-mapper
     fi
 }


### PR DESCRIPTION
When zipl deals with device-mapper targets, it potentially requires an
additional helper script. Install this in the initramfs.

This fixes https://github.com/openshift/os/issues/615.