### PR TITLE
scripts: print deprecation warnings for `coreos.inst=yes`, `coreos.inst.install_dev` without `/dev`

### DIFF
--- a/scripts/coreos-installer-service
+++ b/scripts/coreos-installer-service
@@ -66,6 +66,8 @@ device="$(karg coreos.inst.install_dev)"
 if [ -n "${device}" ]; then
     if [ "${device##*/}" = "${device}" ]; then
         # karg contains no slashes.  Prepend "/dev/" for compatibility.
+        echo "The \"coreos.inst.install_dev=$device\" syntax is deprecated."
+        echo "Use \"coreos.inst.install_dev=/dev/$device\" instead."
         device="/dev/${device}"
     fi
     args+=("${device}")

--- a/scripts/coreos-installer-service
+++ b/scripts/coreos-installer-service
@@ -47,6 +47,11 @@ copy_arg() {
     fi
 }
 
+# Warn on deprecated kargs
+if [ "$(karg coreos.inst)" = yes ]; then
+    echo '"coreos.inst=yes" is deprecated and no longer has any effect.'
+fi
+
 # Config files
 have_config_file=
 for file in ${INSTALLER_CONFIG_DIR}/*; do


### PR DESCRIPTION
`coreos.inst=yes` no longer has any effect.  The `coreos.inst.install_dev=sda` syntax is still supported, and there are no plans to stop supporting it, but the new syntax is more consistent.  While our documentation tries to steer users toward the latter, examples of the old syntax keep showing up.  Add deprecation warnings to encourage users to update their configs.