### PR TITLE
cargo: enable debuginfo in the release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ required-features = ["rdcore"]
 
 [profile.release]
 lto = true
+# We assume we're being delivered via e.g. RPM which supports split debuginfo
+debug = true
 
 [dependencies]
 anyhow = ">= 1.0.38, < 2"


### PR DESCRIPTION
Similar to https://github.com/coreos/afterburn/pull/625