### PR TITLE
Add arch, platform, "Fedora CoreOS" to `StreamLocation` format; print it during `download`

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -45,6 +45,7 @@ pub fn download(config: &DownloadConfig) -> Result<()> {
             config.fetch_retries,
         )?)
     };
+    eprintln!("{}", location);
 
     // walk sources
     let mut sources = location.sources()?;

--- a/src/source.rs
+++ b/src/source.rs
@@ -251,14 +251,14 @@ impl Display for StreamLocation {
         if self.stream_base_url.is_some() {
             write!(
                 f,
-                "Downloading image ({}) and signature referenced from {}",
-                self.format, self.stream_url
+                "Downloading {} {} image ({}) and signature referenced from {}",
+                self.architecture, self.platform, self.format, self.stream_url
             )
         } else {
             write!(
                 f,
-                "Downloading {} image ({}) and signature",
-                self.stream, self.format
+                "Downloading Fedora CoreOS {} {} {} image ({}) and signature",
+                self.stream, self.architecture, self.platform, self.format
             )
         }
     }


### PR DESCRIPTION
The `download` subcommand was launching directly into the download, without saying what it was downloading.  This could be confusing.  In particular, it wasn't necessarily clear that we were downloading an FCOS image and not an RHCOS image.  Print the location as we do in `install`.

In addition, the display text for a location only included some of the parameters used to select the source artifact.  Add the architecture and platform.  If a custom stream metadata URL is not specified, explicitly say "Fedora CoreOS" to avoid confusing users who intend to install RHCOS.

See https://bugzilla.redhat.com/show_bug.cgi?id=2009332.

