### PR TITLE
blockdev: add comments about using `lsblk --paths` for el7

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -882,6 +882,7 @@ pub fn lsblk(dev: &Path, with_deps: bool) -> Result<Vec<HashMap<String, String>>
 /// "part" doesn't match, but "disk" and "mpath" does.
 pub fn find_parent_devices(device: &str) -> Result<Vec<String>> {
     let mut cmd = Command::new("lsblk");
+    // Older lsblk, e.g. in CentOS 7.6, doesn't support PATH, but --paths option
     cmd.arg("--pairs")
         .arg("--paths")
         .arg("--inverse")
@@ -925,6 +926,7 @@ pub fn find_colocated_esps(device: &str) -> Result<Vec<String>> {
     let mut esps = Vec::new();
     for parent_device in parent_devices {
         let mut cmd = Command::new("lsblk");
+        // Older lsblk, e.g. in CentOS 7.6, doesn't support PATH, but --paths option
         cmd.arg("--pairs")
             .arg("--paths")
             .arg("--output")


### PR DESCRIPTION
This is a copy/paste from other instances of this. It's relevant as long
as we consider el7 a supported install platform (see
https://github.com/coreos/coreos-installer/issues/650). The particular
functions here aren't used yet at install time, but could in the future.

Anyway, we should probably instead have an `lsblk` command builder
helper where this lives just once.