### PR TITLE
install: support config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "serde_yaml",
  "structopt",
  "tempfile",
  "thiserror",
@@ -272,6 +273,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "encoding_rs"
@@ -589,6 +596,12 @@ name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -1127,6 +1140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
+dependencies = [
+ "dtoa",
+ "indexmap",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,4 +1587,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -184,6 +184,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "structopt",
  "tempfile",
  "thiserror",
@@ -235,6 +236,41 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -493,6 +529,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -965,6 +1007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1104,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1147,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ reqwest = { version = ">= 0.10, < 0.12", features = ["blocking"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_with = "1.9.4"
+serde_yaml = "0.8"
 structopt = "0.3"
 tempfile = ">= 3.1, < 4"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ regex = ">= 1.4, < 1.6"
 reqwest = { version = ">= 0.10, < 0.12", features = ["blocking"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
+serde_with = "1.9.4"
 structopt = "0.3"
 tempfile = ">= 3.1, < 4"
 thiserror = "1.0"

--- a/docs/cmd/install.md
+++ b/docs/cmd/install.md
@@ -40,3 +40,52 @@ Install Fedora CoreOS or RHEL CoreOS
 | **--architecture** *name* | Target CPU architecture [default: x86_64] |
 | **--preserve-on-error** | Don't clear partition table on error |
 | **--fetch-retries** *N* | Fetch retries, or string "infinite" |
+
+## Config file format
+
+Config files specified by `--config-file` are [YAML](https://yaml.org/) documents containing directives with the same names and semantics as command-line arguments.  Each specified config file is parsed in order, and other command-line arguments are parsed afterward.
+
+All parameters are optional.
+
+```yaml
+# Fedora CoreOS stream
+stream: name
+# Manually specify the image URL
+image-url: URL
+# Manually specify a local image file
+image-file: path
+# Embed an Ignition config from a file
+ignition-file: path
+# Embed an Ignition config from a URL
+ignition-url: URL
+# Digest (type-value) of the Ignition config
+ignition-hash: digest
+# Override the Ignition platform ID
+platform: name
+# Append default kernel arguments
+append-karg: [arg1, arg2]
+# Delete default kernel arguments
+delete-karg: [arg1, arg2]
+# Copy network config from install environment
+copy-network: true
+# Source directory for copy-network
+network-dir: path
+# Save partitions with this label glob
+save-partlabel: [glob, glob]
+# Save partitions with this number or range
+save-partindex: [id-or-range, id-or-range]
+# Force offline installation
+offline: true
+# Skip signature verification
+insecure: true
+# Allow Ignition URL without HTTPS or hash
+insecure-ignition: true
+# Base URL for Fedora CoreOS stream metadata
+stream-base-url: URL
+# Target CPU architecture
+architecture: name
+# Don't clear partition table on error
+preserve-on-error: true
+# Fetch retries, or string "infinite"
+fetch-retries: N
+```

--- a/docs/cmd/install.md
+++ b/docs/cmd/install.md
@@ -19,6 +19,7 @@ Install Fedora CoreOS or RHEL CoreOS
 
 ## Options
 
+| **--config-file**, **-c** *path* | YAML config file with install options |
 | **--stream**, **-s** *name* | Fedora CoreOS stream |
 | **--image-url**, **-u** *URL* | Manually specify the image URL |
 | **--image-file**, **-f** *path* | Manually specify a local image file |

--- a/scripts/coreos-installer-service
+++ b/scripts/coreos-installer-service
@@ -13,6 +13,9 @@ PERSIST_DRACUT_NET_PARAMS=("ip" "ifname" "rd.route" "bootdev" "BOOTIF" "rd.booti
 # IBM S390X params to persist
 PERSIST_S390X_PARAMS=("rd.dasd" "rd.zfcp" "rd.znet" "zfcp.allow_lun_scan" "cio_ignore")
 
+# Installer config directory
+INSTALLER_CONFIG_DIR=/etc/coreos/installer.d
+
 args=("install")
 
 cmdline=( $(</proc/cmdline) )
@@ -44,17 +47,29 @@ copy_arg() {
     fi
 }
 
+# Config files
+have_config_file=
+for file in ${INSTALLER_CONFIG_DIR}/*; do
+    if [ -f "${file}" ]; then
+        args+=("--config-file" "${file}")
+        have_config_file=1
+    fi
+done
+
 # Get install device
 device="$(karg coreos.inst.install_dev)"
-if [ -z "${device}" ]; then
+if [ -n "${device}" ]; then
+    if [ "${device##*/}" = "${device}" ]; then
+        # karg contains no slashes.  Prepend "/dev/" for compatibility.
+        device="/dev/${device}"
+    fi
+    args+=("${device}")
+elif [ -z "${have_config_file}" ]; then
+    # If there's a config file, it may not specify the install device, but
+    # we assume it does.
     echo "No install device specified."
     exit 1
 fi
-if [ "${device##*/}" = "${device}" ]; then
-    # karg contains no slashes.  Prepend "/dev/" for compatibility.
-    device="/dev/${device}"
-fi
-args+=("${device}")
 
 # Ignition URL
 ignition_url="$(karg coreos.inst.ignition_url)"
@@ -106,3 +121,6 @@ udevadm settle
 # Install
 echo "coreos-installer ${args[@]}"
 coreos-installer "${args[@]}"
+
+# Delete config files to avoid boot loops outside of a live system
+rm -rf "${INSTALLER_CONFIG_DIR}"

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -161,6 +161,11 @@ pub enum PxeIgnitionCmd {
 #[derive(Debug, Default, StructOpt, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct InstallConfig {
+    /// YAML config file with install options
+    #[serde(skip)]
+    #[structopt(short, long, value_name = "path", number_of_values = 1)]
+    pub config_file: Vec<String>,
+
     // ways to specify the image source
     /// Fedora CoreOS stream
     #[structopt(short, long, value_name = "name")]
@@ -267,7 +272,8 @@ pub struct InstallConfig {
 
     // positional args
     /// Destination device
-    pub device: String,
+    #[structopt(required_unless = "config-file")]
+    pub dest_device: Option<String>,
 }
 
 #[derive(Debug, DeserializeFromStr, SerializeDisplay, Clone, Copy, PartialEq, Eq)]

--- a/src/install.rs
+++ b/src/install.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use nix::mount;
 use std::fs::{
     copy as fscopy, create_dir_all, read_dir, set_permissions, File, OpenOptions, Permissions,
@@ -31,6 +31,12 @@ use crate::s390x;
 use crate::source::*;
 
 pub fn install(config: InstallConfig) -> Result<()> {
+    // make sure we have a device path
+    let device = config
+        .dest_device
+        .as_deref()
+        .ok_or_else(|| anyhow!("destination device must be specified"))?;
+
     // find Ignition config
     let ignition = if let Some(file) = &config.ignition_file {
         Some(
@@ -84,16 +90,16 @@ pub fn install(config: InstallConfig) -> Result<()> {
     // it changes to the recommended 4096
     // https://bugzilla.redhat.com/show_bug.cgi?id=1905159
     #[allow(clippy::match_bool, clippy::match_single_binding)]
-    let sector_size = match is_dasd(&config.device, None)
-        .with_context(|| format!("checking whether {} is an IBM DASD disk", &config.device))?
+    let sector_size = match is_dasd(device, None)
+        .with_context(|| format!("checking whether {} is an IBM DASD disk", device))?
     {
         #[cfg(target_arch = "s390x")]
-        true => s390x::dasd_try_get_sector_size(&config.device).transpose(),
+        true => s390x::dasd_try_get_sector_size(device).transpose(),
         _ => None,
     };
     let sector_size = sector_size
-        .unwrap_or_else(|| get_sector_size_for_path(Path::new(&config.device)))
-        .with_context(|| format!("getting sector size of {}", &config.device))?
+        .unwrap_or_else(|| get_sector_size_for_path(Path::new(device)))
+        .with_context(|| format!("getting sector size of {}", device))?
         .get();
 
     // set up image source
@@ -127,7 +133,7 @@ pub fn install(config: InstallConfig) -> Result<()> {
                     // 512b image
                     eprintln!(
                         "Found non-standard sector size {} for {}, assuming 512b-compatible",
-                        n, &config.device
+                        n, device
                     );
                     "raw.xz"
                 }
@@ -161,14 +167,14 @@ pub fn install(config: InstallConfig) -> Result<()> {
     // set up DASD
     #[cfg(target_arch = "s390x")]
     {
-        if is_dasd(&config.device, None)? {
+        if is_dasd(device, None)? {
             if !save_partitions.is_empty() {
                 // The user requested partition saving, but SavedPartitions
                 // doesn't understand DASD VTOCs and won't find any partitions
                 // to save.
                 bail!("saving DASD partitions is not supported");
             }
-            s390x::prepare_dasd(&config.device)?;
+            s390x::prepare_dasd(device)?;
         }
     }
 
@@ -176,35 +182,35 @@ pub fn install(config: InstallConfig) -> Result<()> {
     let mut dest = OpenOptions::new()
         .read(true)
         .write(true)
-        .open(&config.device)
-        .with_context(|| format!("opening {}", &config.device))?;
+        .open(device)
+        .with_context(|| format!("opening {}", device))?;
     if !dest
         .metadata()
-        .with_context(|| format!("getting metadata for {}", &config.device))?
+        .with_context(|| format!("getting metadata for {}", device))?
         .file_type()
         .is_block_device()
     {
-        bail!("{} is not a block device", &config.device);
+        bail!("{} is not a block device", device);
     }
-    ensure_exclusive_access(&config.device)
-        .with_context(|| format!("checking for exclusive access to {}", &config.device))?;
+    ensure_exclusive_access(device)
+        .with_context(|| format!("checking for exclusive access to {}", device))?;
 
     // save partitions that we plan to keep
     let saved = SavedPartitions::new_from_disk(&mut dest, &save_partitions)
-        .with_context(|| format!("saving partitions from {}", config.device))?;
+        .with_context(|| format!("saving partitions from {}", device))?;
 
     // get reference to partition table
     // For kpartx partitioning, this will conditionally call kpartx -d
     // when dropped
-    let mut table = Disk::new(&config.device)?
+    let mut table = Disk::new(device)?
         .get_partition_table()
-        .with_context(|| format!("getting partition table for {}", &config.device))?;
+        .with_context(|| format!("getting partition table for {}", device))?;
 
     // copy and postprocess disk image
     // On failure, clear and reread the partition table to prevent the disk
     // from accidentally being used.
     dest.seek(SeekFrom::Start(0))
-        .with_context(|| format!("seeking {}", config.device))?;
+        .with_context(|| format!("seeking {}", device))?;
     if let Err(err) = write_disk(
         &config,
         &mut source,
@@ -244,8 +250,8 @@ pub fn install(config: InstallConfig) -> Result<()> {
     match get_filesystems_with_label("boot") {
         Ok(pts) => {
             if pts.len() > 1 {
-                let rootdev = std::fs::canonicalize(&config.device)
-                    .unwrap_or_else(|_| PathBuf::from(&config.device))
+                let rootdev = std::fs::canonicalize(device)
+                    .unwrap_or_else(|_| PathBuf::from(device))
                     .to_string_lossy()
                     .to_string();
                 let pts = pts
@@ -350,12 +356,14 @@ fn write_disk(
     ignition: Option<File>,
     network_config: Option<&str>,
 ) -> Result<()> {
+    let device = config.dest_device.as_deref().expect("device missing");
+
     // Get sector size of destination, for comparing with image
     let sector_size = get_sector_size(dest)?;
 
     // copy the image
     #[allow(clippy::match_bool, clippy::match_single_binding)]
-    let image_copy = match is_dasd(&config.device, Some(dest))? {
+    let image_copy = match is_dasd(device, Some(dest))? {
         #[cfg(target_arch = "s390x")]
         true => s390x::image_copy_s390x,
         _ => image_copy_default,
@@ -363,7 +371,7 @@ fn write_disk(
     write_image(
         source,
         dest,
-        Path::new(&config.device),
+        Path::new(device),
         image_copy,
         true,
         Some(saved),
@@ -381,8 +389,7 @@ fn write_disk(
         || network_config.is_some()
         || cfg!(target_arch = "s390x")
     {
-        let mount =
-            Disk::new(&config.device)?.mount_partition_by_label("boot", mount::MsFlags::empty())?;
+        let mount = Disk::new(device)?.mount_partition_by_label("boot", mount::MsFlags::empty())?;
         if let Some(ignition) = ignition.as_ref() {
             write_ignition(mount.mountpoint(), &config.ignition_hash, ignition)
                 .context("writing Ignition configuration")?;
@@ -411,7 +418,7 @@ fn write_disk(
         #[cfg(target_arch = "s390x")]
         {
             s390x::zipl(mount.mountpoint())?;
-            s390x::chreipl(&config.device)?;
+            s390x::chreipl(device)?;
         }
     }
 
@@ -574,8 +581,9 @@ fn reset_partition_table(
     saved: &SavedPartitions,
 ) -> Result<()> {
     eprintln!("Resetting partition table");
+    let device = config.dest_device.as_deref().expect("device missing");
 
-    if is_dasd(&config.device, Some(dest))? {
+    if is_dasd(device, Some(dest))? {
         // Don't write out a GPT, since the backup GPT may overwrite
         // something we're not allowed to touch.  Just clear the first MiB
         // of disk.

--- a/src/install.rs
+++ b/src/install.rs
@@ -31,6 +31,9 @@ use crate::s390x;
 use crate::source::*;
 
 pub fn install(config: InstallConfig) -> Result<()> {
+    // evaluate config files
+    let config = config.expand_config_files()?;
+
     // make sure we have a device path
     let device = config
         .dest_device

--- a/src/io/hash.rs
+++ b/src/io/hash.rs
@@ -16,7 +16,9 @@ use anyhow::{bail, ensure, Context, Error, Result};
 use openssl::hash::{Hasher, MessageDigest};
 use openssl::sha;
 use serde::{Deserialize, Serialize};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::convert::{TryFrom, TryInto};
+use std::fmt;
 use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
 use std::os::unix::io::AsRawFd;
@@ -24,7 +26,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 /// Ignition-style message digests
-#[derive(Debug)]
+#[derive(Debug, DeserializeFromStr, SerializeDisplay)]
 pub enum IgnitionHash {
     /// SHA-256 digest.
     Sha256(Vec<u8>),
@@ -76,6 +78,16 @@ impl FromStr for IgnitionHash {
         };
 
         Ok(hash)
+    }
+}
+
+impl fmt::Display for IgnitionHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (kind, value) = match self {
+            Self::Sha256(v) => ("sha256", v),
+            Self::Sha512(v) => ("sha512", v),
+        };
+        write!(f, "{}-{}", kind, hex::encode(value))
     }
 }
 

--- a/src/io/hash.rs
+++ b/src/io/hash.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 /// Ignition-style message digests
-#[derive(Debug, DeserializeFromStr, SerializeDisplay)]
+#[derive(Debug, DeserializeFromStr, SerializeDisplay, PartialEq, Eq)]
 pub enum IgnitionHash {
     /// SHA-256 digest.
     Sha256(Vec<u8>),

--- a/systemd/coreos-installer-generator
+++ b/systemd/coreos-installer-generator
@@ -29,7 +29,8 @@ karg_bool() {
     esac
 }
 
-if [ -n "$(karg coreos.inst.install_dev)" ]; then
+if [ -n "$(karg coreos.inst.install_dev)" -o \
+     -n "$(ls -A /etc/coreos/installer.d 2>/dev/null)" ]; then
     ln -sf "/usr/lib/systemd/system/coreos-installer-post.target" \
         "${UNIT_DIR}/default.target"
 

--- a/systemd/coreos-installer.service
+++ b/systemd/coreos-installer.service
@@ -7,7 +7,8 @@ Wants=network-online.target
 # systemd-resolved comes up if enabled.
 # https://github.com/coreos/coreos-installer/issues/283
 After=systemd-resolved.service
-ConditionKernelCommandLine=coreos.inst.install_dev
+ConditionDirectoryNotEmpty=|/etc/coreos/installer.d
+ConditionKernelCommandLine=|coreos.inst.install_dev
 OnFailure=emergency.target
 OnFailureJobMode=replace-irreversibly
 


### PR DESCRIPTION
Add a repeatable `--config-file` option which specifies a YAML config file.  This contains command-line arguments that are prepended to the actual `coreos-installer install` command line before execution.  This will allow users to configure the install process without resorting to kernel arguments or replacing the `coreos-installer.service` unit.

Make the target device argument optional if a config file is provided, since the config file might specify it instead, but also do a late check in case the config file doesn't provide one either.

Implement config merging by generating a vector of synthesized command-line arguments, prepending it to the actual command line, and having structopt reparse the whole thing.  That allows structopt to apply any validation and constraints specified in struct attributes.