### PR TITLE
miniso: handle hardlinked files

### DIFF
--- a/src/iso9660.rs
+++ b/src/iso9660.rs
@@ -221,7 +221,7 @@ pub struct File {
     pub length: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub struct Address(u32);
 
 impl Address {


### PR DESCRIPTION
On ppc64le, some files are hardlinked. The way hardlinks are represented
in ISO9660 is simply that the dirents point to the same sector and have
identical sizes. So they show up as exact copies in the table. So we can
get rid of them by deduplicating. Rust's `Vec::dedup()` makes this easy.

See: https://github.com/coreos/coreos-assembler/issues/2583