### PR TITLE
Release 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.10.1-alpha.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.10.1-alpha.0"
+version = "0.11.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- Drop Fedora 33 signing key
- iso: Add `extract pxe` subcommand to extract PXE artifacts from ISO
- iso: Add `extract minimal-iso` subcommand to extract netboot ISO image from ISO

Minor changes:

- download: Ignore `--decompress` for artifacts that are meant to be used compressed
- download: Report the selected artifacts before starting download
- download/install: Avoid printing GPG verification result when we're ignoring it
- install: Report automatically selected OS, architecture, platform when downloading install image
- install: Report if multiple filesystems are labeled `boot`
- iso: Find Ignition embed area by directly parsing ISO filesystem
- iso: Find kargs embed areas by directly reading `kargs.json` from ISO, if available
- Add `-a` short option for `--architecture`
- Enable optimization for xz code in dev builds to speed up testing
- Fix build on s390x
- docs: Avoid using privileged container for `download` subcommand

Internal changes:

- Add support for packing minimal ISO
- rdcore: Add `bind-boot` subcommand to bind root and boot filesystems on first boot
- rdcore: Add `verify-unique-fs-label` subcommand to check if multiple filesystems share a label
- kargs: Add `--current` to do a dry run on the booted kargs
- osmet: Drop support for RHCOS unencrypted LUKS container

Packaging changes:

- Include debug symbols in release builds
- Add `bytes`, `structopt`, and `thiserror` dependencies
- Drop `clap` dependency
- Require `nix` &ge; 0.22
- dracut: Install `zipl_helper.device-mapper` on s390x
- Update container to Fedora 35
- Use Fedora build of liblzma in container