### PR TITLE
RFC: iso9660: add `IsoPath` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempfile",
+ "thiserror",
  "url",
  "uuid",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 structopt = "0.3"
 tempfile = ">= 3.1, < 4"
+thiserror = "1.0"
 url = ">= 2.1, < 3.0"
 uuid = { version = "^0.8", features = ["v4"] }
 walkdir = "^2.3"

--- a/src/download.rs
+++ b/src/download.rs
@@ -230,9 +230,7 @@ where
     let byte_limit = saved.map(|saved| saved.get_offset()).transpose()?.flatten();
     let mut limit_reader: Box<dyn Read> = match byte_limit {
         None => Box::new(decompress_reader),
-        Some((limit, conflict)) => {
-            Box::new(LimitReader::new(decompress_reader, limit, Some(conflict)))
-        }
+        Some((limit, conflict)) => Box::new(LimitReader::new(decompress_reader, limit, conflict)),
     };
 
     // Read the first MiB of input and, if requested, check it against the

--- a/src/iso9660.rs
+++ b/src/iso9660.rs
@@ -34,7 +34,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use bytes::{Buf, Bytes};
 use serde::Serialize;
 
-use crate::io::{LimitReader, BUFFER_SIZE};
+use crate::io::BUFFER_SIZE;
 
 // technically the standard supports others, but this is the only one we support
 const ISO9660_SECTOR_SIZE: usize = 2048;
@@ -169,7 +169,7 @@ impl IsoFs {
             .with_context(|| format!("seeking to file {}", file.name))?;
         Ok(BufReader::with_capacity(
             BUFFER_SIZE,
-            LimitReader::new(&self.file, file.length as u64, None),
+            (&self.file).take(file.length as u64),
         ))
     }
 

--- a/src/live.rs
+++ b/src/live.rs
@@ -37,7 +37,7 @@ const COREOS_KARG_EMBED_AREA_HEADER_MAGIC: &[u8] = b"coreKarg";
 const COREOS_KARG_EMBED_AREA_HEADER_SIZE: u64 = 72;
 const COREOS_KARG_EMBED_AREA_HEADER_MAX_OFFSETS: usize = 6;
 const COREOS_KARG_EMBED_AREA_MAX_SIZE: usize = 2048;
-const COREOS_ISO_PXEBOOT_DIR: &str = "IMAGES/PXEBOOT";
+const COREOS_ISO_PXEBOOT_DIR: &str = "images/pxeboot";
 
 pub fn iso_embed(config: &IsoEmbedConfig) -> Result<()> {
     eprintln!("`iso embed` is deprecated; use `iso ignition embed`.  Continuing.");
@@ -693,7 +693,7 @@ pub fn iso_extract_pxe(config: &IsoExtractPxeConfig) -> Result<()> {
             iso9660::DirectoryRecord::File(file) => {
                 let filename = {
                     let mut s = base.clone();
-                    s.push(file.name.to_lowercase());
+                    s.push(&file.name);
                     s
                 };
                 let path = Path::new(&config.output_dir).join(&filename);

--- a/src/live.rs
+++ b/src/live.rs
@@ -677,7 +677,7 @@ pub fn iso_inspect(config: &IsoInspectConfig) -> Result<()> {
 
 pub fn iso_extract_pxe(config: &IsoExtractPxeConfig) -> Result<()> {
     let mut iso = IsoFs::from_file(open_live_iso(&config.input, None)?)?;
-    let pxeboot = iso.get_dir(COREOS_ISO_PXEBOOT_DIR)?;
+    let pxeboot = iso.get_path(COREOS_ISO_PXEBOOT_DIR)?.try_into_dir()?;
     std::fs::create_dir_all(&config.output_dir)?;
 
     let base = {

--- a/tests/iso-inspect.sh
+++ b/tests/iso-inspect.sh
@@ -9,6 +9,10 @@ fatal() {
 iso=$1; shift
 iso=$(realpath "${iso}")
 
+tmpd=$(mktemp -d)
+trap 'rm -rf "${tmpd}"' EXIT
+cd "${tmpd}"
+
 coreos-installer iso inspect "${iso}" | tee inspect.json
 
 # check that we found the descriptors

--- a/tests/iso-inspect.sh
+++ b/tests/iso-inspect.sh
@@ -31,10 +31,10 @@ jq -e '.header.descriptors[]|select(.type == "primary")|.volume_id|contains("fed
 jq -e '.header.descriptors[]|select(.type == "boot")|.boot_system_id|contains("EL TORITO")' inspect.json
 
 # check that it found some various files and directories at various depths
-jq -e '.records|index("EFI") >= 0' inspect.json
-jq -e '.records|index("IMAGES/PXEBOOT") >= 0' inspect.json
-jq -e '.records|index("IMAGES/PXEBOOT/ROOTFS.IMG") >= 0' inspect.json
-jq -e '.records|index("ZIPL.PRM") >= 0' inspect.json
+jq -e '.records|index("efi") >= 0' inspect.json
+jq -e '.records|index("images/pxeboot") >= 0' inspect.json
+jq -e '.records|index("images/pxeboot/rootfs.img") >= 0' inspect.json
+jq -e '.records|index("zipl.prm") >= 0' inspect.json
 
 # Done
 echo "Success."


### PR DESCRIPTION
Add and consistently use an `IsoPath` type that canonicalizes paths and encapsulates the filename restrictions we're applying for interchange level 1: monocase lowercase filenames truncated to 8.3, with some special characters forbidden.  This makes it clear when we're working with ISO 9660 pathnames vs. regular ones, and allows callers to not have to think about the conversion rules.

Broken out of https://github.com/coreos/coreos-installer/pull/627, and requires it.  See discussion in that PR.