### PR TITLE
live: add `iso`/`pxe` subcommands for embedding/wrapping NM keyfiles

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -35,6 +35,16 @@ cosaPod(buildroot: true, runAsUser: 0) {
             scenarios4k: "iso-install,iso-offline-install",
             skipUEFI: true
         )
+        // Only test ISO because kola testiso doesn't support NM keyfiles
+        // for PXE
+        fcosKolaTestIso(
+            cosaDir: "/srv/fcos",
+            scenarios: "iso-install",
+            extraArgs: "--add-nm-keyfile",
+            skipMetal4k: true,
+            skipMultipath: true,
+            skipUEFI: true
+        )
         // for embed commands, test both the built ISO and a minimal fixture
         // with the legacy embed areas
         shwrap("tests/iso-ignition.sh /srv/fcos/builds/latest/x86_64/*.iso")

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -49,6 +49,8 @@ cosaPod(buildroot: true, runAsUser: 0) {
         // with the legacy embed areas
         shwrap("tests/iso-ignition.sh /srv/fcos/builds/latest/x86_64/*.iso")
         shwrap("tests/iso-ignition.sh fixtures/iso/embed-areas-2021-09.iso.xz")
+        shwrap("tests/iso-network.sh /srv/fcos/builds/latest/x86_64/*.iso")
+        shwrap("tests/iso-network.sh fixtures/iso/embed-areas-2021-09.iso.xz")
         shwrap("tests/iso-kargs.sh /srv/fcos/builds/latest/x86_64/*.iso")
         shwrap("tests/iso-kargs.sh fixtures/iso/embed-areas-2021-09.iso.xz")
         shwrap("tests/iso-inspect.sh /srv/fcos/builds/latest/x86_64/*.iso")

--- a/docs/cmd/iso.md
+++ b/docs/cmd/iso.md
@@ -58,6 +58,56 @@ ARGS:
     <ISO>    ISO image
 ```
 
+# coreos-installer iso network embed
+
+```
+Embed network settings in an ISO image
+
+USAGE:
+    coreos-installer iso network embed [OPTIONS] <ISO> --keyfile <path>...
+
+OPTIONS:
+    -k, --keyfile <path>...    NetworkManager keyfile to embed
+    -f, --force                Overwrite existing network settings
+    -o, --output <path>        Write ISO to a new output file
+    -h, --help                 Prints help information
+
+ARGS:
+    <ISO>    ISO image
+```
+
+# coreos-installer iso network extract
+
+```
+Extract embedded network settings from an ISO image
+
+USAGE:
+    coreos-installer iso network extract <ISO>
+
+OPTIONS:
+    -C, --directory <path>    Extract to directory instead of stdout
+    -h, --help                Prints help information
+
+ARGS:
+    <ISO>    ISO image
+```
+
+# coreos-installer iso network remove
+
+```
+Remove existing network settings from an ISO image
+
+USAGE:
+    coreos-installer iso network remove <ISO>
+
+OPTIONS:
+    -o, --output <path>    Write ISO to a new output file
+    -h, --help             Prints help information
+
+ARGS:
+    <ISO>    ISO image
+```
+
 # coreos-installer iso kargs modify
 
 ```

--- a/docs/cmd/pxe.md
+++ b/docs/cmd/pxe.md
@@ -37,3 +37,33 @@ OPTIONS:
 ARGS:
     <initrd>    initrd image [default: stdin]
 ```
+
+# coreos-installer pxe network wrap
+
+```
+Wrap network settings in an initrd image
+
+USAGE:
+    coreos-installer pxe network wrap --keyfile <path>...
+
+OPTIONS:
+    -k, --keyfile <path>...    NetworkManager keyfile to embed
+    -o, --output <path>        Write to a file instead of stdout
+    -h, --help                 Prints help information
+```
+
+# coreos-installer pxe network unwrap
+
+```
+Extract wrapped network settings from an initrd image
+
+USAGE:
+    coreos-installer pxe network unwrap [initrd]
+
+OPTIONS:
+    -C, --directory <path>    Extract to directory instead of stdout
+    -h, --help                Prints help information
+
+ARGS:
+    <initrd>    initrd image [default: stdin]
+```

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -73,6 +73,8 @@ pub enum IsoCmd {
     Remove(IsoRemoveConfig),
     /// Embed an Ignition config in a CoreOS live ISO image
     Ignition(IsoIgnitionCmd),
+    /// Embed network settings in a CoreOS live ISO image
+    Network(IsoNetworkCmd),
     /// Modify kernel args in a CoreOS live ISO image
     Kargs(IsoKargsCmd),
     /// Inspect the CoreOS live ISO image
@@ -91,6 +93,16 @@ pub enum IsoIgnitionCmd {
     Show(IsoIgnitionShowConfig),
     /// Remove an existing embedded Ignition config from an ISO image
     Remove(IsoIgnitionRemoveConfig),
+}
+
+#[derive(Debug, StructOpt)]
+pub enum IsoNetworkCmd {
+    /// Embed network settings in an ISO image
+    Embed(IsoNetworkEmbedConfig),
+    /// Extract embedded network settings from an ISO image
+    Extract(IsoNetworkExtractConfig),
+    /// Remove existing network settings from an ISO image
+    Remove(IsoNetworkRemoveConfig),
 }
 
 #[derive(Debug, StructOpt)]
@@ -130,6 +142,8 @@ pub enum OsmetCmd {
 pub enum PxeCmd {
     /// Commands to manage a live PXE Ignition config
     Ignition(PxeIgnitionCmd),
+    /// Commands to manage live PXE network settings
+    Network(PxeNetworkCmd),
 }
 
 #[derive(Debug, StructOpt)]
@@ -138,6 +152,14 @@ pub enum PxeIgnitionCmd {
     Wrap(PxeIgnitionWrapConfig),
     /// Show the wrapped Ignition config in an initrd image
     Unwrap(PxeIgnitionUnwrapConfig),
+}
+
+#[derive(Debug, StructOpt)]
+pub enum PxeNetworkCmd {
+    /// Wrap network settings in an initrd image
+    Wrap(PxeNetworkWrapConfig),
+    /// Extract wrapped network settings from an initrd image
+    Unwrap(PxeNetworkUnwrapConfig),
 }
 
 // As a special case, this struct supports Serialize and Deserialize for
@@ -507,6 +529,45 @@ pub struct IsoIgnitionRemoveConfig {
 }
 
 #[derive(Debug, StructOpt)]
+pub struct IsoNetworkEmbedConfig {
+    /// NetworkManager keyfile to embed
+    // Required option. :-(  In future we might support other configuration
+    // sources.
+    #[structopt(short, long, required = true, value_name = "path")]
+    #[structopt(number_of_values = 1)]
+    pub keyfile: Vec<String>,
+    /// Overwrite existing network settings
+    #[structopt(short, long)]
+    pub force: bool,
+    /// Write ISO to a new output file
+    #[structopt(short, long, value_name = "path")]
+    pub output: Option<String>,
+    /// ISO image
+    #[structopt(value_name = "ISO")]
+    pub input: String,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct IsoNetworkExtractConfig {
+    /// Extract to directory instead of stdout
+    #[structopt(short = "C", long, value_name = "path")]
+    pub directory: Option<String>,
+    /// ISO image
+    #[structopt(value_name = "ISO")]
+    pub input: String,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct IsoNetworkRemoveConfig {
+    /// Write ISO to a new output file
+    #[structopt(short, long, value_name = "path")]
+    pub output: Option<String>,
+    /// ISO image
+    #[structopt(value_name = "ISO")]
+    pub input: String,
+}
+
+#[derive(Debug, StructOpt)]
 pub struct IsoKargsModifyConfig {
     /// Kernel argument to append
     #[structopt(short, long, number_of_values = 1, value_name = "KARG")]
@@ -649,6 +710,29 @@ pub struct PxeIgnitionWrapConfig {
 
 #[derive(Debug, StructOpt)]
 pub struct PxeIgnitionUnwrapConfig {
+    /// initrd image [default: stdin]
+    #[structopt(value_name = "initrd")]
+    pub input: Option<String>,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PxeNetworkWrapConfig {
+    /// NetworkManager keyfile to embed
+    // Required option. :-(  In future we might support other configuration
+    // sources.
+    #[structopt(short, long, required = true, value_name = "path")]
+    #[structopt(number_of_values = 1)]
+    pub keyfile: Vec<String>,
+    /// Write to a file instead of stdout
+    #[structopt(short, long, value_name = "path")]
+    pub output: Option<String>,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct PxeNetworkUnwrapConfig {
+    /// Extract to directory instead of stdout
+    #[structopt(short = "C", long, value_name = "path")]
+    pub directory: Option<String>,
     /// initrd image [default: stdin]
     #[structopt(value_name = "initrd")]
     pub input: Option<String>,

--- a/src/io/initrd.rs
+++ b/src/io/initrd.rs
@@ -14,143 +14,177 @@
 
 use anyhow::{Context, Result};
 use cpio::{write_cpio, NewcBuilder, NewcReader};
+use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Cursor, Read};
 use xz2::stream::{Check, Stream};
 use xz2::write::XzEncoder;
 
 use crate::io::*;
 
-/// Make an xz-compressed initrd containing the specified members.
-pub fn make_initrd(members: &[(&str, &[u8])]) -> Result<Vec<u8>> {
-    // kernel requires CRC32: https://www.kernel.org/doc/Documentation/xz.txt
-    let mut encoder = XzEncoder::new_stream(
-        Vec::new(),
-        Stream::new_easy_encoder(9, Check::Crc32).context("creating XZ encoder")?,
-    );
-    write_cpio(
-        members.iter().map(|(path, contents)|
-        // S_IFREG | 0644
-        (NewcBuilder::new(path).mode(0o100_644),
-        Cursor::new(*contents))),
-        &mut encoder,
-    )
-    .context("writing CPIO archive")?;
-    encoder.finish().context("closing XZ compressor")
+#[derive(Default, Debug)]
+pub struct Initrd {
+    members: BTreeMap<String, Vec<u8>>,
 }
 
-/// Extract a compressed or uncompressed CPIO archive and return the
-/// contents of the specified path.
-pub fn extract_initrd<R: Read>(source: R, path: &str) -> Result<Option<Vec<u8>>> {
-    let mut source = BufReader::with_capacity(BUFFER_SIZE, source);
-    let mut result: Option<Vec<u8>> = None;
-    // loop until EOF
-    while !source
-        .fill_buf()
-        .context("checking for data in initrd")?
-        .is_empty()
-    {
-        // read one archive
-        let mut decompressor = DecompressReader::for_concatenated(source)?;
-        loop {
-            let mut reader = NewcReader::new(decompressor).context("reading CPIO entry")?;
-            let entry = reader.entry();
-            if entry.is_trailer() {
-                decompressor = reader.finish().context("finishing reading CPIO trailer")?;
-                break;
-            }
-            if entry.name() == path {
-                let mut buf = Vec::with_capacity(entry.file_size() as usize);
-                reader
-                    .read_to_end(&mut buf)
-                    .context("reading CPIO entry contents")?;
-                result = Some(buf);
-            }
-            decompressor = reader.finish().context("finishing reading CPIO entry")?;
-        }
+impl Initrd {
+    /// Generate an xz-compressed initrd.
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        // kernel requires CRC32: https://www.kernel.org/doc/Documentation/xz.txt
+        let mut encoder = XzEncoder::new_stream(
+            Vec::new(),
+            Stream::new_easy_encoder(9, Check::Crc32).context("creating XZ encoder")?,
+        );
+        write_cpio(
+            self.members.iter().map(|(path, contents)|
+            // S_IFREG | 0644
+            (NewcBuilder::new(path).mode(0o100_644),
+            Cursor::new(contents))),
+            &mut encoder,
+        )
+        .context("writing CPIO archive")?;
+        encoder.finish().context("closing XZ compressor")
+    }
 
-        // finish decompression, if any, and recover source
-        if decompressor.compressed() {
-            let mut trailing = Vec::new();
-            decompressor
-                .read_to_end(&mut trailing)
-                .context("finishing reading compressed archive")?;
-            // padding is okay; data is not
-            if trailing.iter().any(|v| *v != 0) {
-                bail!("found trailing garbage inside compressed archive");
-            }
-        }
-        source = decompressor.into_inner();
-
-        // skip any zero padding between archives
-        loop {
-            let buf = source
-                .fill_buf()
-                .context("checking for padding in initrd")?;
-            if buf.is_empty() {
-                // EOF
-                break;
-            }
-            match buf.iter().position(|v| *v != 0) {
-                Some(pos) => {
-                    source.consume(pos);
+    /// Read an initrd containing compressed and/or uncompressed archives.
+    pub fn from_reader<R: Read>(source: R) -> Result<Self> {
+        let mut source = BufReader::with_capacity(BUFFER_SIZE, source);
+        let mut result = Self::default();
+        // loop until EOF
+        while !source
+            .fill_buf()
+            .context("checking for data in initrd")?
+            .is_empty()
+        {
+            // read one archive
+            let mut decompressor = DecompressReader::for_concatenated(source)?;
+            loop {
+                let mut reader = NewcReader::new(decompressor).context("reading CPIO entry")?;
+                let entry = reader.entry();
+                if entry.is_trailer() {
+                    decompressor = reader.finish().context("finishing reading CPIO trailer")?;
                     break;
                 }
-                None => {
-                    let len = buf.len();
-                    source.consume(len);
+                let name = entry.name().to_string();
+                if entry.mode() & 0o170_000 == 0o100_000 {
+                    // regular file
+                    let mut buf = Vec::with_capacity(entry.file_size() as usize);
+                    reader
+                        .read_to_end(&mut buf)
+                        .context("reading CPIO entry contents")?;
+                    result.members.insert(name, buf);
+                }
+                decompressor = reader.finish().context("finishing reading CPIO entry")?;
+            }
+
+            // finish decompression, if any, and recover source
+            if decompressor.compressed() {
+                let mut trailing = Vec::new();
+                decompressor
+                    .read_to_end(&mut trailing)
+                    .context("finishing reading compressed archive")?;
+                // padding is okay; data is not
+                if trailing.iter().any(|v| *v != 0) {
+                    bail!("found trailing garbage inside compressed archive");
+                }
+            }
+            source = decompressor.into_inner();
+
+            // skip any zero padding between archives
+            loop {
+                let buf = source
+                    .fill_buf()
+                    .context("checking for padding in initrd")?;
+                if buf.is_empty() {
+                    // EOF
+                    break;
+                }
+                match buf.iter().position(|v| *v != 0) {
+                    Some(pos) => {
+                        source.consume(pos);
+                        break;
+                    }
+                    None => {
+                        let len = buf.len();
+                        source.consume(len);
+                    }
                 }
             }
         }
+        Ok(result)
     }
-    Ok(result)
+
+    pub fn get(&self, path: &str) -> Option<&[u8]> {
+        self.members.get(path).map(|v| v.as_slice())
+    }
+
+    pub fn add(&mut self, path: &str, contents: Vec<u8>) {
+        self.members.insert(path.into(), contents);
+    }
+
+    pub fn remove(&mut self, path: &str) {
+        self.members.remove(path);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maplit::btreemap;
     use xz2::read::XzDecoder;
 
     #[test]
-    fn test_cpio_roundtrip() {
+    fn roundtrip() {
         let input = r#"{}"#;
-        let cpio = make_initrd(&[("z", input.as_bytes())]).unwrap();
-        let output = extract_initrd(&*cpio, "z").unwrap().unwrap();
-        assert_eq!(input.as_bytes(), output.as_slice());
+        let mut initrd = Initrd::default();
+        initrd.add("z", input.as_bytes().into());
+        assert_eq!(
+            input.as_bytes(),
+            Initrd::from_reader(&*initrd.to_bytes().unwrap())
+                .unwrap()
+                .get("z")
+                .unwrap()
+        );
     }
 
     #[test]
-    fn test_cpio_compression() {
+    fn compression() {
         let mut archive: Vec<u8> = Vec::new();
         XzDecoder::new(&include_bytes!("../../fixtures/initrd/compressed.img.xz")[..])
             .read_to_end(&mut archive)
             .unwrap();
-        for dir in &["uncompressed-1", "gzip", "xz", "uncompressed-2"] {
-            assert_eq!(
-                extract_initrd(&*archive, &format!("{}/hello", dir))
-                    .unwrap()
-                    .unwrap(),
-                b"HELLO\n"
-            );
-            assert_eq!(
-                extract_initrd(&*archive, &format!("{}/world", dir))
-                    .unwrap()
-                    .unwrap(),
-                b"WORLD\n"
-            );
-        }
-        assert!(extract_initrd(&*archive, "z").unwrap().is_none());
+        let initrd = Initrd::from_reader(&*archive).unwrap();
+        assert_eq!(
+            initrd.members,
+            btreemap! {
+                "uncompressed-1/hello".into() => b"HELLO\n".to_vec(),
+                "uncompressed-1/world".into() => b"WORLD\n".to_vec(),
+                "uncompressed-2/hello".into() => b"HELLO\n".to_vec(),
+                "uncompressed-2/world".into() => b"WORLD\n".to_vec(),
+                "gzip/hello".into() => b"HELLO\n".to_vec(),
+                "gzip/world".into() => b"WORLD\n".to_vec(),
+                "xz/hello".into() => b"HELLO\n".to_vec(),
+                "xz/world".into() => b"WORLD\n".to_vec(),
+            }
+        );
     }
 
     /// Check that the last copy of a file in an archive wins, which is
     /// how the kernel behaves.
     #[test]
-    fn test_cpio_redundancy() {
+    fn redundancy() {
         let mut archive: Vec<u8> = Vec::new();
         XzDecoder::new(&include_bytes!("../../fixtures/initrd/redundant.img.xz")[..])
             .read_to_end(&mut archive)
             .unwrap();
         assert_eq!(
-            extract_initrd(&*archive, "data/file").unwrap().unwrap(),
+            Initrd::from_reader(&*archive)
+                .unwrap()
+                .get("data/file")
+                .unwrap(),
             b"third\n"
         );
     }

--- a/src/io/initrd.rs
+++ b/src/io/initrd.rs
@@ -63,9 +63,9 @@ impl Initrd {
                     Cursor::new(&[][..]),
                 ));
             }
-            // create file, S_IFREG | 0644
+            // create file, S_IFREG | 0600
             members.push((
-                NewcBuilder::new(path).mode(0o100_644),
+                NewcBuilder::new(path).mode(0o100_600),
                 Cursor::new(contents),
             ));
         }

--- a/src/live.rs
+++ b/src/live.rs
@@ -32,8 +32,8 @@ use crate::iso9660::{self, IsoFs};
 use crate::miniso;
 
 const INITRD_IGNITION_PATH: &str = "config.ign";
-const COREOS_IGNITION_EMBED_PATH: &str = "IMAGES/IGNITION.IMG";
-const COREOS_IGNITION_HEADER_SIZE: u64 = 24;
+const COREOS_INITRD_EMBED_PATH: &str = "IMAGES/IGNITION.IMG";
+const COREOS_INITRD_HEADER_SIZE: u64 = 24;
 const COREOS_KARG_EMBED_AREA_HEADER_MAGIC: &[u8] = b"coreKarg";
 const COREOS_KARG_EMBED_AREA_HEADER_SIZE: u64 = 72;
 const COREOS_KARG_EMBED_AREA_HEADER_MAX_OFFSETS: usize = 6;
@@ -594,7 +594,7 @@ impl KargEmbedAreas {
         // 8 bytes little-endian x 6: offsets to karg embed areas
         let region = Region::read(
             file,
-            32768 - COREOS_IGNITION_HEADER_SIZE - COREOS_KARG_EMBED_AREA_HEADER_SIZE,
+            32768 - COREOS_INITRD_HEADER_SIZE - COREOS_KARG_EMBED_AREA_HEADER_SIZE,
             COREOS_KARG_EMBED_AREA_HEADER_SIZE as usize,
         )
         .context("reading karg embed header")?;
@@ -712,7 +712,7 @@ impl KargEmbedAreas {
 
 fn ignition_embed_area(iso: &mut IsoFs) -> Result<Region> {
     let f = iso
-        .get_path(COREOS_IGNITION_EMBED_PATH)
+        .get_path(COREOS_INITRD_EMBED_PATH)
         .context("finding Ignition embed area")?
         .try_into_file()?;
     // read (checks offset/length as a side effect)

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,11 @@ fn main() -> Result<()> {
                 IsoIgnitionCmd::Show(c) => live::iso_ignition_show(c),
                 IsoIgnitionCmd::Remove(c) => live::iso_ignition_remove(c),
             },
+            IsoCmd::Network(c) => match c {
+                IsoNetworkCmd::Embed(c) => live::iso_network_embed(c),
+                IsoNetworkCmd::Extract(c) => live::iso_network_extract(c),
+                IsoNetworkCmd::Remove(c) => live::iso_network_remove(c),
+            },
             IsoCmd::Kargs(c) => match c {
                 IsoKargsCmd::Modify(c) => live::iso_kargs_modify(c),
                 IsoKargsCmd::Reset(c) => live::iso_kargs_reset(c),
@@ -54,6 +59,10 @@ fn main() -> Result<()> {
             PxeCmd::Ignition(c) => match c {
                 PxeIgnitionCmd::Wrap(c) => live::pxe_ignition_wrap(c),
                 PxeIgnitionCmd::Unwrap(c) => live::pxe_ignition_unwrap(c),
+            },
+            PxeCmd::Network(c) => match c {
+                PxeNetworkCmd::Wrap(c) => live::pxe_network_wrap(c),
+                PxeNetworkCmd::Unwrap(c) => live::pxe_network_unwrap(c),
             },
         },
     }

--- a/tests/iso-ignition.sh
+++ b/tests/iso-ignition.sh
@@ -94,6 +94,28 @@ rm "${out_iso}"
 (large_config | coreos-installer iso ignition embed -o "${out_iso}" "${iso}" 2>&1 ||:) | grep -q "too large"
 (large_config | coreos-installer iso ignition embed "${iso}" 2>&1 ||:) | grep -q "too large"
 
+# Check that Ignition configs work independently of network configs
+echo "foo=baz" > one.nmconnection
+echo "bar=baz" > two.nmconnection
+coreos-installer iso network embed -k one.nmconnection -k two.nmconnection "${iso}"
+(coreos-installer iso ignition show "${iso}" 2>&1 ||:) | grep -q "No embedded Ignition config"
+coreos-installer iso ignition embed -i <(echo "${config}") "${iso}" -o "${out_iso}"
+coreos-installer iso ignition show "${out_iso}" | cmp - <(echo "${config}")
+coreos-installer iso network extract "${out_iso}" | grep -q "foo=baz"
+coreos-installer iso network extract "${out_iso}" | grep -q "bar=baz"
+coreos-installer iso ignition embed -i <(echo "${config}") "${iso}" -f
+coreos-installer iso network extract "${out_iso}" | grep -q "foo=baz"
+rm "${out_iso}"
+coreos-installer iso ignition remove "${iso}" -o "${out_iso}"
+coreos-installer iso network extract "${out_iso}" | grep -q "foo=baz"
+coreos-installer iso ignition remove "${iso}"
+coreos-installer iso network extract "${out_iso}" | grep -q "foo=baz"
+(coreos-installer iso ignition show "${iso}" 2>&1 ||:) | grep -q "No embedded Ignition config"
+coreos-installer iso network remove "${iso}"
+# verify we haven't written an empty cpio archive
+dd if="${iso}" skip="${offset}" count="${length}" bs=1 status=none | cmp -n "${length}" - /dev/zero
+rm "${out_iso}"
+
 # Clobber the **kargs** header magic and make sure we still succeed
 dd if=/dev/zero of="${iso}" seek=32672 count=8 bs=1 conv=notrunc status=none
 coreos-installer iso ignition embed -i <(echo "${config}") "${iso}" -o "${out_iso}"

--- a/tests/iso-network.sh
+++ b/tests/iso-network.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+set -xeuo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+digest() {
+    # Ignore filename
+    sha256sum "${1:--}" | awk '{print $1}'
+}
+
+check() {
+    rm -rf extract
+    coreos-installer iso network extract -C extract "$1" > /dev/null
+    if ! diff -ur src extract; then
+        return 1
+    fi
+}
+
+iso=$1; shift
+iso=$(realpath "${iso}")
+
+tmpd=$(mktemp -d)
+trap 'rm -rf "${tmpd}"' EXIT
+cd "${tmpd}"
+
+if [ "${iso%.xz}" != "${iso}" ]; then
+    xz -dc "${iso}" > test.iso
+else
+    cp --reflink=auto "${iso}" "test.iso"
+fi
+iso=test.iso
+out_iso="${iso}.out"
+orig_hash=$(digest "${iso}")
+
+mkdir src
+cat > src/a.nmconnection <<EOF
+[connection]
+id=a
+EOF
+cat > src/b.nmconnection <<EOF
+[connection]
+id=b
+EOF
+embed="-k src/b.nmconnection -k src/a.nmconnection"
+
+# Test all the modification operations.
+stdout_hash=$(coreos-installer iso network embed ${embed} -o - "${iso}" | tee "${out_iso}" | digest)
+check "${out_iso}"
+rm "${out_iso}"
+coreos-installer iso network embed ${embed} "${iso}" -o "${out_iso}"
+check "${out_iso}"
+hash=$(digest "${out_iso}")
+if [ "${stdout_hash}" != "${hash}" ]; then
+    fatal "Streamed hash doesn't match copied hash: ${stdout_hash} vs ${hash}"
+fi
+coreos-installer iso network embed ${embed} "${iso}"
+check "${iso}"
+hash=$(digest "${iso}")
+if [ "${stdout_hash}" != "${hash}" ]; then
+    fatal "Streamed hash doesn't match modified hash: ${stdout_hash} vs ${hash}"
+fi
+
+# Test forcing
+(coreos-installer iso network embed ${embed} "${iso}" 2>&1 ||:) | grep -q "already has embedded network settings"
+coreos-installer iso network embed -f ${embed} "${iso}"
+rm "${out_iso}"
+(coreos-installer iso network embed ${embed} "${iso}" -o "${out_iso}" 2>&1 ||:) | grep -q "already has embedded network settings"
+coreos-installer iso network embed -f ${embed} "${iso}" -o "${out_iso}"
+(coreos-installer iso network embed ${embed} "${iso}" -o - 2>&1 ||:) | grep -q "already has embedded network settings"
+coreos-installer iso network embed -f ${embed} "${iso}" -o - >/dev/null
+
+# Test `extract` to stdout
+coreos-installer iso network extract "${iso}" | grep -q "id=a"
+coreos-installer iso network extract "${iso}" | grep -q "id=b"
+
+# Test `remove`
+hash=$(coreos-installer iso network remove "${iso}" -o - | digest)
+if [ "${orig_hash}" != "${hash}" ]; then
+    fatal "Hash doesn't match original hash: ${hash} vs ${orig_hash}"
+fi
+rm "${out_iso}"
+coreos-installer iso network remove "${iso}" -o "${out_iso}"
+hash=$(digest "${out_iso}")
+if [ "${orig_hash}" != "${hash}" ]; then
+    fatal "Hash doesn't match original hash: ${hash} vs ${orig_hash}"
+fi
+coreos-installer iso network remove "${iso}"
+hash=$(digest "${iso}")
+if [ "${orig_hash}" != "${hash}" ]; then
+    fatal "Hash doesn't match original hash: ${hash} vs ${orig_hash}"
+fi
+
+# Check that network configs work independently of Ignition configs
+echo '{"ignition": {"version": "3.0.0"}' | coreos-installer iso ignition embed "${iso}"
+(coreos-installer iso network extract "${iso}" 2>&1 ||:) | grep -q "No embedded network settings"
+rm "${out_iso}"
+coreos-installer iso network embed ${embed} "${iso}" -o "${out_iso}"
+check "${out_iso}"
+coreos-installer iso ignition show "${out_iso}" | grep -q "version"
+coreos-installer iso network embed ${embed} "${iso}"
+coreos-installer iso ignition show "${iso}" | grep -q "version"
+rm "${out_iso}"
+coreos-installer iso network remove "${iso}" -o "${out_iso}"
+coreos-installer iso ignition show "${out_iso}" | grep -q "version"
+coreos-installer iso network remove "${iso}"
+coreos-installer iso ignition show "${iso}" | grep -q "version"
+(coreos-installer iso network extract "${iso}" 2>&1 ||:) | grep -q "No embedded network settings"
+coreos-installer iso ignition remove "${iso}"
+# verify we haven't written an empty cpio archive
+offset=$(coreos-installer iso ignition show --header "${iso}" | jq -r .offset)
+length=$(coreos-installer iso ignition show --header "${iso}" | jq -r .length)
+dd if="${iso}" skip="${offset}" count="${length}" bs=1 status=none | cmp -n "${length}" - /dev/zero
+rm "${out_iso}"
+
+# Clobber the **kargs** header magic and make sure we still succeed
+dd if=/dev/zero of="${iso}" seek=32672 count=8 bs=1 conv=notrunc status=none
+coreos-installer iso network embed ${embed} "${iso}" -o "${out_iso}"
+coreos-installer iso network embed ${embed} "${iso}" -o - >/dev/null
+coreos-installer iso network embed ${embed} "${iso}"
+coreos-installer iso network extract "${iso}" >/dev/null
+coreos-installer iso network remove "${iso}" -o - >/dev/null
+rm "${out_iso}"
+coreos-installer iso network remove "${iso}" -o "${out_iso}"
+coreos-installer iso network remove "${iso}"
+
+# Done
+echo "Success."


### PR DESCRIPTION
An Ignition config for the live system might want to fetch remote resources, and the system might need non-default network configuration to do so.  This is possible in a limited way with kargs, but it's better to expose the full flexibility of NetworkManager keyfiles.

Add `iso` subcommands to `embed`/`extract`/`remove` network settings, and `pxe` subcommands to `wrap`/`unwrap` them.  These are analogous to the Ignition embed mechanism, and in the case of ISO images they share the same initrd and embed area.  NetworkManager keyfiles are deposited into `/etc/coreos-firstboot-network` in the initrd, which is supported by the OS
as of https://github.com/coreos/fedora-coreos-config/pull/1371.

The show/unwrap subcommands are a bit different than the Ignition ones, since there might be multiple keyfiles in an initrd.  By default, print each keyfile to stdout, with a header listing the filename.  Also provide a `-C`/`--directory` option to extract each keyfile to a directory.  Because `show` doesn't completely capture the command's functionality, call the ISO subcommand `iso network extract` instead.

Fixes #545.