### PR TITLE
Dockerfile: update to F34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.fedoraproject.org/fedora:33 AS builder
+FROM registry.fedoraproject.org/fedora:34 AS builder
 RUN dnf install -y cargo openssl-devel
 WORKDIR /build
 COPY Cargo.* ./
 COPY src src/
 RUN cargo build --release
 
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.fedoraproject.org/fedora:34
 RUN dnf install -y /usr/bin/gpg /usr/sbin/kpartx /usr/bin/lsblk \
     /usr/sbin/udevadm && \
     dnf clean all


### PR DESCRIPTION
coreos-installer now successfully builds in Quay on Fedora 34.