### PR TITLE
*: lock stdin/stdout before doing I/O

### DIFF
--- a/src/bin/rdcore/stream_hash.rs
+++ b/src/bin/rdcore/stream_hash.rs
@@ -43,7 +43,7 @@ pub fn stream_hash(config: &StreamHashConfig) -> Result<()> {
         .read(true)
         .open(&config.hash_file)
         .with_context(|| format!("opening {}", config.hash_file))?;
-    do_stream_hash(&mut hash_file, &mut stdin(), &mut stdout())
+    do_stream_hash(&mut hash_file, &mut stdin().lock(), &mut stdout().lock())
 }
 
 fn do_stream_hash(

--- a/src/osmet/mod.rs
+++ b/src/osmet/mod.rs
@@ -83,11 +83,10 @@ pub fn osmet_fiemap(config: &OsmetFiemapConfig) -> Result<()> {
     let output = FiemapOutput {
         extents: fiemap_path(config.file.as_str().as_ref())?,
     };
-    serde_json::to_writer_pretty(std::io::stdout(), &output)
-        .context("failed to serialize extents")?;
-    std::io::stdout()
-        .write_all(b"\n")
-        .context("failed to write newline")?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    serde_json::to_writer_pretty(&mut out, &output).context("failed to serialize extents")?;
+    out.write_all(b"\n").context("failed to write newline")?;
     Ok(())
 }
 


### PR DESCRIPTION
The repeated lock/unlock overhead shouldn't matter for trivial amounts of I/O, but it's good to establish a consistent pattern.

For https://github.com/coreos/coreos-installer/pull/616#discussion_r705320940.