### PR TITLE
Release 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.10.1"
+version = "0.10.2-alpha.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.10.1"
+version = "0.10.2-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Security fixes:

- Fix GPG signature check when decompressing gzipped images (CVE-2021-20319)

Major changes:

- Add Fedora 36 signing key