### PR TITLE
rdcore: add `bind-boot` command

### DIFF
--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -30,6 +30,8 @@ use structopt::StructOpt;
 pub enum Cmd {
     /// Generate rootmap kargs and optionally inject into BLS configs
     Rootmap(RootmapConfig),
+    /// Generate bootmap kargs and binds bootfs to rootfs and GRUB
+    BindBoot(BindBootConfig),
     /// Modify kargs in BLS configs
     Kargs(KargsConfig),
     /// Copy data from stdin to stdout, checking piecewise hashes
@@ -54,6 +56,16 @@ pub struct RootmapConfig {
     /// Path to rootfs mount
     #[structopt(value_name = "ROOT_MOUNT")]
     pub root_mount: String,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct BindBootConfig {
+    /// Path to rootfs mount
+    #[structopt(value_name = "ROOT_MOUNT")]
+    pub root_mount: String,
+    /// Path to bootfs mount
+    #[structopt(value_name = "BOOT_MOUNT")]
+    pub boot_mount: String,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/bin/rdcore/main.rs
+++ b/src/bin/rdcore/main.rs
@@ -27,6 +27,7 @@ fn main() -> Result<()> {
     match Cmd::from_args() {
         Cmd::Kargs(c) => kargs::kargs(&c),
         Cmd::Rootmap(c) => rootmap::rootmap(&c),
+        Cmd::BindBoot(c) => rootmap::bind_boot(&c),
         Cmd::StreamHash(c) => stream_hash::stream_hash(&c),
         Cmd::VerifyUniqueFsLabel(c) => unique_fs::verify_unique_fs(&c),
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -607,6 +607,8 @@ fn bls_entry_options_write_platform(orig_options: &str, platform: &str) -> Resul
 ///
 /// Note that on s390x, this does not handle the call to `zipl`. We expect it to be done at a
 /// higher level if needed for batching purposes.
+///
+/// Returns `true` if BLS content was modified.
 pub fn visit_bls_entry(
     mountpoint: &Path,
     f: impl Fn(&str) -> Result<Option<String>>,
@@ -675,7 +677,7 @@ pub fn visit_bls_entry(
 
 /// Wrapper around `visit_bls_entry` to specifically visit just the BLS entry's `options` line and
 /// optionally update it if the function returns new content. Errors out if none or more than one
-/// `options` field was found.
+/// `options` field was found. Returns `true` if BLS content was modified.
 pub fn visit_bls_entry_options(
     mountpoint: &Path,
     f: impl Fn(&str) -> Result<Option<String>>,


### PR DESCRIPTION
This command does a few things:
- adds a `boot=UUID=<uuid>` karg to ensure the rootfs mounts by UUID
- "claims" the bootfs for the rootfs by adding a stamp file and erroring
  out if one already exists
- adds a GRUB dropin containing the boot UUID

A natural follow-up to this would be have `coreos-installer install`
optimistically pre-randomize the bootfs UUID and adding the stamp file,
though it's worth discussing separately.

Part of coreos/fedora-coreos-tracker#976.

