### PR TITLE
bind-boot: look for ESPs on the same disk(s) as bootfs

### DIFF
--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -278,7 +278,7 @@ pub fn bind_boot(config: BindBootConfig) -> Result<()> {
         write_boot_uuid_grub2_dropin(&boot_uuid, grub_bios_path)?;
     }
 
-    for esp in find_esps()? {
+    for esp in find_colocated_esps(boot_mount.device())? {
         let mount = Mount::try_mount(&esp, "vfat", mount::MsFlags::empty())?;
         let vendor_dir = find_efi_vendor_dir(&mount)?;
         let grub_efi_path = vendor_dir.join("bootuuid.cfg");


### PR DESCRIPTION
Right now, to find the ESP devices, we just query all the devices on the
system with the matching partition type. This is clumsy though. E.g. in
case multipathing is in use, this will match both the multipathed
version and the non-multipathed versions.

Another case is multiple re-installs of the OS on different disks: we're
working to ensure that users don't have multiple boot filesystems, but
haven't so far required them to also wipe old ESPs. So we want to ensure
we only modify the ESPs on *our* boot disk.

Rework things by trying to be smarter: since we know what the right boot
filesystem is (`coreos-boot-edit.service` uses `--boot-mount`), use that
knowledge to derive the ESPs by only looking for them in the same
storage hierarchy.