### PR TITLE
Adjust for `lzma-sys` bundling `liblzma` if it doesn't find it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,9 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.miniz_oxide]
 opt-level = 3
+
+# If liblzma development headers aren't installed, lzma-sys builds its own
+# copy of liblzma.  The unoptimized performance is okay but optimizing gives
+# a ~2x improvement.
+[profile.dev.package.lzma-sys]
+opt-level = 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:34 AS builder
-RUN dnf install -y cargo openssl-devel
+RUN dnf install -y cargo openssl-devel xz-devel
 WORKDIR /build
 COPY Cargo.* ./
 COPY src src/


### PR DESCRIPTION
If `lzma-sys` can't find development headers for `liblzma`, it builds its own copy.  Add `xz-devel` to the builder container so the containerized version uses Fedora's `liblzma` instead.  For the case where the developer doesn't have `liblzma` headers installed, avoid a 2x slowdown by building `lzma-sys` with optimization in the `dev` profile.

It appears that the Fedora package currently uses the system `liblzma` (by happenstance?) and the RHEL package currently bundles.  We'll want to add `BuildRequires: xz-devel` to both in any case.