### PR TITLE
download: only decompress if artifacts have `.gz`/`.xz` extension

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -70,14 +70,13 @@ pub fn download(config: &DownloadConfig) -> Result<()> {
                 .filename
                 .trim_end_matches(".gz")
                 .trim_end_matches(".xz")
-                .to_string()
         } else {
-            source.filename.to_string()
+            &source.filename
         };
         let mut path = PathBuf::new();
         path.push(&config.directory);
-        path.push(&filename);
-        let sig_path = path.with_file_name(format!("{}.sig", &filename));
+        path.push(filename);
+        let sig_path = path.with_file_name(format!("{}.sig", filename));
 
         // check existing image and signature; don't redownload if OK
         // If we decompressed last time, the call will fail because we can't


### PR DESCRIPTION
Some formats use compression as part of the format definition, without intending that the file should be decompressed before use.  For example, on non-x86 arches, the format sniffer detects the initramfs as a gzipped archive, but it's actually the concatenation of several cpio archives which might be compressed with different compressors.  Similarly, the aarch64 kernel is a regular gzip archive.

When `--decompress` is specified, only decompress files whose URLs have a `.gz`/`.xz` extension.  For consistency, always skip writing the signature in this case.

As a special case, do not decompress `.tar.gz` or `.tar.xz` files.  This is mostly to avoid decompressing the GCP `.tar.gz` image, which is meant to be uploaded to GCP as a unit.

If downloading from a mirror which has removed the filename extensions, this will lead to silently failing to decompress the file.

Fixes #633.