### PR TITLE
Exclude snake-oil GPG private key from Red Hat secret scanning

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+description = "Exclude snake-oil GPG private key from Red Hat secret scanning"
+files = [
+    '''test-key.priv.asc$''',
+]


### PR DESCRIPTION
Internal secret scanning reads an allowlist from `.gitleaks.toml` in [this format](https://github.com/zricethezav/gitleaks/#rules-summary).