### PR TITLE
Some ISO 9660 refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempfile",
+ "thiserror",
  "url",
  "uuid",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 structopt = "0.3"
 tempfile = ">= 3.1, < 4"
+thiserror = "1.0"
 url = ">= 2.1, < 3.0"
 uuid = { version = "^0.8", features = ["v4"] }
 walkdir = "^2.3"

--- a/src/download.rs
+++ b/src/download.rs
@@ -230,9 +230,7 @@ where
     let byte_limit = saved.map(|saved| saved.get_offset()).transpose()?.flatten();
     let mut limit_reader: Box<dyn Read> = match byte_limit {
         None => Box::new(decompress_reader),
-        Some((limit, conflict)) => {
-            Box::new(LimitReader::new(decompress_reader, limit, Some(conflict)))
-        }
+        Some((limit, conflict)) => Box::new(LimitReader::new(decompress_reader, limit, conflict)),
     };
 
     // Read the first MiB of input and, if requested, check it against the

--- a/src/iso9660.rs
+++ b/src/iso9660.rs
@@ -34,7 +34,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use bytes::{Buf, Bytes};
 use serde::Serialize;
 
-use crate::io::{LimitReader, BUFFER_SIZE};
+use crate::io::BUFFER_SIZE;
 
 // technically the standard supports others, but this is the only one we support
 const ISO9660_SECTOR_SIZE: usize = 2048;
@@ -169,7 +169,7 @@ impl IsoFs {
             .with_context(|| format!("seeking to file {}", file.name))?;
         Ok(BufReader::with_capacity(
             BUFFER_SIZE,
-            LimitReader::new(&self.file, file.length as u64, None),
+            (&self.file).take(file.length as u64),
         ))
     }
 

--- a/src/live.rs
+++ b/src/live.rs
@@ -677,7 +677,7 @@ pub fn iso_inspect(config: &IsoInspectConfig) -> Result<()> {
 
 pub fn iso_extract_pxe(config: &IsoExtractPxeConfig) -> Result<()> {
     let mut iso = IsoFs::from_file(open_live_iso(&config.input, None)?)?;
-    let pxeboot = iso.get_dir(COREOS_ISO_PXEBOOT_DIR)?;
+    let pxeboot = iso.get_path(COREOS_ISO_PXEBOOT_DIR)?.try_into_dir()?;
     std::fs::create_dir_all(&config.output_dir)?;
 
     let base = {


### PR DESCRIPTION
1. Remove from `LimitReader` the ability to return `Ok(0)` when the limit is reached.  Use `Read.take()` instead.
1. Drop the `IsoFs` `get_{dir,file}` wrappers in favor of new `try_into_{dir,file}` methods on `DirectoryRecord`.
1. Add `IsoFs.try_get_path()` method returning `Result<Option<DirectoryRecord>>`, for callers that can handle a missing path.