### PR TITLE
workflows: run tests in Fedora container; add s390x tests via qemu-user

### DIFF
--- a/.github/workflows/env-setup
+++ b/.github/workflows/env-setup
@@ -2,6 +2,30 @@
 
 set -euxo pipefail
 
+# Start the job container
+mkdir ~/ctx
+CID=$(podman create -v ${GITHUB_WORKSPACE}:/workspace -v ~/ctx:/ctx \
+    "${CONTAINER}" tail -f /dev/null)
+podman start ${CID}
+
+# Build the wrapper script that will be used as a shell by subsequent job steps
+sudo tee /usr/bin/wrap-container > /dev/null <<EOF
+#!/bin/bash
+set -euxo pipefail
+script=$(mktemp ~/ctx/script-XXXXXX)
+cp "\$1" "\${script}"
+chmod +x "\${script}"
+# Use the same shell invocation that GitHub Actions does
+podman exec -w /workspace -e PATH="/root/.cargo/bin:/usr/sbin:/usr/bin:/sbin:/bin" ${CID} \
+    bash --noprofile --norc -eo pipefail "/ctx/\$(basename \${script})"
+EOF
+sudo chmod +x /usr/bin/wrap-container
+
+# Use it to install the requested Rust version
+wrap-container <(cat <<EOF
+set -x
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
     sh -s -- --default-toolchain ${TOOLCHAIN} --profile minimal \
     ${COMPONENTS:+--component ${COMPONENTS}} -y
+EOF
+)

--- a/.github/workflows/env-setup
+++ b/.github/workflows/env-setup
@@ -43,5 +43,7 @@ set -x
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
     sh -s -- --default-toolchain ${TOOLCHAIN} --profile minimal \
     ${COMPONENTS:+--component ${COMPONENTS}} -y
+rustc -V | cut -f2 -d\  > /ctx/toolchain-version
 EOF
 )
+echo "INSTALLED_TOOLCHAIN=$(cat ~/ctx/toolchain-version)" >> $GITHUB_ENV

--- a/.github/workflows/env-setup
+++ b/.github/workflows/env-setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+    sh -s -- --default-toolchain ${TOOLCHAIN} --profile minimal \
+    ${COMPONENTS:+--component ${COMPONENTS}} -y

--- a/.github/workflows/env-setup
+++ b/.github/workflows/env-setup
@@ -2,10 +2,26 @@
 
 set -euxo pipefail
 
+case "${ARCH}" in
+x86_64)
+    ARCH=amd64
+    ;;
+*)
+    # We need qemu-user-static.  Ubuntu 20.04 has it, but the s390x emulation
+    # causes segfaults in rustup-init.  Luckily it's statically linked, so
+    # extract the working Fedora package.
+    podman run --rm -v $HOME:/pwd -w /pwd "${CONTAINER}" \
+        sh -c "dnf install -y python3-dnf-plugins-core && dnf download qemu-user-static.x86_64"
+    rpm2cpio ~/qemu-user-static-*.x86_64.rpm |
+        sudo cpio -D / -i --make-directories
+    sudo systemctl restart systemd-binfmt
+    ;;
+esac
+
 # Start the job container
 mkdir ~/ctx
 CID=$(podman create -v ${GITHUB_WORKSPACE}:/workspace -v ~/ctx:/ctx \
-    "${CONTAINER}" tail -f /dev/null)
+    --arch="${ARCH}" "${CONTAINER}" tail -f /dev/null)
 podman start ${CID}
 
 # Build the wrapper script that will be used as a shell by subsequent job steps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,12 +9,18 @@ permissions:
   contents: read
 
 env:
+  CONTAINER: registry.fedoraproject.org/fedora:latest
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   # Minimum supported Rust version (MSRV)
   ACTIONS_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
   ACTIONS_LINTS_TOOLCHAIN: 1.57.0
+
+defaults:
+  run:
+    # Created by env-setup early in the job
+    shell: 'wrap-container {0}'
 
 jobs:
   tests-stable:
@@ -25,8 +31,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up environment
         run: .github/workflows/env-setup
+        shell: bash
         env:
           TOOLCHAIN: stable
+      - name: Install dependencies
+        run: dnf install -y gcc openssl-devel cpio diffutils jq xz
       - name: cargo build
         run: cargo build
       - name: cargo test
@@ -45,8 +54,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up environment
         run: .github/workflows/env-setup
+        shell: bash
         env:
           TOOLCHAIN: ${{ env.ACTIONS_MSRV_TOOLCHAIN }}
+      - name: Install dependencies
+        run: dnf install -y gcc openssl-devel cpio diffutils jq xz
       - name: cargo build
         run: cargo build
       - name: cargo test
@@ -65,9 +77,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up environment
         run: .github/workflows/env-setup
+        shell: bash
         env:
           TOOLCHAIN: ${{ env.ACTIONS_LINTS_TOOLCHAIN }}
           COMPONENTS: rustfmt,clippy
+      - name: Install dependencies
+        run: dnf install -y gcc openssl-devel
       - name: cargo fmt (check)
         run: cargo fmt -- --check -l
       - name: cargo clippy (warnings)
@@ -88,8 +103,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up environment
         run: .github/workflows/env-setup
+        shell: bash
         env:
           TOOLCHAIN: ${{ matrix.channel }}
+      - name: Install dependencies
+        run: dnf install -y gcc openssl-devel cpio diffutils jq xz
       - name: cargo build
         run: cargo build
       - name: cargo test
@@ -108,8 +126,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up environment
         run: .github/workflows/env-setup
+        shell: bash
         env:
           TOOLCHAIN: stable
+      - name: Install dependencies
+        run: dnf install -y gcc openssl-devel util-linux
       - name: cargo build
         run: cargo build
       - name: Help text line length

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,11 +23,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: "stable"
-          default: true
+      - name: Set up environment
+        run: .github/workflows/env-setup
+        env:
+          TOOLCHAIN: stable
       - name: cargo build
         run: cargo build
       - name: cargo test
@@ -44,11 +43,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env['ACTIONS_MSRV_TOOLCHAIN']  }}
-          default: true
+      - name: Set up environment
+        run: .github/workflows/env-setup
+        env:
+          TOOLCHAIN: ${{ env.ACTIONS_MSRV_TOOLCHAIN }}
       - name: cargo build
         run: cargo build
       - name: cargo test
@@ -65,12 +63,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env['ACTIONS_LINTS_TOOLCHAIN']  }}
-          default: true
-          components: rustfmt, clippy
+      - name: Set up environment
+        run: .github/workflows/env-setup
+        env:
+          TOOLCHAIN: ${{ env.ACTIONS_LINTS_TOOLCHAIN }}
+          COMPONENTS: rustfmt,clippy
       - name: cargo fmt (check)
         run: cargo fmt -- --check -l
       - name: cargo clippy (warnings)
@@ -89,11 +86,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.channel }}
-          default: true
+      - name: Set up environment
+        run: .github/workflows/env-setup
+        env:
+          TOOLCHAIN: ${{ matrix.channel }}
       - name: cargo build
         run: cargo build
       - name: cargo test
@@ -110,11 +106,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: "stable"
-          default: true
+      - name: Set up environment
+        run: .github/workflows/env-setup
+        env:
+          TOOLCHAIN: stable
       - name: cargo build
         run: cargo build
       - name: Help text line length

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,11 @@ jobs:
   tests-stable:
     name: "Tests, stable toolchain"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - x86_64
+          - s390x
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -33,6 +38,7 @@ jobs:
         run: .github/workflows/env-setup
         shell: bash
         env:
+          ARCH: ${{ matrix.arch }}
           TOOLCHAIN: stable
       - name: Install dependencies
         run: dnf install -y gcc openssl-devel cpio diffutils jq xz
@@ -45,10 +51,16 @@ jobs:
       - name: cargo test (rdcore)
         run: cargo test --features rdcore
       - name: Image tests
+        if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh
   tests-msrv:
     name: "Tests, minimum supported toolchain"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - x86_64
+          - s390x
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -56,6 +68,7 @@ jobs:
         run: .github/workflows/env-setup
         shell: bash
         env:
+          ARCH: ${{ matrix.arch }}
           TOOLCHAIN: ${{ env.ACTIONS_MSRV_TOOLCHAIN }}
       - name: Install dependencies
         run: dnf install -y gcc openssl-devel cpio diffutils jq xz
@@ -68,10 +81,16 @@ jobs:
       - name: cargo test (rdcore)
         run: cargo test --features rdcore
       - name: Image tests
+        if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh
   lints:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - x86_64
+          - s390x
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -79,6 +98,7 @@ jobs:
         run: .github/workflows/env-setup
         shell: bash
         env:
+          ARCH: ${{ matrix.arch }}
           TOOLCHAIN: ${{ env.ACTIONS_LINTS_TOOLCHAIN }}
           COMPONENTS: rustfmt,clippy
       - name: Install dependencies
@@ -98,6 +118,8 @@ jobs:
         channel:
           - "beta"
           - "nightly"
+        arch:
+          - x86_64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -105,6 +127,7 @@ jobs:
         run: .github/workflows/env-setup
         shell: bash
         env:
+          ARCH: ${{ matrix.arch }}
           TOOLCHAIN: ${{ matrix.channel }}
       - name: Install dependencies
         run: dnf install -y gcc openssl-devel cpio diffutils jq xz
@@ -117,6 +140,7 @@ jobs:
       - name: cargo test (rdcore)
         run: cargo test --features rdcore
       - name: Image tests
+        if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh
   docs:
     name: "Docs"
@@ -128,6 +152,7 @@ jobs:
         run: .github/workflows/env-setup
         shell: bash
         env:
+          ARCH: x86_64
           TOOLCHAIN: stable
       - name: Install dependencies
         run: dnf install -y gcc openssl-devel util-linux

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,12 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           TOOLCHAIN: stable
+      - name: Cache build artifacts
+        if: ${{ matrix.arch == 's390x' }}
+        uses: actions/cache@v2
+        with:
+          path: target/debug
+          key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
       - name: Install dependencies
         run: dnf install -y gcc openssl-devel cpio diffutils jq xz
       - name: cargo build
@@ -53,6 +59,8 @@ jobs:
       - name: Image tests
         if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh
+      - name: Clean up cache
+        run: "rm -rf target/debug/{*inst*,examples,incremental,deps/*inst*}"
   tests-msrv:
     name: "Tests, minimum supported toolchain"
     runs-on: ubuntu-latest
@@ -70,6 +78,12 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           TOOLCHAIN: ${{ env.ACTIONS_MSRV_TOOLCHAIN }}
+      - name: Cache build artifacts
+        if: ${{ matrix.arch == 's390x' }}
+        uses: actions/cache@v2
+        with:
+          path: target/debug
+          key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
       - name: Install dependencies
         run: dnf install -y gcc openssl-devel cpio diffutils jq xz
       - name: cargo build
@@ -83,6 +97,8 @@ jobs:
       - name: Image tests
         if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh
+      - name: Clean up cache
+        run: "rm -rf target/debug/{*inst*,examples,incremental,deps/*inst*}"
   lints:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest
@@ -101,6 +117,12 @@ jobs:
           ARCH: ${{ matrix.arch }}
           TOOLCHAIN: ${{ env.ACTIONS_LINTS_TOOLCHAIN }}
           COMPONENTS: rustfmt,clippy
+      - name: Cache build artifacts
+        if: ${{ matrix.arch == 's390x' }}
+        uses: actions/cache@v2
+        with:
+          path: target/debug
+          key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}-lints
       - name: Install dependencies
         run: dnf install -y gcc openssl-devel
       - name: cargo fmt (check)
@@ -109,6 +131,8 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: cargo clippy (rdcore, warnings)
         run: cargo clippy --features rdcore -- -D warnings
+      - name: Clean up cache
+        run: "rm -rf target/debug/{*inst*,examples,incremental,deps/*inst*}"
   tests-other-channels:
     name: "Tests, unstable toolchain"
     runs-on: ubuntu-latest
@@ -129,6 +153,12 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           TOOLCHAIN: ${{ matrix.channel }}
+      - name: Cache build artifacts
+        if: ${{ matrix.arch == 's390x' }}
+        uses: actions/cache@v2
+        with:
+          path: target/debug
+          key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
       - name: Install dependencies
         run: dnf install -y gcc openssl-devel cpio diffutils jq xz
       - name: cargo build
@@ -142,6 +172,8 @@ jobs:
       - name: Image tests
         if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh
+      - name: Clean up cache
+        run: "rm -rf target/debug/{*inst*,examples,incremental,deps/*inst*}"
   docs:
     name: "Docs"
     runs-on: ubuntu-latest

--- a/src/s390x/fba.rs
+++ b/src/s390x/fba.rs
@@ -25,7 +25,7 @@ pub(crate) fn fba_make_partitions(
     device: &mut File,
     first_mb: &[u8],
 ) -> Result<Vec<Range>> {
-    let bytes_per_block = get_sector_size(&device)?.get();
+    let bytes_per_block = get_sector_size(device)?.get();
     let partitions = partitions_from_gpt_header(bytes_per_block as u64, first_mb)?;
     let mut ranges = Vec::new();
     let mut mbr = MBR::new_from(device, bytes_per_block, rand::random())

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -103,7 +103,7 @@ fn extract_firstboot_kargs(s: &str) -> Result<Option<String>> {
 
     let captures = Regex::new(r#"^set ignition_network_kcmdline="([^\n]*)"$"#)
         .expect("compiling RE")
-        .captures(&s)
+        .captures(s)
         .context("couldn't parse kargs from ignition.firstboot file")?;
     match captures.get(1).expect("kargs").as_str() {
         "" => Ok(None), // this shouldn't really happen, but be nice


### PR DESCRIPTION
Run s390x tests in a Fedora container via a Fedora `qemu-user` static binary (since that one works, unlike the one in `ubuntu-latest`).  We can't use `actions-rs/toolchain` with an s390x container, so download and run `rustup` manually as well.  For consistency, use a Fedora container and manual `rustup` in the x86_64 tests too.

This gets us the s390x build, unit test, and lint coverage that we've been missing since switching away from Travis.