### PR TITLE
Disable LTO; disable debug symbols in container build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ path = "src/bin/rdcore/main.rs"
 required-features = ["rdcore"]
 
 [profile.release]
-lto = true
 # We assume we're being delivered via e.g. RPM which supports split debuginfo
 debug = true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ RUN dnf install -y cargo openssl-devel xz-devel
 WORKDIR /build
 COPY Cargo.* ./
 COPY src src/
+# Debug symbols are nice but they're not 100+ MB of nice
+RUN sed -i 's/^debug = true$/debug = false/' Cargo.toml
 RUN cargo build --release
 
 FROM registry.fedoraproject.org/fedora:35

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ RUN dnf install -y cargo openssl-devel xz-devel
 WORKDIR /build
 COPY Cargo.* ./
 COPY src src/
-# Disable LTO to avoid OOM in Quay
-RUN sed -i 's/^lto = true$/lto = false/' Cargo.toml
 RUN cargo build --release
 
 FROM registry.fedoraproject.org/fedora:35


### PR DESCRIPTION
LTO saves us 1.5 MB (11%) in the release binary with debug symbols disabled.  On the other hand it's been an enormous pain.  The RHCOS package disables LTO because of problems on s390x.  Quay and the Fedora armv7hl builders apparently OOM building 0.12.0 with LTO.  And it's not a default option in the first place.  Get rid of it.

Meanwhile, our binary size in the container is now 125 MB.  Disable debug symbols there to bring it down to 13 MB.  Symbols can make it easier to debug problems in production, but our bug reports don't generally take advantage of that, and the space requirement is excessive.