### PR TITLE
cargo: coreos-installer release 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -166,7 +166,7 @@ dependencies = [
  "libc",
  "maplit",
  "mbrman",
- "nix 0.23.1",
+ "nix",
  "openat-ext",
  "openssl",
  "pipe",
@@ -403,7 +403,7 @@ checksum = "f5a6ef4b3fdbdf3d312de4fb312ea65d2e58cc046a7554742dbf8eccc49eb0c5"
 dependencies = [
  "bincode",
  "crc",
- "nix 0.22.0",
+ "nix",
  "serde",
  "thiserror",
 ]
@@ -743,19 +743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,7 +783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ebe55c8d6ada962ca7ddaef14f020dae1af91748bea3d36e8c941036b5d85b"
 dependencies = [
  "libc",
- "nix 0.22.0",
+ "nix",
  "openat",
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.11.0"
+version = "0.12.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- Add high-level [`iso customize`](https://coreos.github.io/coreos-installer/cmd/iso/#coreos-installer-iso-customize) and [`pxe customize`](https://coreos.github.io/coreos-installer/cmd/pxe/#coreos-installer-pxe-customize) subcommands for flexibly customizing a live image
- install: Add `--config-file` to specify install options via a YAML [config file](https://coreos.github.io/coreos-installer/customizing-install/#config-file-format)
- systemd: Automatically install if config files exist in `/etc/coreos/installer.d`
- Add [`iso network`](https://coreos.github.io/coreos-installer/cmd/iso/#coreos-installer-iso-network-embed) and [`pxe network`](https://coreos.github.io/coreos-installer/cmd/pxe/#coreos-installer-pxe-network-wrap) subcommands to embed NetworkManager configs in an ISO or wrap them in an initrd

Minor changes:

- Add [`iso reset`](https://coreos.github.io/coreos-installer/cmd/iso/#coreos-installer-iso-reset) subcommand to reset an ISO image to pristine state
- Differentiate `-h` and `--help`.  `--help` will produce longer-form documentation, similar to a man page.  Add long help to `install` and `iso/pxe customize`.
- pxe: Have [`ignition unwrap`](https://coreos.github.io/coreos-installer/cmd/pxe/#coreos-installer-pxe-ignition-unwrap) read from stdin if no filename specified
- pxe: Support [`ignition unwrap`](https://coreos.github.io/coreos-installer/cmd/pxe/#coreos-installer-pxe-ignition-unwrap) from concatenated initrds
- systemd: Print deprecation warning on `coreos.inst=yes`
- systemd: Print deprecation warning if `coreos.inst.install_dev` value omits `/dev`
- docs: Autogenerate [subcommand pages](https://coreos.github.io/coreos-installer/cmd/) from help text
- docs: Remove instructions for replacing `coreos-installer.service`, in favor of `installer.d` config files

Internal changes:

- Fix packing minimal ISO with hard-linked files
- bind-boot: Ignore ESPs not colocated with the boot filesystem
- rootmap: Properly handle linear RAID devices

Packaging changes:

- Add `base64`, `ignition-config`, `serde_with`, and `serde_yaml` dependencies
- Enable `structopt` `wrap_help` feature