### PR TITLE
add flag for rereading partition table

### DIFF
--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -115,4 +115,8 @@ pub struct VerifyUniqueFsLabelConfig {
     /// Filesystem's label
     #[structopt(value_name = "LABEL")]
     pub label: String,
+
+    /// Force rereading of partition table
+    #[structopt(long)]
+    pub rereadpt: bool,
 }

--- a/src/bin/rdcore/unique_fs.rs
+++ b/src/bin/rdcore/unique_fs.rs
@@ -18,7 +18,7 @@ use anyhow::{bail, Result};
 use libcoreinst::blockdev::*;
 
 pub fn verify_unique_fs(config: VerifyUniqueFsLabelConfig) -> Result<()> {
-    let pts = get_filesystems_with_label(&config.label)?;
+    let pts = get_filesystems_with_label(&config.label, config.rereadpt)?;
     let count = pts.len();
     if count != 1 {
         bail!(

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -801,11 +801,11 @@ pub fn lsblk_single(dev: &Path) -> Result<HashMap<String, String>> {
     Ok(devinfos.remove(0))
 }
 
-/// Rereads partition table and than returns all available filesystems
-/// rereading mitigates possble issue with outdated UUIDs on different
+/// Returns all available filesystems.
+/// rereadpt mitigates possible issue with outdated UUIDs on different
 /// paths to the same disk: after 'ignition-ostree-firstboot-uuid'
 /// '/dev/sdaX' path gets new UUID, but '/dev/sdbX/' path has an old one
-fn lsblk_all_and_reread_partition_tables() -> Result<Vec<HashMap<String, String>>> {
+fn lsblk_all(rereadpt: bool) -> Result<Vec<HashMap<String, String>>> {
     let mut cmd = Command::new("lsblk");
     cmd.arg("--noheadings")
         .arg("--nodeps")
@@ -814,12 +814,14 @@ fn lsblk_all_and_reread_partition_tables() -> Result<Vec<HashMap<String, String>
         .arg("--output")
         .arg("NAME");
     let output = cmd_output(&mut cmd)?;
-    for dev in output.lines() {
-        if let Ok(mut fd) = std::fs::File::open(dev) {
-            let _ = reread_partition_table(&mut fd);
+    if rereadpt {
+        for dev in output.lines() {
+            if let Ok(mut fd) = std::fs::File::open(dev) {
+                let _ = reread_partition_table(&mut fd);
+            }
         }
+        udev_settle()?;
     }
-    udev_settle()?;
     let mut result: Vec<HashMap<String, String>> = Vec::new();
     for dev in output.lines() {
         let mut info = lsblk(Path::new(dev), true)?;
@@ -830,9 +832,9 @@ fn lsblk_all_and_reread_partition_tables() -> Result<Vec<HashMap<String, String>
 
 /// Returns filesystems with given label.
 /// If multiple filesystems with the label have the same UUID, we only return one of them.
-pub fn get_filesystems_with_label(label: &str) -> Result<Vec<String>> {
+pub fn get_filesystems_with_label(label: &str, rereadpt: bool) -> Result<Vec<String>> {
     let mut uuids = HashSet::new();
-    let result = lsblk_all_and_reread_partition_tables()?
+    let result = lsblk_all(rereadpt)?
         .iter()
         .filter(|v| v.get("LABEL").map(|l| l.as_str()) == Some(label))
         .filter(|v| match v.get("UUID") {

--- a/src/install.rs
+++ b/src/install.rs
@@ -250,7 +250,7 @@ pub fn install(config: InstallConfig) -> Result<()> {
     // Because grub picks /boot by label and the OS picks /boot, we can end up racing/flapping
     // between picking a /boot partition on startup. So check amount of filesystems labeled 'boot'
     // and warn user if it's not only one
-    match get_filesystems_with_label("boot") {
+    match get_filesystems_with_label("boot", true) {
         Ok(pts) => {
             if pts.len() > 1 {
                 let rootdev = std::fs::canonicalize(device)


### PR DESCRIPTION
Partition table rereading is not always needed,
so it's beeter to let user decide if such behaviour
is required, i.e. after some changes were made to
filesystems, like change of UUID.