### PR TITLE
install: fix call to dasd_try_get_sector_size() on s390x

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -22,8 +22,6 @@ use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
 use crate::io::IgnitionHash;
-#[cfg(target_arch = "s390x")]
-use crate::s390x::dasd_try_get_sector_size;
 
 // Args are listed in --help in the order declared in these structs/enums.
 // Please keep the entire help text to 80 columns.

--- a/src/install.rs
+++ b/src/install.rs
@@ -90,7 +90,7 @@ pub fn install(config: &InstallConfig) -> Result<()> {
         .with_context(|| format!("checking whether {} is an IBM DASD disk", &config.device))?
     {
         #[cfg(target_arch = "s390x")]
-        true => dasd_try_get_sector_size(&config.device).transpose(),
+        true => s390x::dasd_try_get_sector_size(&config.device).transpose(),
         _ => None,
     };
     let sector_size = sector_size


### PR DESCRIPTION
The call to dasd_try_get_sector_size() was shuffled around, adjust the
use paths accordingly.

Fixes: ae1f4a79bfcc ("cmdline: move all postprocessing into command implementations")
Signed-off-by: Julian Wiedmann <jwi@linux.ibm.com>