### PR TITLE
[release-0.10] dracut: also ship zipl_helper.device-mapper on s390x 

### DIFF
--- a/dracut/50rdcore/module-setup.sh
+++ b/dracut/50rdcore/module-setup.sh
@@ -9,5 +9,6 @@ install() {
     if [[ "$_arch" == "s390x" ]]; then
         inst_multiple zipl
         inst /lib/s390-tools/stage3.bin
+        inst /lib/s390-tools/zipl_helper.device-mapper
     fi
 }


### PR DESCRIPTION
Cherry-pick a small s390x fix for multipath setups, so that the `multipath.day1` test goes green.

Missed to queue this up for v0.10.1, here's hoping that there will be a v0.10.2 to piggyback on :).