### PR TITLE
*: replace `ok_or_else` with `context`

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use nix::mount;
 use std::fs::{
     copy as fscopy, create_dir_all, read_dir, set_permissions, File, OpenOptions, Permissions,
@@ -38,7 +38,7 @@ pub fn install(config: InstallConfig) -> Result<()> {
     let device = config
         .dest_device
         .as_deref()
-        .ok_or_else(|| anyhow!("destination device must be specified"))?;
+        .context("destination device must be specified")?;
 
     // find Ignition config
     let ignition = if let Some(file) = &config.ignition_file {

--- a/src/live.rs
+++ b/src/live.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use bytes::Buf;
 use cpio::{write_cpio, NewcBuilder, NewcReader};
 use nix::unistd::isatty;
@@ -316,13 +316,13 @@ impl IsoConfig {
     fn unwrap_kargs(&self) -> Result<&KargEmbedAreas> {
         self.kargs
             .as_ref()
-            .ok_or_else(|| anyhow!("No karg embed areas found; old or corrupted CoreOS ISO image."))
+            .context("No karg embed areas found; old or corrupted CoreOS ISO image.")
     }
 
     fn unwrap_kargs_mut(&mut self) -> Result<&mut KargEmbedAreas> {
         self.kargs
             .as_mut()
-            .ok_or_else(|| anyhow!("No karg embed areas found; old or corrupted CoreOS ISO image."))
+            .context("No karg embed areas found; old or corrupted CoreOS ISO image.")
     }
 
     pub fn write(&self, file: &mut File) -> Result<()> {
@@ -935,7 +935,7 @@ fn modify_miniso_kargs(f: &mut File, rootfs_url: Option<&String>) -> Result<()> 
     let liveiso_karg = kargs
         .split_ascii_whitespace()
         .find(|&karg| karg.starts_with("coreos.liveiso="))
-        .ok_or_else(|| anyhow!("minimal ISO does not have coreos.liveiso= karg"))?
+        .context("minimal ISO does not have coreos.liveiso= karg")?
         .to_string();
 
     let new_default_kargs = KargsEditor::new().delete(&[liveiso_karg]).apply_to(kargs)?;
@@ -957,10 +957,10 @@ fn modify_miniso_kargs(f: &mut File, rootfs_url: Option<&String>) -> Result<()> 
 
     // also modify the default kargs because we don't want `coreos-installer iso kargs reset` to
     // re-add `coreos.liveiso`
-    let mut kargs_info = KargEmbedInfo::for_iso(&mut iso)?.ok_or_else(|| {
+    let mut kargs_info = KargEmbedInfo::for_iso(&mut iso)?.context(
         // should be impossible; we only support new-style CoreOS ISOs with kargs.json
-        anyhow!("minimal ISO does not have kargs.json; please report this as a bug")
-    })?;
+        "minimal ISO does not have kargs.json; please report this as a bug",
+    )?;
 
     // NB: We don't need to update the length for this; it's a fixed property of the kargs files.
     // (Though its original value did depend on the original default kargs at build time.)

--- a/src/miniso.rs
+++ b/src/miniso.rs
@@ -17,7 +17,7 @@ use std::convert::TryInto;
 use std::fs::File;
 use std::io::{copy, Read, Seek, SeekFrom, Write};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use bincode::Options;
 use serde::{Deserialize, Serialize};
 use structopt::clap::crate_version;
@@ -52,7 +52,7 @@ impl Table {
         for (path, minimal_entry) in minimal_files {
             let full_entry = full_files
                 .get(path)
-                .ok_or_else(|| anyhow!("missing minimal file {} in full ISO", path))?;
+                .with_context(|| format!("missing minimal file {} in full ISO", path))?;
             if full_entry.length != minimal_entry.length {
                 bail!(
                     "File {} has different lengths in full and minimal ISOs",

--- a/src/osmet/file.rs
+++ b/src/osmet/file.rs
@@ -16,7 +16,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read};
 use std::path::Path;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use bincode::Options;
 use serde::{Deserialize, Serialize};
 use structopt::clap::crate_version;
@@ -169,7 +169,7 @@ fn validate_osmet(osmet: &Osmet) -> Result<()> {
                 verify_canonical(&partition.mappings)
                     .with_context(|| format!("partition {}", i))?,
             )
-            .ok_or_else(|| anyhow!("overflow after partition {}", i))?;
+            .with_context(|| format!("overflow after partition {}", i))?;
         if cursor > partition.end_offset {
             bail!(
                 "cursor past partition end: {} vs {}",
@@ -197,7 +197,7 @@ fn verify_canonical(mappings: &[Mapping]) -> Result<u64> {
             .extent
             .physical
             .checked_add(mapping.extent.length)
-            .ok_or_else(|| anyhow!("overflow after mapping {}", i))?;
+            .with_context(|| format!("overflow after mapping {}", i))?;
     }
 
     Ok(cursor)

--- a/src/osmet/io_helpers.rs
+++ b/src/osmet/io_helpers.rs
@@ -15,7 +15,7 @@
 use std::io::Write;
 use std::path::Path;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Context, Result};
 
 use crate::io::Sha256Digest;
 
@@ -32,7 +32,7 @@ pub fn object_path_to_checksum(path: &Path) -> Result<Sha256Digest> {
         .file_stem()
         .unwrap()
         .to_str()
-        .ok_or_else(|| anyhow!("invalid non-UTF-8 object filename: {:?}", path))?;
+        .with_context(|| format!("invalid non-UTF-8 object filename: {:?}", path))?;
     if chksum2.len() != 2 || chksum62.len() != 62 {
         bail!("Malformed object path {:?}", path);
     }

--- a/src/s390x/eckd.rs
+++ b/src/s390x/eckd.rs
@@ -217,8 +217,7 @@ fn get_sectors_per_track(file: &File) -> Result<NonZeroU32> {
     let fd = file.as_raw_fd();
     let mut geo: ioctl::hd_geometry = Default::default();
     match unsafe { ioctl::hdio_getgeo(fd, &mut geo) } {
-        Ok(_) => NonZeroU32::new(geo.sectors.into())
-            .ok_or_else(|| anyhow!("found sectors/track of zero")),
+        Ok(_) => NonZeroU32::new(geo.sectors.into()).context("found sectors/track of zero"),
         Err(e) => Err(e).context("getting disk geometry"),
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -339,11 +339,11 @@ impl ImageLocation for OsmetLocation {
         let unpacker = OsmetUnpacker::new_from_sysroot(Path::new(&self.osmet_path))?;
 
         let filename = {
-            let stem = self.osmet_path.file_stem().ok_or_else(|| {
+            let stem = self.osmet_path.file_stem().with_context(|| {
                 // This really should never happen since for us to get here, we must've found a
                 // valid osmet file... But let's still just error out instead of assert in case
                 // somehow this doesn't hold true in the future and a user hits this.
-                anyhow!(
+                format!(
                     "can't create new .raw filename from osmet path {:?}",
                     &self.osmet_path
                 )
@@ -351,7 +351,7 @@ impl ImageLocation for OsmetLocation {
             // really we don't need to care about UTF-8 here, but ImageSource right now does
             let mut filename: String = stem
                 .to_str()
-                .ok_or_else(|| anyhow!("non-UTF-8 osmet file stem: {:?}", stem))?
+                .with_context(|| format!("non-UTF-8 osmet file stem: {:?}", stem))?
                 .into();
             filename.push_str(".raw");
             filename


### PR DESCRIPTION
It appears that anyhow has always supported `context()` and `with_context()` on `Option`, and we missed it during the error_chain conversion.