### PR TITLE
Replace structopt with clap 3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1229,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
  "terminal_size",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,30 +18,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -117,18 +97,31 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
- "term_size",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "terminal_size",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -156,6 +149,7 @@ dependencies = [
  "bincode",
  "byte-unit",
  "bytes",
+ "clap",
  "cpio",
  "flate2",
  "glob",
@@ -176,7 +170,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "structopt",
  "tempfile",
  "thiserror",
  "url",
@@ -255,7 +248,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -443,12 +436,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -831,6 +821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1183,45 +1182,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1249,10 +1218,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
+name = "terminal_size"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
@@ -1260,12 +1229,11 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
- "term_size",
- "unicode-width",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1393,18 +1361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,12 +1398,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ base64 = "0.13"
 bincode = "^1.3"
 bytes = ">= 1.0.1, < 1.2.0"
 byte-unit = ">= 3.1.0, < 5.0.0"
+clap = { version = "3.0", default-features = false, features = ["std", "cargo", "derive", "suggestions", "wrap_help"] }
 cpio = "0.2.1"
 flate2 = "^1.0"
 glob = "^0.3"
@@ -61,7 +62,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_with = ">= 1.9.4, < 2"
 serde_yaml = "0.8"
-structopt = { version = "0.3", features = ["wrap_help"] }
 tempfile = ">= 3.1, < 4"
 thiserror = "1.0"
 url = ">= 2.1, < 3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ base64 = "0.13"
 bincode = "^1.3"
 bytes = ">= 1.0.1, < 1.2.0"
 byte-unit = ">= 3.1.0, < 5.0.0"
-clap = { version = "3.0", default-features = false, features = ["std", "cargo", "derive", "suggestions", "wrap_help"] }
+clap = { version = "3.1", default-features = false, features = ["std", "cargo", "derive", "suggestions", "wrap_help"] }
 cpio = "0.2.1"
 flate2 = "^1.0"
 glob = "^0.3"

--- a/docs/cmd/download.md
+++ b/docs/cmd/download.md
@@ -22,5 +22,5 @@ OPTIONS:
         --insecure                 Skip signature verification
         --stream-base-url <URL>    Base URL for Fedora CoreOS stream metadata
         --fetch-retries <N>        Fetch retries, or "infinite" [default: 0]
-    -h, --help                     Prints help information
+    -h, --help                     Print help information
 ```

--- a/docs/cmd/install.md
+++ b/docs/cmd/install.md
@@ -85,7 +85,7 @@ OPTIONS:
             Copy NetworkManager keyfiles from the install environment to the installed system.
 
         --network-dir <path>
-            For use with -n
+            Override NetworkManager keyfile dir for -n
 
             Specify the path to NetworkManager keyfiles to be copied with --copy-network.
 

--- a/docs/cmd/install.md
+++ b/docs/cmd/install.md
@@ -9,10 +9,17 @@ nav_order: 1
 Install Fedora CoreOS or RHEL CoreOS
 
 USAGE:
-    coreos-installer install [OPTIONS] <dest-device>
+    coreos-installer install [OPTIONS] [--] [DEST_DEVICE]
+
+ARGS:
+    <DEST_DEVICE>
+            Destination device
+
+            Path to the device node for the destination disk.  The beginning of the device will
+            be overwritten without further confirmation.
 
 OPTIONS:
-    -c, --config-file <path>...
+    -c, --config-file <path>
             YAML config file with install options
 
             Load additional config options from the specified YAML config file. Later config
@@ -21,11 +28,13 @@ OPTIONS:
             Config file keys are long option names without the leading "--". Values are strings
             for non-repeatable options, arrays of strings for repeatable options, and "true"
             for flags.  The destination device can be specified with the "dest-device" key.
+
     -s, --stream <name>
             Fedora CoreOS stream
 
             The name of the Fedora CoreOS stream to install, such as "stable", "testing", or
             "next".
+
     -u, --image-url <URL>
             Manually specify the image URL
 
@@ -40,42 +49,52 @@ OPTIONS:
 
             Immediately fetch the Ignition config from the URL and embed it in the installed
             system.
+
         --ignition-hash <digest>
             Digest (type-value) of the Ignition config
 
             Verify that the Ignition config matches the specified digest, formatted as
             <type>-<hexvalue>.  <type> can be sha256 or sha512.
+
     -a, --architecture <name>
             Target CPU architecture
 
-            Create an install disk for a different CPU architecture than the host. [default:
-            x86_64]
+            Create an install disk for a different CPU architecture than the host.
+
+            [default: x86_64]
+
     -p, --platform <name>
             Override the Ignition platform ID
 
             Install a system that will run on the specified cloud or virtualization platform,
             such as "vmware".
-        --append-karg <arg>...
+
+        --append-karg <arg>
             Append default kernel arg
 
             Add a kernel argument to the installed system.
-        --delete-karg <arg>...
+
+        --delete-karg <arg>
             Delete default kernel arg
 
             Delete a default kernel argument from the installed system.
+
     -n, --copy-network
             Copy network config from install environment
 
             Copy NetworkManager keyfiles from the install environment to the installed system.
+
         --network-dir <path>
             For use with -n
 
             Specify the path to NetworkManager keyfiles to be copied with --copy-network.
+
             [default: /etc/NetworkManager/system-connections/]
-        --save-partlabel <lx>...
+
+        --save-partlabel <lx>
             Save partitions with this label glob
 
-        --save-partindex <id>...
+        --save-partindex <id>
             Save partitions with this number or range
 
         --offline
@@ -92,25 +111,22 @@ OPTIONS:
 
             Override the base URL for fetching CoreOS stream metadata. The default is
             "https://builds.coreos.fedoraproject.org/streams/".
+
         --preserve-on-error
             Don't clear partition table on error
 
             If installation fails, coreos-installer normally clears the destination's partition
             table to prevent booting from invalid boot media.  Skip clearing the partition
             table as a debugging aid.
+
         --fetch-retries <N>
             Fetch retries, or "infinite"
 
             Number of times to retry network fetches, or the string "infinite" to retry
-            indefinitely. [default: 0]
+            indefinitely.
+
+            [default: 0]
+
     -h, --help
-            Prints help information
-
-
-ARGS:
-    <dest-device>
-            Destination device
-
-            Path to the device node for the destination disk.  The beginning of the device will
-            be overwritten without further confirmation.
+            Print help information
 ```

--- a/docs/cmd/install.md
+++ b/docs/cmd/install.md
@@ -97,6 +97,10 @@ OPTIONS:
         --save-partindex <id>
             Save partitions with this number or range
 
+    -h, --help
+            Print help information
+
+ADVANCED OPTIONS:
         --offline
             Force offline installation
 
@@ -126,7 +130,4 @@ OPTIONS:
             indefinitely.
 
             [default: 0]
-
-    -h, --help
-            Print help information
 ```

--- a/docs/cmd/iso.md
+++ b/docs/cmd/iso.md
@@ -17,73 +17,90 @@ Customize a CoreOS live ISO image
 USAGE:
     coreos-installer iso customize [OPTIONS] <ISO>
 
+ARGS:
+    <ISO>
+            ISO image
+
 OPTIONS:
-        --dest-ignition <path>...
+        --dest-ignition <path>
             Ignition config fragment for dest sys
 
             Automatically run installer and merge the specified Ignition config into the config
             for the destination system.
+
         --dest-device <path>
             Install destination device
 
             Automatically run installer, installing to the specified destination device.  The
             resulting boot media will overwrite the destination device without confirmation.
-        --dest-karg-append <arg>...
+
+        --dest-karg-append <arg>
             Destination kernel argument to append
 
             Automatically run installer, adding the specified kernel argument for every boot of
             the destination system.
-        --dest-karg-delete <arg>...
+
+        --dest-karg-delete <arg>
             Destination kernel argument to delete
 
             Automatically run installer, deleting the specified kernel argument for every boot
             of the destination system.
-        --network-keyfile <path>...
+
+        --network-keyfile <path>
             NetworkManager keyfile for live & dest
 
             Configure networking using the specified NetworkManager keyfile. Network settings
             will be applied in the live environment, including when Ignition is run.  If
             installer is enabled via additional options, network settings will also be applied
             in the destination system, including when Ignition is run.
-        --ignition-ca <path>...
+
+        --ignition-ca <path>
             Ignition PEM CA bundle for live & dest
 
             Specify additional TLS certificate authorities to be trusted by Ignition, in PEM
             format.  Authorities will be trusted by Ignition in the live environment and, if
             installer is enabled via additional options, in the destination system.
-        --pre-install <path>...
+
+        --pre-install <path>
             Script to run before installation
 
             If installer is run at boot, run this script before installation. If the script
             fails, the live environment will stop at an emergency shell.
-        --post-install <path>...
+
+        --post-install <path>
             Script to run after installation
 
             If installer is run at boot, run this script after installation. If the script
             fails, the live environment will stop at an emergency shell.
-        --installer-config <path>...
+
+        --installer-config <path>
             Installer config file
 
             Automatically run coreos-installer and apply the specified installer config file.
             Config files are applied in the order that they are specified.
-        --live-ignition <path>...
+
+        --live-ignition <path>
             Ignition config fragment for live env
 
             Merge the specified Ignition config into the config for the live environment.
-        --live-karg-append <arg>...
+
+        --live-karg-append <arg>
             Live kernel argument to append
 
             Kernel argument to append to boots of the live environment.
-        --live-karg-delete <arg>...
+
+        --live-karg-delete <arg>
             Live kernel argument to delete
 
             Kernel argument to delete from boots of the live environment.
-        --live-karg-replace <k=o=n>...
+
+        --live-karg-replace <k=o=n>
             Live kernel argument to replace
 
             Kernel argument to replace for boots of the live environment, in the form
             key=old=new.  For a default argument "a=b", specifying "--live-karg-replace a=b=c"
             will produce the argument "a=c".
+
     -f, --force
             Overwrite existing customizations
 
@@ -91,13 +108,7 @@ OPTIONS:
             Write ISO to a new output file
 
     -h, --help
-            Prints help information
-
-
-ARGS:
-    <ISO>
-            ISO image
-
+            Print help information
 ```
 
 # coreos-installer iso ignition embed
@@ -108,14 +119,14 @@ Embed an Ignition config in an ISO image
 USAGE:
     coreos-installer iso ignition embed [OPTIONS] <ISO>
 
+ARGS:
+    <ISO>    ISO image
+
 OPTIONS:
     -f, --force                   Overwrite an existing Ignition config
     -i, --ignition-file <path>    Ignition config to embed [default: stdin]
     -o, --output <path>           Write ISO to a new output file
-    -h, --help                    Prints help information
-
-ARGS:
-    <ISO>    ISO image
+    -h, --help                    Print help information
 ```
 
 # coreos-installer iso ignition show
@@ -126,11 +137,11 @@ Show the embedded Ignition config from an ISO image
 USAGE:
     coreos-installer iso ignition show <ISO>
 
-OPTIONS:
-    -h, --help    Prints help information
-
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -h, --help    Print help information
 ```
 
 # coreos-installer iso ignition remove
@@ -139,14 +150,14 @@ ARGS:
 Remove an existing embedded Ignition config from an ISO image
 
 USAGE:
-    coreos-installer iso ignition remove <ISO>
-
-OPTIONS:
-    -o, --output <path>    Write ISO to a new output file
-    -h, --help             Prints help information
+    coreos-installer iso ignition remove [OPTIONS] <ISO>
 
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -o, --output <path>    Write ISO to a new output file
+    -h, --help             Print help information
 ```
 
 # coreos-installer iso network embed
@@ -155,16 +166,16 @@ ARGS:
 Embed network settings in an ISO image
 
 USAGE:
-    coreos-installer iso network embed [OPTIONS] <ISO> --keyfile <path>...
-
-OPTIONS:
-    -k, --keyfile <path>...    NetworkManager keyfile to embed
-    -f, --force                Overwrite existing network settings
-    -o, --output <path>        Write ISO to a new output file
-    -h, --help                 Prints help information
+    coreos-installer iso network embed [OPTIONS] --keyfile <path> <ISO>
 
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -k, --keyfile <path>    NetworkManager keyfile to embed
+    -f, --force             Overwrite existing network settings
+    -o, --output <path>     Write ISO to a new output file
+    -h, --help              Print help information
 ```
 
 # coreos-installer iso network extract
@@ -173,14 +184,14 @@ ARGS:
 Extract embedded network settings from an ISO image
 
 USAGE:
-    coreos-installer iso network extract <ISO>
-
-OPTIONS:
-    -C, --directory <path>    Extract to directory instead of stdout
-    -h, --help                Prints help information
+    coreos-installer iso network extract [OPTIONS] <ISO>
 
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -C, --directory <path>    Extract to directory instead of stdout
+    -h, --help                Print help information
 ```
 
 # coreos-installer iso network remove
@@ -189,14 +200,14 @@ ARGS:
 Remove existing network settings from an ISO image
 
 USAGE:
-    coreos-installer iso network remove <ISO>
-
-OPTIONS:
-    -o, --output <path>    Write ISO to a new output file
-    -h, --help             Prints help information
+    coreos-installer iso network remove [OPTIONS] <ISO>
 
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -o, --output <path>    Write ISO to a new output file
+    -h, --help             Print help information
 ```
 
 # coreos-installer iso kargs modify
@@ -205,17 +216,17 @@ ARGS:
 Modify kernel args in an ISO image
 
 USAGE:
-    coreos-installer iso kargs modify <ISO>
-
-OPTIONS:
-    -a, --append <KARG>...                   Kernel argument to append
-    -d, --delete <KARG>...                   Kernel argument to delete
-    -r, --replace <KARG=OLDVAL=NEWVAL>...    Kernel argument to replace
-    -o, --output <PATH>                      Write ISO to a new output file
-    -h, --help                               Prints help information
+    coreos-installer iso kargs modify [OPTIONS] <ISO>
 
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -a, --append <KARG>                   Kernel argument to append
+    -d, --delete <KARG>                   Kernel argument to delete
+    -r, --replace <KARG=OLDVAL=NEWVAL>    Kernel argument to replace
+    -o, --output <PATH>                   Write ISO to a new output file
+    -h, --help                            Print help information
 ```
 
 # coreos-installer iso kargs reset
@@ -224,14 +235,14 @@ ARGS:
 Reset kernel args in an ISO image to defaults
 
 USAGE:
-    coreos-installer iso kargs reset <ISO>
-
-OPTIONS:
-    -o, --output <PATH>    Write ISO to a new output file
-    -h, --help             Prints help information
+    coreos-installer iso kargs reset [OPTIONS] <ISO>
 
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -o, --output <PATH>    Write ISO to a new output file
+    -h, --help             Print help information
 ```
 
 # coreos-installer iso kargs show
@@ -242,12 +253,12 @@ Show kernel args from an ISO image
 USAGE:
     coreos-installer iso kargs show [OPTIONS] <ISO>
 
-OPTIONS:
-    -d, --default    Show default kernel args
-    -h, --help       Prints help information
-
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -d, --default    Show default kernel args
+    -h, --help       Print help information
 ```
 
 # coreos-installer iso extract pxe
@@ -256,14 +267,14 @@ ARGS:
 Extract PXE files from an ISO image
 
 USAGE:
-    coreos-installer iso extract pxe <ISO>
-
-OPTIONS:
-    -o, --output-dir <PATH>    Output directory [default: .]
-    -h, --help                 Prints help information
+    coreos-installer iso extract pxe [OPTIONS] <ISO>
 
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -o, --output-dir <PATH>    Output directory [default: .]
+    -h, --help                 Print help information
 ```
 
 # coreos-installer iso extract minimal-iso
@@ -272,16 +283,16 @@ ARGS:
 Extract a minimal ISO from a CoreOS live ISO image
 
 USAGE:
-    coreos-installer iso extract minimal-iso <ISO> [OUTPUT_ISO]
-
-OPTIONS:
-        --output-rootfs <PATH>    Extract rootfs image as well
-        --rootfs-url <URL>        Inject rootfs URL karg into minimal ISO
-    -h, --help                    Prints help information
+    coreos-installer iso extract minimal-iso [OPTIONS] <ISO> [OUTPUT_ISO]
 
 ARGS:
     <ISO>           ISO image
     <OUTPUT_ISO>    Minimal ISO output file [default: -]
+
+OPTIONS:
+        --output-rootfs <PATH>    Extract rootfs image as well
+        --rootfs-url <URL>        Inject rootfs URL karg into minimal ISO
+    -h, --help                    Print help information
 ```
 
 # coreos-installer iso reset
@@ -290,12 +301,12 @@ ARGS:
 Restore a CoreOS live ISO image to default settings
 
 USAGE:
-    coreos-installer iso reset <ISO>
-
-OPTIONS:
-    -o, --output <path>    Write ISO to a new output file
-    -h, --help             Prints help information
+    coreos-installer iso reset [OPTIONS] <ISO>
 
 ARGS:
     <ISO>    ISO image
+
+OPTIONS:
+    -o, --output <path>    Write ISO to a new output file
+    -h, --help             Print help information
 ```

--- a/docs/cmd/list-stream.md
+++ b/docs/cmd/list-stream.md
@@ -9,10 +9,10 @@ nav_order: 3
 List available images in a Fedora CoreOS stream
 
 USAGE:
-    coreos-installer list-stream
+    coreos-installer list-stream [OPTIONS]
 
 OPTIONS:
     -s, --stream <name>            Fedora CoreOS stream [default: stable]
         --stream-base-url <URL>    Base URL for Fedora CoreOS stream metadata
-    -h, --help                     Prints help information
+    -h, --help                     Print help information
 ```

--- a/docs/cmd/pxe.md
+++ b/docs/cmd/pxe.md
@@ -15,72 +15,80 @@ nav_order: 5
 Create a custom live PXE boot config
 
 USAGE:
-    coreos-installer pxe customize <path> --output <path>
+    coreos-installer pxe customize [OPTIONS] --output <path> <path>
+
+ARGS:
+    <path>
+            CoreOS live initramfs image
 
 OPTIONS:
-        --dest-ignition <path>...
+        --dest-ignition <path>
             Ignition config fragment for dest sys
 
             Automatically run installer and merge the specified Ignition config into the config
             for the destination system.
+
         --dest-device <path>
             Install destination device
 
             Automatically run installer, installing to the specified destination device.  The
             resulting boot media will overwrite the destination device without confirmation.
-        --dest-karg-append <arg>...
+
+        --dest-karg-append <arg>
             Destination kernel argument to append
 
             Automatically run installer, adding the specified kernel argument for every boot of
             the destination system.
-        --dest-karg-delete <arg>...
+
+        --dest-karg-delete <arg>
             Destination kernel argument to delete
 
             Automatically run installer, deleting the specified kernel argument for every boot
             of the destination system.
-        --network-keyfile <path>...
+
+        --network-keyfile <path>
             NetworkManager keyfile for live & dest
 
             Configure networking using the specified NetworkManager keyfile. Network settings
             will be applied in the live environment, including when Ignition is run.  If
             installer is enabled via additional options, network settings will also be applied
             in the destination system, including when Ignition is run.
-        --ignition-ca <path>...
+
+        --ignition-ca <path>
             Ignition PEM CA bundle for live & dest
 
             Specify additional TLS certificate authorities to be trusted by Ignition, in PEM
             format.  Authorities will be trusted by Ignition in the live environment and, if
             installer is enabled via additional options, in the destination system.
-        --pre-install <path>...
+
+        --pre-install <path>
             Script to run before installation
 
             If installer is run at boot, run this script before installation. If the script
             fails, the live environment will stop at an emergency shell.
-        --post-install <path>...
+
+        --post-install <path>
             Script to run after installation
 
             If installer is run at boot, run this script after installation. If the script
             fails, the live environment will stop at an emergency shell.
-        --installer-config <path>...
+
+        --installer-config <path>
             Installer config file
 
             Automatically run coreos-installer and apply the specified installer config file.
             Config files are applied in the order that they are specified.
-        --live-ignition <path>...
+
+        --live-ignition <path>
             Ignition config fragment for live env
 
             Merge the specified Ignition config into the config for the live environment.
+
     -o, --output <path>
             Output file
 
     -h, --help
-            Prints help information
-
-
-ARGS:
-    <path>
-            CoreOS live initramfs image
-
+            Print help information
 ```
 
 # coreos-installer pxe ignition wrap
@@ -89,12 +97,12 @@ ARGS:
 Wrap an Ignition config in an initrd image
 
 USAGE:
-    coreos-installer pxe ignition wrap
+    coreos-installer pxe ignition wrap [OPTIONS]
 
 OPTIONS:
     -i, --ignition-file <path>    Ignition config to wrap [default: stdin]
     -o, --output <path>           Write to a file instead of stdout
-    -h, --help                    Prints help information
+    -h, --help                    Print help information
 ```
 
 # coreos-installer pxe ignition unwrap
@@ -105,11 +113,11 @@ Show the wrapped Ignition config in an initrd image
 USAGE:
     coreos-installer pxe ignition unwrap [initrd]
 
-OPTIONS:
-    -h, --help    Prints help information
-
 ARGS:
     <initrd>    initrd image [default: stdin]
+
+OPTIONS:
+    -h, --help    Print help information
 ```
 
 # coreos-installer pxe network wrap
@@ -118,12 +126,12 @@ ARGS:
 Wrap network settings in an initrd image
 
 USAGE:
-    coreos-installer pxe network wrap --keyfile <path>...
+    coreos-installer pxe network wrap [OPTIONS] --keyfile <path>
 
 OPTIONS:
-    -k, --keyfile <path>...    NetworkManager keyfile to embed
-    -o, --output <path>        Write to a file instead of stdout
-    -h, --help                 Prints help information
+    -k, --keyfile <path>    NetworkManager keyfile to embed
+    -o, --output <path>     Write to a file instead of stdout
+    -h, --help              Print help information
 ```
 
 # coreos-installer pxe network unwrap
@@ -132,12 +140,12 @@ OPTIONS:
 Extract wrapped network settings from an initrd image
 
 USAGE:
-    coreos-installer pxe network unwrap [initrd]
-
-OPTIONS:
-    -C, --directory <path>    Extract to directory instead of stdout
-    -h, --help                Prints help information
+    coreos-installer pxe network unwrap [OPTIONS] [initrd]
 
 ARGS:
     <initrd>    initrd image [default: stdin]
+
+OPTIONS:
+    -C, --directory <path>    Extract to directory instead of stdout
+    -h, --help                Print help information
 ```

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -15,11 +15,11 @@
 // For consistency, have all parse_*() functions return Result.
 #![allow(clippy::unnecessary_wraps)]
 
-use clap::{AppSettings, StructOpt};
+use clap::{AppSettings, Parser};
 
 // Args are listed in --help in the order declared in these structs/enums.
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 #[structopt(name = "rdcore")]
 #[structopt(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[structopt(global_setting(AppSettings::DeriveDisplayOrder))]
@@ -38,7 +38,7 @@ pub enum Cmd {
     VerifyUniqueFsLabel(VerifyUniqueFsLabelConfig),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct RootmapConfig {
     // we allow mounting /boot ourselves (--boot-device) or letting our
     // caller do the mount and point us to it (--boot-mount); lots of
@@ -56,7 +56,7 @@ pub struct RootmapConfig {
     pub root_mount: String,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct BindBootConfig {
     /// Path to rootfs mount
     #[structopt(value_name = "ROOT_MOUNT")]
@@ -66,7 +66,7 @@ pub struct BindBootConfig {
     pub boot_mount: String,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct KargsConfig {
     // see comment block in rootmap command above
     /// Boot device containing BLS entries to modify
@@ -83,7 +83,7 @@ pub struct KargsConfig {
     pub current: bool,
     /// Modify this option string instead of fetching from BLS entry
     // this is purely for dev testing
-    #[structopt(long, value_name = "OPTIONS", hidden = true)]
+    #[structopt(long, value_name = "OPTIONS", hide = true)]
     pub override_options: Option<String>,
     /// File to create if BLS entry was modified
     #[structopt(long, value_name = "PATH")]
@@ -101,14 +101,14 @@ pub struct KargsConfig {
     pub delete: Vec<String>,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct StreamHashConfig {
     /// Path to the piecewise hash file
     #[structopt(value_name = "hash-file")]
     pub hash_file: String,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct VerifyUniqueFsLabelConfig {
     /// Filesystem's label
     #[structopt(value_name = "LABEL")]

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -24,7 +24,6 @@ use clap::{AppSettings, Parser};
 #[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 #[clap(global_setting(AppSettings::DisableHelpSubcommand))]
-#[clap(global_setting(AppSettings::UnifiedHelpMessage))]
 pub enum Cmd {
     /// Generate rootmap kargs and optionally inject into BLS configs
     Rootmap(RootmapConfig),
@@ -89,14 +88,14 @@ pub struct KargsConfig {
     #[clap(long, value_name = "PATH")]
     pub create_if_changed: Option<String>,
     /// Append kernel arg
-    #[clap(long, value_name = "ARG", number_of_values = 1)]
+    #[clap(long, value_name = "ARG")]
     pub append: Vec<String>,
     /// Append kernel arg if missing
-    #[clap(long, value_name = "ARG", number_of_values = 1)]
+    #[clap(long, value_name = "ARG")]
     #[clap(alias = "should-exist")]
     pub append_if_missing: Vec<String>,
     /// Delete kernel arg
-    #[clap(long, value_name = "ARG", number_of_values = 1)]
+    #[clap(long, value_name = "ARG")]
     #[clap(alias = "should-not-exist")]
     pub delete: Vec<String>,
 }

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -24,6 +24,7 @@ use clap::{AppSettings, Parser};
 #[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 #[clap(global_setting(AppSettings::DisableHelpSubcommand))]
+#[clap(global_setting(AppSettings::HelpExpected))]
 pub enum Cmd {
     /// Generate rootmap kargs and optionally inject into BLS configs
     Rootmap(RootmapConfig),

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -21,10 +21,10 @@ use clap::{AppSettings, Parser};
 
 #[derive(Debug, Parser)]
 #[clap(name = "rdcore", version)]
-#[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
-#[clap(global_setting(AppSettings::DisableHelpSubcommand))]
-#[clap(global_setting(AppSettings::HelpExpected))]
+#[clap(args_conflicts_with_subcommands = true)]
+#[clap(disable_help_subcommand = true)]
+#[clap(help_expected = true)]
 pub enum Cmd {
     /// Generate rootmap kargs and optionally inject into BLS configs
     Rootmap(RootmapConfig),
@@ -126,6 +126,6 @@ mod test {
 
     #[test]
     fn clap_app() {
-        Cmd::into_app().debug_assert()
+        Cmd::command().debug_assert()
     }
 }

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -15,8 +15,7 @@
 // For consistency, have all parse_*() functions return Result.
 #![allow(clippy::unnecessary_wraps)]
 
-use structopt::clap::AppSettings;
-use structopt::StructOpt;
+use clap::{AppSettings, StructOpt};
 
 // Args are listed in --help in the order declared in these structs/enums.
 
@@ -26,7 +25,6 @@ use structopt::StructOpt;
 #[structopt(global_setting(AppSettings::DeriveDisplayOrder))]
 #[structopt(global_setting(AppSettings::DisableHelpSubcommand))]
 #[structopt(global_setting(AppSettings::UnifiedHelpMessage))]
-#[structopt(global_setting(AppSettings::VersionlessSubcommands))]
 pub enum Cmd {
     /// Generate rootmap kargs and optionally inject into BLS configs
     Rootmap(RootmapConfig),

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -117,3 +117,14 @@ pub struct VerifyUniqueFsLabelConfig {
     #[clap(long)]
     pub rereadpt: bool,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use clap::IntoApp;
+
+    #[test]
+    fn clap_app() {
+        Cmd::into_app().debug_assert()
+    }
+}

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -20,11 +20,11 @@ use clap::{AppSettings, Parser};
 // Args are listed in --help in the order declared in these structs/enums.
 
 #[derive(Debug, Parser)]
-#[structopt(name = "rdcore")]
-#[structopt(global_setting(AppSettings::ArgsNegateSubcommands))]
-#[structopt(global_setting(AppSettings::DeriveDisplayOrder))]
-#[structopt(global_setting(AppSettings::DisableHelpSubcommand))]
-#[structopt(global_setting(AppSettings::UnifiedHelpMessage))]
+#[clap(name = "rdcore")]
+#[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
+#[clap(global_setting(AppSettings::DisableHelpSubcommand))]
+#[clap(global_setting(AppSettings::UnifiedHelpMessage))]
 pub enum Cmd {
     /// Generate rootmap kargs and optionally inject into BLS configs
     Rootmap(RootmapConfig),
@@ -46,23 +46,23 @@ pub struct RootmapConfig {
     // for changing implementation details on the OS side without having to
     // respin rdcore
     /// Boot device containing BLS entries to modify
-    #[structopt(long, value_name = "DEVPATH", conflicts_with = "boot-mount")]
+    #[clap(long, value_name = "DEVPATH", conflicts_with = "boot-mount")]
     pub boot_device: Option<String>,
     /// Boot mount containing BLS entries to modify
-    #[structopt(long, value_name = "BOOT_MOUNT", conflicts_with = "boot-device")]
+    #[clap(long, value_name = "BOOT_MOUNT", conflicts_with = "boot-device")]
     pub boot_mount: Option<String>,
     /// Path to rootfs mount
-    #[structopt(value_name = "ROOT_MOUNT")]
+    #[clap(value_name = "ROOT_MOUNT")]
     pub root_mount: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct BindBootConfig {
     /// Path to rootfs mount
-    #[structopt(value_name = "ROOT_MOUNT")]
+    #[clap(value_name = "ROOT_MOUNT")]
     pub root_mount: String,
     /// Path to bootfs mount
-    #[structopt(value_name = "BOOT_MOUNT")]
+    #[clap(value_name = "BOOT_MOUNT")]
     pub boot_mount: String,
 }
 
@@ -70,51 +70,51 @@ pub struct BindBootConfig {
 pub struct KargsConfig {
     // see comment block in rootmap command above
     /// Boot device containing BLS entries to modify
-    #[structopt(long, value_name = "DEVPATH")]
-    #[structopt(conflicts_with = "boot-mount", conflicts_with = "current")]
+    #[clap(long, value_name = "DEVPATH")]
+    #[clap(conflicts_with = "boot-mount", conflicts_with = "current")]
     pub boot_device: Option<String>,
     /// Boot mount containing BLS entries to modify
-    #[structopt(long, value_name = "BOOT_MOUNT")]
-    #[structopt(conflicts_with = "boot-device", conflicts_with = "current")]
+    #[clap(long, value_name = "BOOT_MOUNT")]
+    #[clap(conflicts_with = "boot-device", conflicts_with = "current")]
     pub boot_mount: Option<String>,
     /// Dry run using kargs from this boot
-    #[structopt(long)]
-    #[structopt(conflicts_with = "boot-device", conflicts_with = "boot-mount")]
+    #[clap(long)]
+    #[clap(conflicts_with = "boot-device", conflicts_with = "boot-mount")]
     pub current: bool,
     /// Modify this option string instead of fetching from BLS entry
     // this is purely for dev testing
-    #[structopt(long, value_name = "OPTIONS", hide = true)]
+    #[clap(long, value_name = "OPTIONS", hide = true)]
     pub override_options: Option<String>,
     /// File to create if BLS entry was modified
-    #[structopt(long, value_name = "PATH")]
+    #[clap(long, value_name = "PATH")]
     pub create_if_changed: Option<String>,
     /// Append kernel arg
-    #[structopt(long, value_name = "ARG", number_of_values = 1)]
+    #[clap(long, value_name = "ARG", number_of_values = 1)]
     pub append: Vec<String>,
     /// Append kernel arg if missing
-    #[structopt(long, value_name = "ARG", number_of_values = 1)]
-    #[structopt(alias = "should-exist")]
+    #[clap(long, value_name = "ARG", number_of_values = 1)]
+    #[clap(alias = "should-exist")]
     pub append_if_missing: Vec<String>,
     /// Delete kernel arg
-    #[structopt(long, value_name = "ARG", number_of_values = 1)]
-    #[structopt(alias = "should-not-exist")]
+    #[clap(long, value_name = "ARG", number_of_values = 1)]
+    #[clap(alias = "should-not-exist")]
     pub delete: Vec<String>,
 }
 
 #[derive(Debug, Parser)]
 pub struct StreamHashConfig {
     /// Path to the piecewise hash file
-    #[structopt(value_name = "hash-file")]
+    #[clap(value_name = "hash-file")]
     pub hash_file: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct VerifyUniqueFsLabelConfig {
     /// Filesystem's label
-    #[structopt(value_name = "LABEL")]
+    #[clap(value_name = "LABEL")]
     pub label: String,
 
     /// Force rereading of partition table
-    #[structopt(long)]
+    #[clap(long)]
     pub rereadpt: bool,
 }

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -20,7 +20,7 @@ use clap::{AppSettings, Parser};
 // Args are listed in --help in the order declared in these structs/enums.
 
 #[derive(Debug, Parser)]
-#[clap(name = "rdcore")]
+#[clap(name = "rdcore", version)]
 #[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 #[clap(global_setting(AppSettings::DisableHelpSubcommand))]

--- a/src/bin/rdcore/main.rs
+++ b/src/bin/rdcore/main.rs
@@ -19,7 +19,7 @@ mod stream_hash;
 mod unique_fs;
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::StructOpt;
 
 use crate::cmdline::*;
 

--- a/src/bin/rdcore/main.rs
+++ b/src/bin/rdcore/main.rs
@@ -19,12 +19,12 @@ mod stream_hash;
 mod unique_fs;
 
 use anyhow::Result;
-use clap::StructOpt;
+use clap::Parser;
 
 use crate::cmdline::*;
 
 fn main() -> Result<()> {
-    match Cmd::from_args() {
+    match Cmd::parse() {
         Cmd::Kargs(c) => kargs::kargs(c),
         Cmd::Rootmap(c) => rootmap::rootmap(c),
         Cmd::BindBoot(c) => rootmap::bind_boot(c),

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1072,7 +1072,11 @@ mod serializer {
             .context("reading subcommand help text")?;
 
         let mut serializer = Serializer {
-            help_text: String::from_utf8(help).context("decoding subcommand help text")?,
+            help_text: String::from_utf8(help)
+                .context("decoding subcommand help text")?
+                // add trailing space to each line, so push_field()
+                // option check works consistently for boolean flags
+                .replace('\n', " \n"),
             output: Vec::new(),
             field_stack: Vec::new(),
         };

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -315,10 +315,10 @@ pub struct InstallConfig {
     #[structopt(next_line_help(true))]
     pub network_dir: DefaultedString<NetworkDir>,
     /// Save partitions with this label glob
+    #[serde(skip_serializing_if = "is_default")]
     #[structopt(long, value_name = "lx")]
     // Allow argument multiple times, but one value each.  Allow "a,b" in
     // one argument.
-    #[serde(skip_serializing_if = "is_default")]
     #[structopt(number_of_values = 1, require_delimiter = true)]
     pub save_partlabel: Vec<String>,
     /// Save partitions with this number or range

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -199,6 +199,8 @@ pub enum DevExtractCmd {
     Initrd(DevExtractInitrdConfig),
 }
 
+const ADVANCED: &str = "ADVANCED OPTIONS";
+
 // As a special case, this struct supports Serialize and Deserialize for
 // config file parsing.  Here are the rules.  Build or test should fail if
 // you break anything too badly.
@@ -347,22 +349,22 @@ pub struct InstallConfig {
     // obscure options without short names
     /// Force offline installation
     #[serde(skip_serializing_if = "is_default")]
-    #[clap(long)]
+    #[clap(long, help_heading = ADVANCED)]
     pub offline: bool,
     /// Skip signature verification
     #[serde(skip_serializing_if = "is_default")]
-    #[clap(long)]
+    #[clap(long, help_heading = ADVANCED)]
     pub insecure: bool,
     /// Allow Ignition URL without HTTPS or hash
     #[serde(skip_serializing_if = "is_default")]
-    #[clap(long)]
+    #[clap(long, help_heading = ADVANCED)]
     pub insecure_ignition: bool,
     /// Base URL for CoreOS stream metadata
     ///
     /// Override the base URL for fetching CoreOS stream metadata.
     /// The default is "https://builds.coreos.fedoraproject.org/streams/".
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[clap(long, value_name = "URL")]
+    #[clap(long, value_name = "URL", help_heading = ADVANCED)]
     pub stream_base_url: Option<Url>,
     /// Don't clear partition table on error
     ///
@@ -370,14 +372,14 @@ pub struct InstallConfig {
     /// destination's partition table to prevent booting from invalid
     /// boot media.  Skip clearing the partition table as a debugging aid.
     #[serde(skip_serializing_if = "is_default")]
-    #[clap(long)]
+    #[clap(long, help_heading = ADVANCED)]
     pub preserve_on_error: bool,
     /// Fetch retries, or "infinite"
     ///
     /// Number of times to retry network fetches, or the string "infinite"
     /// to retry indefinitely.
     #[serde(skip_serializing_if = "is_default")]
-    #[clap(long, value_name = "N", default_value_t)]
+    #[clap(long, value_name = "N", default_value_t, help_heading = ADVANCED)]
     pub fetch_retries: FetchRetries,
 
     // positional args

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -36,11 +36,11 @@ use crate::io::IgnitionHash;
 // Please keep the entire help text to 80 columns.
 
 #[derive(Debug, Parser)]
-#[structopt(name = "coreos-installer")]
-#[structopt(global_setting(AppSettings::ArgsNegateSubcommands))]
-#[structopt(global_setting(AppSettings::DeriveDisplayOrder))]
-#[structopt(global_setting(AppSettings::DisableHelpSubcommand))]
-#[structopt(global_setting(AppSettings::UnifiedHelpMessage))]
+#[clap(name = "coreos-installer")]
+#[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
+#[clap(global_setting(AppSettings::DisableHelpSubcommand))]
+#[clap(global_setting(AppSettings::UnifiedHelpMessage))]
 pub enum Cmd {
     /// Install Fedora CoreOS or RHEL CoreOS
     Install(InstallConfig),
@@ -66,15 +66,15 @@ pub enum Cmd {
 pub enum IsoCmd {
     /// Embed an Ignition config in an ISO image
     // deprecated
-    #[structopt(setting(AppSettings::Hidden))]
+    #[clap(setting(AppSettings::Hidden))]
     Embed(IsoEmbedConfig),
     /// Show the embedded Ignition config from an ISO image
     // deprecated
-    #[structopt(setting(AppSettings::Hidden))]
+    #[clap(setting(AppSettings::Hidden))]
     Show(IsoShowConfig),
     /// Remove an existing embedded Ignition config from an ISO image
     // deprecated
-    #[structopt(setting(AppSettings::Hidden))]
+    #[clap(setting(AppSettings::Hidden))]
     Remove(IsoRemoveConfig),
     /// Customize a CoreOS live ISO image
     Customize(IsoCustomizeConfig),
@@ -162,7 +162,7 @@ pub enum PxeNetworkCmd {
 
 #[derive(Debug, Parser)]
 // users shouldn't be interacting with this command normally
-#[structopt(setting(AppSettings::Hidden))]
+#[clap(setting(AppSettings::Hidden))]
 pub enum PackCmd {
     /// Create osmet file from CoreOS block device
     Osmet(PackOsmetConfig),
@@ -172,7 +172,7 @@ pub enum PackCmd {
 
 #[derive(Debug, Parser)]
 // users shouldn't be interacting with this command normally
-#[structopt(setting(AppSettings::Hidden))]
+#[clap(setting(AppSettings::Hidden))]
 pub enum DevCmd {
     /// Commands to show metadata
     #[clap(subcommand)]
@@ -203,9 +203,9 @@ pub enum DevExtractCmd {
 // As a special case, this struct supports Serialize and Deserialize for
 // config file parsing.  Here are the rules.  Build or test should fail if
 // you break anything too badly.
-// - Defaults cannot be specified using #[structopt(default_value = "x")]
+// - Defaults cannot be specified using #[clap(default_value = "x")]
 //   because serde won't see them otherwise.  Instead, use
-//   #[structopt(default_value_t)], implement Default, and derive PartialEq
+//   #[clap(default_value_t)], implement Default, and derive PartialEq
 //   for the type.  (For string-typed defaults, you can use
 //   DefaultedString<T> where T is a custom type implementing
 //   DefaultString.)
@@ -222,7 +222,7 @@ pub enum DevExtractCmd {
 #[skip_serializing_none]
 #[derive(Debug, Default, Parser, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
-#[structopt(global_setting(AppSettings::AllArgsOverrideSelf))]
+#[clap(global_setting(AppSettings::AllArgsOverrideSelf))]
 pub struct InstallConfig {
     /// YAML config file with install options
     ///
@@ -235,7 +235,7 @@ pub struct InstallConfig {
     /// repeatable options, and "true" for flags.  The destination device
     /// can be specified with the "dest-device" key.
     #[serde(skip)]
-    #[structopt(short, long, value_name = "path", number_of_values = 1)]
+    #[clap(short, long, value_name = "path", number_of_values = 1)]
     pub config_file: Vec<String>,
 
     // ways to specify the image source
@@ -243,125 +243,125 @@ pub struct InstallConfig {
     ///
     /// The name of the Fedora CoreOS stream to install, such as "stable",
     /// "testing", or "next".
-    #[structopt(short, long, value_name = "name")]
-    #[structopt(conflicts_with = "image-file", conflicts_with = "image-url")]
+    #[clap(short, long, value_name = "name")]
+    #[clap(conflicts_with = "image-file", conflicts_with = "image-url")]
     pub stream: Option<String>,
     /// Manually specify the image URL
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[structopt(short = 'u', long, value_name = "URL")]
-    #[structopt(conflicts_with = "stream", conflicts_with = "image-file")]
+    #[clap(short = 'u', long, value_name = "URL")]
+    #[clap(conflicts_with = "stream", conflicts_with = "image-file")]
     pub image_url: Option<Url>,
     /// Manually specify a local image file
-    #[structopt(short = 'f', long, value_name = "path")]
-    #[structopt(conflicts_with = "stream", conflicts_with = "image-url")]
+    #[clap(short = 'f', long, value_name = "path")]
+    #[clap(conflicts_with = "stream", conflicts_with = "image-url")]
     pub image_file: Option<String>,
 
     // postprocessing options
     /// Embed an Ignition config from a file
     // deprecated long name from <= 0.1.2
-    #[structopt(short, long, alias = "ignition", value_name = "path")]
-    #[structopt(conflicts_with = "ignition-url")]
+    #[clap(short, long, alias = "ignition", value_name = "path")]
+    #[clap(conflicts_with = "ignition-url")]
     pub ignition_file: Option<String>,
     /// Embed an Ignition config from a URL
     ///
     /// Immediately fetch the Ignition config from the URL and embed it in
     /// the installed system.
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[structopt(short = 'I', long, value_name = "URL")]
-    #[structopt(conflicts_with = "ignition-file")]
+    #[clap(short = 'I', long, value_name = "URL")]
+    #[clap(conflicts_with = "ignition-file")]
     pub ignition_url: Option<Url>,
     /// Digest (type-value) of the Ignition config
     ///
     /// Verify that the Ignition config matches the specified digest,
     /// formatted as <type>-<hexvalue>.  <type> can be sha256 or sha512.
-    #[structopt(long, value_name = "digest")]
+    #[clap(long, value_name = "digest")]
     pub ignition_hash: Option<IgnitionHash>,
     /// Target CPU architecture
     ///
     /// Create an install disk for a different CPU architecture than the
     /// host.
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(short, long, default_value_t, value_name = "name")]
+    #[clap(short, long, default_value_t, value_name = "name")]
     pub architecture: DefaultedString<Architecture>,
     /// Override the Ignition platform ID
     ///
     /// Install a system that will run on the specified cloud or
     /// virtualization platform, such as "vmware".
-    #[structopt(short, long, value_name = "name")]
+    #[clap(short, long, value_name = "name")]
     pub platform: Option<String>,
     /// Additional kernel args for the first boot
     // This used to be for configuring networking from the cmdline, but it has
     // been obsoleted by the nicer `--copy-network` approach. We still need it
     // for now though. It's used at least by `coreos-installer.service`.
     #[serde(skip)]
-    #[structopt(long, hide = true, value_name = "args")]
+    #[clap(long, hide = true, value_name = "args")]
     pub firstboot_args: Option<String>,
     /// Append default kernel arg
     ///
     /// Add a kernel argument to the installed system.
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long, value_name = "arg", number_of_values = 1)]
+    #[clap(long, value_name = "arg", number_of_values = 1)]
     pub append_karg: Vec<String>,
     /// Delete default kernel arg
     ///
     /// Delete a default kernel argument from the installed system.
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long, value_name = "arg", number_of_values = 1)]
+    #[clap(long, value_name = "arg", number_of_values = 1)]
     pub delete_karg: Vec<String>,
     /// Copy network config from install environment
     ///
     /// Copy NetworkManager keyfiles from the install environment to the
     /// installed system.
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(short = 'n', long)]
+    #[clap(short = 'n', long)]
     pub copy_network: bool,
     /// For use with -n
     ///
     /// Specify the path to NetworkManager keyfiles to be copied with
     /// --copy-network.
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long, value_name = "path", default_value_t)]
+    #[clap(long, value_name = "path", default_value_t)]
     // so we can stay under 80 chars
-    #[structopt(next_line_help(true))]
+    #[clap(next_line_help(true))]
     pub network_dir: DefaultedString<NetworkDir>,
     /// Save partitions with this label glob
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long, value_name = "lx")]
+    #[clap(long, value_name = "lx")]
     // Allow argument multiple times, but one value each.  Allow "a,b" in
     // one argument.
-    #[structopt(number_of_values = 1, require_delimiter = true)]
-    #[structopt(value_delimiter = ',')]
+    #[clap(number_of_values = 1, require_delimiter = true)]
+    #[clap(value_delimiter = ',')]
     pub save_partlabel: Vec<String>,
     /// Save partitions with this number or range
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long, value_name = "id")]
+    #[clap(long, value_name = "id")]
     // Allow argument multiple times, but one value each.  Allow "1-5,7" in
     // one argument.
-    #[structopt(number_of_values = 1, require_delimiter = true)]
-    #[structopt(value_delimiter = ',')]
+    #[clap(number_of_values = 1, require_delimiter = true)]
+    #[clap(value_delimiter = ',')]
     // Allow ranges like "-2".
-    #[structopt(allow_hyphen_values = true)]
+    #[clap(allow_hyphen_values = true)]
     pub save_partindex: Vec<String>,
 
     // obscure options without short names
     /// Force offline installation
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long)]
+    #[clap(long)]
     pub offline: bool,
     /// Skip signature verification
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long)]
+    #[clap(long)]
     pub insecure: bool,
     /// Allow Ignition URL without HTTPS or hash
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long)]
+    #[clap(long)]
     pub insecure_ignition: bool,
     /// Base URL for CoreOS stream metadata
     ///
     /// Override the base URL for fetching CoreOS stream metadata.
     /// The default is "https://builds.coreos.fedoraproject.org/streams/".
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[structopt(long, value_name = "URL")]
+    #[clap(long, value_name = "URL")]
     pub stream_base_url: Option<Url>,
     /// Don't clear partition table on error
     ///
@@ -369,14 +369,14 @@ pub struct InstallConfig {
     /// destination's partition table to prevent booting from invalid
     /// boot media.  Skip clearing the partition table as a debugging aid.
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long)]
+    #[clap(long)]
     pub preserve_on_error: bool,
     /// Fetch retries, or "infinite"
     ///
     /// Number of times to retry network fetches, or the string "infinite"
     /// to retry indefinitely.
     #[serde(skip_serializing_if = "is_default")]
-    #[structopt(long, value_name = "N", default_value_t)]
+    #[clap(long, value_name = "N", default_value_t)]
     pub fetch_retries: FetchRetries,
 
     // positional args
@@ -384,7 +384,7 @@ pub struct InstallConfig {
     ///
     /// Path to the device node for the destination disk.  The beginning of
     /// the device will be overwritten without further confirmation.
-    #[structopt(required_unless_present = "config-file")]
+    #[clap(required_unless_present = "config-file")]
     pub dest_device: Option<String>,
 }
 
@@ -458,44 +458,44 @@ pub enum PartitionFilter {
 #[derive(Debug, Parser)]
 pub struct DownloadConfig {
     /// Fedora CoreOS stream
-    #[structopt(short, long, value_name = "name", default_value = "stable")]
+    #[clap(short, long, value_name = "name", default_value = "stable")]
     pub stream: String,
     /// Target CPU architecture
-    #[structopt(short, long, value_name = "name", default_value_t)]
+    #[clap(short, long, value_name = "name", default_value_t)]
     pub architecture: DefaultedString<Architecture>,
     /// Fedora CoreOS platform name
-    #[structopt(short, long, value_name = "name", default_value = "metal")]
+    #[clap(short, long, value_name = "name", default_value = "metal")]
     pub platform: String,
     /// Image format
-    #[structopt(short, long, value_name = "name", default_value = "raw.xz")]
+    #[clap(short, long, value_name = "name", default_value = "raw.xz")]
     pub format: String,
     /// Manually specify the image URL
-    #[structopt(short = 'u', long, value_name = "URL")]
+    #[clap(short = 'u', long, value_name = "URL")]
     pub image_url: Option<Url>,
     /// Destination directory
-    #[structopt(short = 'C', long, value_name = "path", default_value = ".")]
+    #[clap(short = 'C', long, value_name = "path", default_value = ".")]
     pub directory: String,
     /// Decompress image and don't save signature
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub decompress: bool,
     /// Skip signature verification
-    #[structopt(long)]
+    #[clap(long)]
     pub insecure: bool,
     /// Base URL for Fedora CoreOS stream metadata
-    #[structopt(long, value_name = "URL")]
+    #[clap(long, value_name = "URL")]
     pub stream_base_url: Option<Url>,
     /// Fetch retries, or "infinite"
-    #[structopt(long, value_name = "N", default_value_t)]
+    #[clap(long, value_name = "N", default_value_t)]
     pub fetch_retries: FetchRetries,
 }
 
 #[derive(Debug, Parser)]
 pub struct ListStreamConfig {
     /// Fedora CoreOS stream
-    #[structopt(short, long, value_name = "name", default_value = "stable")]
+    #[clap(short, long, value_name = "name", default_value = "stable")]
     pub stream: String,
     /// Base URL for Fedora CoreOS stream metadata
-    #[structopt(long, value_name = "URL")]
+    #[clap(long, value_name = "URL")]
     pub stream_base_url: Option<Url>,
 }
 
@@ -505,26 +505,26 @@ pub struct CommonCustomizeConfig {
     ///
     /// Automatically run installer and merge the specified Ignition config
     /// into the config for the destination system.
-    #[structopt(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, number_of_values = 1, value_name = "path")]
     pub dest_ignition: Vec<String>,
     /// Install destination device
     ///
     /// Automatically run installer, installing to the specified destination
     /// device.  The resulting boot media will overwrite the destination
     /// device without confirmation.
-    #[structopt(long, value_name = "path")]
+    #[clap(long, value_name = "path")]
     pub dest_device: Option<String>,
     /// Destination kernel argument to append
     ///
     /// Automatically run installer, adding the specified kernel argument
     /// for every boot of the destination system.
-    #[structopt(long, number_of_values = 1, value_name = "arg")]
+    #[clap(long, number_of_values = 1, value_name = "arg")]
     pub dest_karg_append: Vec<String>,
     /// Destination kernel argument to delete
     ///
     /// Automatically run installer, deleting the specified kernel argument
     /// for every boot of the destination system.
-    #[structopt(long, number_of_values = 1, value_name = "arg")]
+    #[clap(long, number_of_values = 1, value_name = "arg")]
     pub dest_karg_delete: Vec<String>,
     /// NetworkManager keyfile for live & dest
     ///
@@ -533,7 +533,7 @@ pub struct CommonCustomizeConfig {
     /// when Ignition is run.  If installer is enabled via additional options,
     /// network settings will also be applied in the destination system,
     /// including when Ignition is run.
-    #[structopt(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, number_of_values = 1, value_name = "path")]
     pub network_keyfile: Vec<String>,
     /// Ignition PEM CA bundle for live & dest
     ///
@@ -541,135 +541,135 @@ pub struct CommonCustomizeConfig {
     /// Ignition, in PEM format.  Authorities will be trusted by Ignition
     /// in the live environment and, if installer is enabled via additional
     /// options, in the destination system.
-    #[structopt(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, number_of_values = 1, value_name = "path")]
     pub ignition_ca: Vec<String>,
     /// Script to run before installation
     ///
     /// If installer is run at boot, run this script before installation.
     /// If the script fails, the live environment will stop at an emergency
     /// shell.
-    #[structopt(long, value_name = "path")]
+    #[clap(long, value_name = "path")]
     pub pre_install: Vec<String>,
     /// Script to run after installation
     ///
     /// If installer is run at boot, run this script after installation.
     /// If the script fails, the live environment will stop at an emergency
     /// shell.
-    #[structopt(long, value_name = "path")]
+    #[clap(long, value_name = "path")]
     pub post_install: Vec<String>,
     /// Installer config file
     ///
     /// Automatically run coreos-installer and apply the specified installer
     /// config file.  Config files are applied in the order that they are
     /// specified.
-    #[structopt(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, number_of_values = 1, value_name = "path")]
     pub installer_config: Vec<String>,
     /// Ignition config fragment for live env
     ///
     /// Merge the specified Ignition config into the config for the live
     /// environment.
-    #[structopt(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, number_of_values = 1, value_name = "path")]
     pub live_ignition: Vec<String>,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoCustomizeConfig {
     // Customizations
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub common: CommonCustomizeConfig,
     /// Live kernel argument to append
     ///
     /// Kernel argument to append to boots of the live environment.
-    #[structopt(long, number_of_values = 1, value_name = "arg")]
+    #[clap(long, number_of_values = 1, value_name = "arg")]
     pub live_karg_append: Vec<String>,
     /// Live kernel argument to delete
     ///
     /// Kernel argument to delete from boots of the live environment.
-    #[structopt(long, number_of_values = 1, value_name = "arg")]
+    #[clap(long, number_of_values = 1, value_name = "arg")]
     pub live_karg_delete: Vec<String>,
     /// Live kernel argument to replace
     ///
     /// Kernel argument to replace for boots of the live environment, in the
     /// form key=old=new.  For a default argument "a=b", specifying
     /// "--live-karg-replace a=b=c" will produce the argument "a=c".
-    #[structopt(long, number_of_values = 1, value_name = "k=o=n")]
+    #[clap(long, number_of_values = 1, value_name = "k=o=n")]
     pub live_karg_replace: Vec<String>,
 
     // I/O configuration
     /// Overwrite existing customizations
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub force: bool,
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoEmbedConfig {
     /// Ignition config to embed [default: stdin]
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub config: Option<String>,
     /// Overwrite an existing embedded Ignition config
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub force: bool,
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoShowConfig {
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoRemoveConfig {
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoIgnitionEmbedConfig {
     /// Overwrite an existing Ignition config
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub force: bool,
     /// Ignition config to embed [default: stdin]
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub ignition_file: Option<String>,
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoIgnitionShowConfig {
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoIgnitionRemoveConfig {
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
@@ -678,215 +678,215 @@ pub struct IsoNetworkEmbedConfig {
     /// NetworkManager keyfile to embed
     // Required option. :-(  In future we might support other configuration
     // sources.
-    #[structopt(short, long, required = true, value_name = "path")]
-    #[structopt(number_of_values = 1)]
+    #[clap(short, long, required = true, value_name = "path")]
+    #[clap(number_of_values = 1)]
     pub keyfile: Vec<String>,
     /// Overwrite existing network settings
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub force: bool,
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoNetworkExtractConfig {
     /// Extract to directory instead of stdout
-    #[structopt(short = 'C', long, value_name = "path")]
+    #[clap(short = 'C', long, value_name = "path")]
     pub directory: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoNetworkRemoveConfig {
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoKargsModifyConfig {
     /// Kernel argument to append
-    #[structopt(short, long, number_of_values = 1, value_name = "KARG")]
+    #[clap(short, long, number_of_values = 1, value_name = "KARG")]
     pub append: Vec<String>,
     /// Kernel argument to delete
-    #[structopt(short, long, number_of_values = 1, value_name = "KARG")]
+    #[clap(short, long, number_of_values = 1, value_name = "KARG")]
     pub delete: Vec<String>,
     /// Kernel argument to replace
-    #[structopt(short, long, number_of_values = 1, value_name = "KARG=OLDVAL=NEWVAL")]
+    #[clap(short, long, number_of_values = 1, value_name = "KARG=OLDVAL=NEWVAL")]
     pub replace: Vec<String>,
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "PATH")]
+    #[clap(short, long, value_name = "PATH")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoKargsResetConfig {
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "PATH")]
+    #[clap(short, long, value_name = "PATH")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoKargsShowConfig {
     /// Show default kernel args
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub default: bool,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct DevShowIsoConfig {
     /// Show Ignition embed area parameters
-    #[structopt(long, conflicts_with = "kargs")]
+    #[clap(long, conflicts_with = "kargs")]
     pub ignition: bool,
     /// Show kargs embed area parameters
-    #[structopt(long, conflicts_with = "ignition")]
+    #[clap(long, conflicts_with = "ignition")]
     pub kargs: bool,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoExtractPxeConfig {
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
     /// Output directory
-    #[structopt(short, long, value_name = "PATH", default_value = ".")]
+    #[clap(short, long, value_name = "PATH", default_value = ".")]
     pub output_dir: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoExtractMinimalIsoConfig {
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
     /// Extract rootfs image as well
-    #[structopt(long, value_name = "PATH")]
+    #[clap(long, value_name = "PATH")]
     pub output_rootfs: Option<String>,
     /// Minimal ISO output file
-    #[structopt(value_name = "OUTPUT_ISO", default_value = "-")]
+    #[clap(value_name = "OUTPUT_ISO", default_value = "-")]
     pub output: String,
     /// Inject rootfs URL karg into minimal ISO
-    #[structopt(long, value_name = "URL")]
+    #[clap(long, value_name = "URL")]
     pub rootfs_url: Option<String>,
 }
 
 #[derive(Debug, Parser)]
 pub struct PackMinimalIsoConfig {
     /// ISO image
-    #[structopt(value_name = "FULL_ISO")]
+    #[clap(value_name = "FULL_ISO")]
     pub full: String,
     /// Minimal ISO image
-    #[structopt(value_name = "MINIMAL_ISO")]
+    #[clap(value_name = "MINIMAL_ISO")]
     pub minimal: String,
     /// Delete minimal ISO after packing
-    #[structopt(long)]
+    #[clap(long)]
     pub consume: bool,
 }
 
 #[derive(Debug, Parser)]
 pub struct IsoResetConfig {
     /// Write ISO to a new output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
     /// ISO image
-    #[structopt(value_name = "ISO")]
+    #[clap(value_name = "ISO")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 // default usage line lists all mandatory options and so exceeds 80 characters
-#[structopt(override_usage = "coreos-installer pack osmet [OPTIONS]")]
+#[clap(override_usage = "coreos-installer pack osmet [OPTIONS]")]
 pub struct PackOsmetConfig {
     /// Path to osmet file to write
     // could output to stdout if missing?
-    #[structopt(long, required = true, value_name = "FILE")]
+    #[clap(long, required = true, value_name = "FILE")]
     pub output: String,
     /// Expected SHA256 of block device
     // XXX: rebase on top of
     // https://github.com/coreos/coreos-installer/pull/178 and use the same
     // type-digest format
-    #[structopt(long, required = true, value_name = "SHA256")]
+    #[clap(long, required = true, value_name = "SHA256")]
     pub checksum: String,
     /// Description of OS
-    #[structopt(long, required = true, value_name = "TEXT")]
+    #[clap(long, required = true, value_name = "TEXT")]
     pub description: String,
     /// Use worse compression, for development builds
-    #[structopt(long)]
+    #[clap(long)]
     pub fast: bool,
     /// Source device
-    #[structopt(value_name = "DEV")]
+    #[clap(value_name = "DEV")]
     pub device: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct DevExtractOsmetConfig {
     /// osmet file
-    #[structopt(long, required = true, value_name = "PATH")]
+    #[clap(long, required = true, value_name = "PATH")]
     pub osmet: String,
     /// OSTree repo
-    #[structopt(value_name = "PATH")]
+    #[clap(value_name = "PATH")]
     pub repo: String,
     /// Destination device
-    #[structopt(value_name = "DEV")]
+    #[clap(value_name = "DEV")]
     pub device: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct DevShowFiemapConfig {
     /// File to map
-    #[structopt(value_name = "PATH")]
+    #[clap(value_name = "PATH")]
     pub file: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct PxeCustomizeConfig {
     // Customizations
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub common: CommonCustomizeConfig,
 
     // I/O configuration
     /// Output file
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: String,
     /// CoreOS live initramfs image
-    #[structopt(value_name = "path")]
+    #[clap(value_name = "path")]
     pub input: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct PxeIgnitionWrapConfig {
     /// Ignition config to wrap [default: stdin]
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub ignition_file: Option<String>,
     /// Write to a file instead of stdout
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
 }
 
 #[derive(Debug, Parser)]
 pub struct PxeIgnitionUnwrapConfig {
     /// initrd image [default: stdin]
-    #[structopt(value_name = "initrd")]
+    #[clap(value_name = "initrd")]
     pub input: Option<String>,
 }
 
@@ -895,47 +895,47 @@ pub struct PxeNetworkWrapConfig {
     /// NetworkManager keyfile to embed
     // Required option. :-(  In future we might support other configuration
     // sources.
-    #[structopt(short, long, required = true, value_name = "path")]
-    #[structopt(number_of_values = 1)]
+    #[clap(short, long, required = true, value_name = "path")]
+    #[clap(number_of_values = 1)]
     pub keyfile: Vec<String>,
     /// Write to a file instead of stdout
-    #[structopt(short, long, value_name = "path")]
+    #[clap(short, long, value_name = "path")]
     pub output: Option<String>,
 }
 
 #[derive(Debug, Parser)]
 pub struct PxeNetworkUnwrapConfig {
     /// Extract to directory instead of stdout
-    #[structopt(short = 'C', long, value_name = "path")]
+    #[clap(short = 'C', long, value_name = "path")]
     pub directory: Option<String>,
     /// initrd image [default: stdin]
-    #[structopt(value_name = "initrd")]
+    #[clap(value_name = "initrd")]
     pub input: Option<String>,
 }
 
 #[derive(Debug, Parser)]
 pub struct DevShowInitrdConfig {
     /// initrd image ("-" for stdin)
-    #[structopt(value_name = "initrd")]
+    #[clap(value_name = "initrd")]
     pub input: String,
     /// Files or globs to list
-    #[structopt(value_name = "glob")]
+    #[clap(value_name = "glob")]
     pub filter: Vec<String>,
 }
 
 #[derive(Debug, Parser)]
 pub struct DevExtractInitrdConfig {
     /// Output directory
-    #[structopt(short = 'C', long, value_name = "path", default_value = ".")]
+    #[clap(short = 'C', long, value_name = "path", default_value = ".")]
     pub directory: String,
     /// List extracted contents
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub verbose: bool,
     /// initrd image ("-" for stdin)
-    #[structopt(value_name = "initrd")]
+    #[clap(value_name = "initrd")]
     pub input: String,
     /// Files or globs to list
-    #[structopt(value_name = "glob")]
+    #[clap(value_name = "glob")]
     pub filter: Vec<String>,
 }
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -40,6 +40,7 @@ use crate::io::IgnitionHash;
 #[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 #[clap(global_setting(AppSettings::DisableHelpSubcommand))]
+#[clap(global_setting(AppSettings::HelpExpected))]
 pub enum Cmd {
     /// Install Fedora CoreOS or RHEL CoreOS
     Install(InstallConfig),

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1365,8 +1365,14 @@ mod serializer {
 #[cfg(test)]
 mod test {
     use super::*;
+    use clap::IntoApp;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn clap_app() {
+        Cmd::into_app().debug_assert()
+    }
 
     /// Check that full InstallConfig serializes as expected
     #[test]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -313,14 +313,16 @@ pub struct InstallConfig {
     #[serde(skip_serializing_if = "is_default")]
     #[clap(short = 'n', long)]
     pub copy_network: bool,
-    /// For use with -n
+    /// Override NetworkManager keyfile dir for -n
     ///
     /// Specify the path to NetworkManager keyfiles to be copied with
     /// --copy-network.
+    ///
+    /// [default: /etc/NetworkManager/system-connections/]
     #[serde(skip_serializing_if = "is_default")]
     #[clap(long, value_name = "path", default_value_t)]
-    // so we can stay under 80 chars
-    #[clap(next_line_help(true))]
+    // showing the default converts every option to multiline help
+    #[clap(hide_default_value = true)]
     pub network_dir: DefaultedString<NetworkDir>,
     /// Save partitions with this label glob
     #[serde(skip_serializing_if = "is_default")]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -36,11 +36,9 @@ use crate::io::IgnitionHash;
 // Please keep the entire help text to 80 columns.
 
 #[derive(Debug, Parser)]
-#[clap(name = "coreos-installer")]
 #[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 #[clap(global_setting(AppSettings::DisableHelpSubcommand))]
-#[clap(global_setting(AppSettings::UnifiedHelpMessage))]
 pub enum Cmd {
     /// Install Fedora CoreOS or RHEL CoreOS
     Install(InstallConfig),
@@ -235,7 +233,7 @@ pub struct InstallConfig {
     /// repeatable options, and "true" for flags.  The destination device
     /// can be specified with the "dest-device" key.
     #[serde(skip)]
-    #[clap(short, long, value_name = "path", number_of_values = 1)]
+    #[clap(short, long, value_name = "path")]
     pub config_file: Vec<String>,
 
     // ways to specify the image source
@@ -300,13 +298,13 @@ pub struct InstallConfig {
     ///
     /// Add a kernel argument to the installed system.
     #[serde(skip_serializing_if = "is_default")]
-    #[clap(long, value_name = "arg", number_of_values = 1)]
+    #[clap(long, value_name = "arg")]
     pub append_karg: Vec<String>,
     /// Delete default kernel arg
     ///
     /// Delete a default kernel argument from the installed system.
     #[serde(skip_serializing_if = "is_default")]
-    #[clap(long, value_name = "arg", number_of_values = 1)]
+    #[clap(long, value_name = "arg")]
     pub delete_karg: Vec<String>,
     /// Copy network config from install environment
     ///
@@ -505,7 +503,7 @@ pub struct CommonCustomizeConfig {
     ///
     /// Automatically run installer and merge the specified Ignition config
     /// into the config for the destination system.
-    #[clap(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, value_name = "path")]
     pub dest_ignition: Vec<String>,
     /// Install destination device
     ///
@@ -518,13 +516,13 @@ pub struct CommonCustomizeConfig {
     ///
     /// Automatically run installer, adding the specified kernel argument
     /// for every boot of the destination system.
-    #[clap(long, number_of_values = 1, value_name = "arg")]
+    #[clap(long, value_name = "arg")]
     pub dest_karg_append: Vec<String>,
     /// Destination kernel argument to delete
     ///
     /// Automatically run installer, deleting the specified kernel argument
     /// for every boot of the destination system.
-    #[clap(long, number_of_values = 1, value_name = "arg")]
+    #[clap(long, value_name = "arg")]
     pub dest_karg_delete: Vec<String>,
     /// NetworkManager keyfile for live & dest
     ///
@@ -533,7 +531,7 @@ pub struct CommonCustomizeConfig {
     /// when Ignition is run.  If installer is enabled via additional options,
     /// network settings will also be applied in the destination system,
     /// including when Ignition is run.
-    #[clap(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, value_name = "path")]
     pub network_keyfile: Vec<String>,
     /// Ignition PEM CA bundle for live & dest
     ///
@@ -541,7 +539,7 @@ pub struct CommonCustomizeConfig {
     /// Ignition, in PEM format.  Authorities will be trusted by Ignition
     /// in the live environment and, if installer is enabled via additional
     /// options, in the destination system.
-    #[clap(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, value_name = "path")]
     pub ignition_ca: Vec<String>,
     /// Script to run before installation
     ///
@@ -562,13 +560,13 @@ pub struct CommonCustomizeConfig {
     /// Automatically run coreos-installer and apply the specified installer
     /// config file.  Config files are applied in the order that they are
     /// specified.
-    #[clap(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, value_name = "path")]
     pub installer_config: Vec<String>,
     /// Ignition config fragment for live env
     ///
     /// Merge the specified Ignition config into the config for the live
     /// environment.
-    #[clap(long, number_of_values = 1, value_name = "path")]
+    #[clap(long, value_name = "path")]
     pub live_ignition: Vec<String>,
 }
 
@@ -580,19 +578,19 @@ pub struct IsoCustomizeConfig {
     /// Live kernel argument to append
     ///
     /// Kernel argument to append to boots of the live environment.
-    #[clap(long, number_of_values = 1, value_name = "arg")]
+    #[clap(long, value_name = "arg")]
     pub live_karg_append: Vec<String>,
     /// Live kernel argument to delete
     ///
     /// Kernel argument to delete from boots of the live environment.
-    #[clap(long, number_of_values = 1, value_name = "arg")]
+    #[clap(long, value_name = "arg")]
     pub live_karg_delete: Vec<String>,
     /// Live kernel argument to replace
     ///
     /// Kernel argument to replace for boots of the live environment, in the
     /// form key=old=new.  For a default argument "a=b", specifying
     /// "--live-karg-replace a=b=c" will produce the argument "a=c".
-    #[clap(long, number_of_values = 1, value_name = "k=o=n")]
+    #[clap(long, value_name = "k=o=n")]
     pub live_karg_replace: Vec<String>,
 
     // I/O configuration
@@ -679,7 +677,6 @@ pub struct IsoNetworkEmbedConfig {
     // Required option. :-(  In future we might support other configuration
     // sources.
     #[clap(short, long, required = true, value_name = "path")]
-    #[clap(number_of_values = 1)]
     pub keyfile: Vec<String>,
     /// Overwrite existing network settings
     #[clap(short, long)]
@@ -715,13 +712,13 @@ pub struct IsoNetworkRemoveConfig {
 #[derive(Debug, Parser)]
 pub struct IsoKargsModifyConfig {
     /// Kernel argument to append
-    #[clap(short, long, number_of_values = 1, value_name = "KARG")]
+    #[clap(short, long, value_name = "KARG")]
     pub append: Vec<String>,
     /// Kernel argument to delete
-    #[clap(short, long, number_of_values = 1, value_name = "KARG")]
+    #[clap(short, long, value_name = "KARG")]
     pub delete: Vec<String>,
     /// Kernel argument to replace
-    #[clap(short, long, number_of_values = 1, value_name = "KARG=OLDVAL=NEWVAL")]
+    #[clap(short, long, value_name = "KARG=OLDVAL=NEWVAL")]
     pub replace: Vec<String>,
     /// Write ISO to a new output file
     #[clap(short, long, value_name = "PATH")]
@@ -896,7 +893,6 @@ pub struct PxeNetworkWrapConfig {
     // Required option. :-(  In future we might support other configuration
     // sources.
     #[clap(short, long, required = true, value_name = "path")]
-    #[clap(number_of_values = 1)]
     pub keyfile: Vec<String>,
     /// Write to a file instead of stdout
     #[clap(short, long, value_name = "path")]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -36,6 +36,7 @@ use crate::io::IgnitionHash;
 // Please keep the entire help text to 80 columns.
 
 #[derive(Debug, Parser)]
+#[clap(version)]
 #[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 #[clap(global_setting(AppSettings::DisableHelpSubcommand))]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -37,10 +37,10 @@ use crate::io::IgnitionHash;
 
 #[derive(Debug, Parser)]
 #[clap(version)]
-#[clap(global_setting(AppSettings::ArgsNegateSubcommands))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
-#[clap(global_setting(AppSettings::DisableHelpSubcommand))]
-#[clap(global_setting(AppSettings::HelpExpected))]
+#[clap(args_conflicts_with_subcommands = true)]
+#[clap(disable_help_subcommand = true)]
+#[clap(help_expected = true)]
 pub enum Cmd {
     /// Install Fedora CoreOS or RHEL CoreOS
     Install(InstallConfig),
@@ -66,15 +66,15 @@ pub enum Cmd {
 pub enum IsoCmd {
     /// Embed an Ignition config in an ISO image
     // deprecated
-    #[clap(setting(AppSettings::Hidden))]
+    #[clap(hide = true)]
     Embed(IsoEmbedConfig),
     /// Show the embedded Ignition config from an ISO image
     // deprecated
-    #[clap(setting(AppSettings::Hidden))]
+    #[clap(hide = true)]
     Show(IsoShowConfig),
     /// Remove an existing embedded Ignition config from an ISO image
     // deprecated
-    #[clap(setting(AppSettings::Hidden))]
+    #[clap(hide = true)]
     Remove(IsoRemoveConfig),
     /// Customize a CoreOS live ISO image
     Customize(IsoCustomizeConfig),
@@ -162,7 +162,7 @@ pub enum PxeNetworkCmd {
 
 #[derive(Debug, Parser)]
 // users shouldn't be interacting with this command normally
-#[clap(setting(AppSettings::Hidden))]
+#[clap(hide = true)]
 pub enum PackCmd {
     /// Create osmet file from CoreOS block device
     Osmet(PackOsmetConfig),
@@ -172,7 +172,7 @@ pub enum PackCmd {
 
 #[derive(Debug, Parser)]
 // users shouldn't be interacting with this command normally
-#[clap(setting(AppSettings::Hidden))]
+#[clap(hide = true)]
 pub enum DevCmd {
     /// Commands to show metadata
     #[clap(subcommand)]
@@ -224,7 +224,7 @@ const ADVANCED: &str = "ADVANCED OPTIONS";
 #[skip_serializing_none]
 #[derive(Debug, Default, Parser, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
-#[clap(global_setting(AppSettings::AllArgsOverrideSelf))]
+#[clap(args_override_self = true)]
 pub struct InstallConfig {
     /// YAML config file with install options
     ///
@@ -333,7 +333,7 @@ pub struct InstallConfig {
     #[clap(long, value_name = "lx")]
     // Allow argument multiple times, but one value each.  Allow "a,b" in
     // one argument.
-    #[clap(number_of_values = 1, require_delimiter = true)]
+    #[clap(number_of_values = 1, require_value_delimiter = true)]
     #[clap(value_delimiter = ',')]
     pub save_partlabel: Vec<String>,
     /// Save partitions with this number or range
@@ -341,7 +341,7 @@ pub struct InstallConfig {
     #[clap(long, value_name = "id")]
     // Allow argument multiple times, but one value each.  Allow "1-5,7" in
     // one argument.
-    #[clap(number_of_values = 1, require_delimiter = true)]
+    #[clap(number_of_values = 1, require_value_delimiter = true)]
     #[clap(value_delimiter = ',')]
     // Allow ranges like "-2".
     #[clap(allow_hyphen_values = true)]
@@ -1073,7 +1073,7 @@ mod serializer {
         // and we don't want to implement a proc macro because those have to
         // go in a separate crate.  Get the subcommand help text and grep it.
         let mut help = Vec::new();
-        T::into_app()
+        T::command()
             .write_long_help(&mut help)
             .context("reading subcommand help text")?;
 
@@ -1372,7 +1372,7 @@ mod test {
 
     #[test]
     fn clap_app() {
-        Cmd::into_app().debug_assert()
+        Cmd::command().debug_assert()
     }
 
     /// Check that full InstallConfig serializes as expected

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -55,12 +55,8 @@ pub enum Cmd {
     /// Commands to manage a CoreOS live PXE image
     Pxe(PxeCmd),
     /// Metadata packing commands used when building an OS image
-    // users shouldn't be interacting with this command normally
-    #[structopt(setting(AppSettings::Hidden))]
     Pack(PackCmd),
     /// Development commands (unstable)
-    // users shouldn't be interacting with this command normally
-    #[structopt(setting(AppSettings::Hidden))]
     Dev(DevCmd),
 }
 
@@ -157,6 +153,8 @@ pub enum PxeNetworkCmd {
 }
 
 #[derive(Debug, StructOpt)]
+// users shouldn't be interacting with this command normally
+#[structopt(setting(AppSettings::Hidden))]
 pub enum PackCmd {
     /// Create osmet file from CoreOS block device
     Osmet(PackOsmetConfig),
@@ -165,6 +163,8 @@ pub enum PackCmd {
 }
 
 #[derive(Debug, StructOpt)]
+// users shouldn't be interacting with this command normally
+#[structopt(setting(AppSettings::Hidden))]
 pub enum DevCmd {
     /// Commands to show metadata
     Show(DevShowCmd),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 use anyhow::Result;
-use clap::StructOpt;
+use clap::Parser;
 
 use libcoreinst::{cmdline, download, install, live, osmet, source};
 
 use cmdline::*;
 
 fn main() -> Result<()> {
-    match Cmd::from_args() {
+    match Cmd::parse() {
         Cmd::Download(c) => download::download(c),
         Cmd::Install(c) => install::install(c),
         Cmd::ListStream(c) => source::list_stream(c),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::StructOpt;
 
 use libcoreinst::{cmdline, download, install, live, osmet, source};
 

--- a/src/miniso.rs
+++ b/src/miniso.rs
@@ -18,8 +18,8 @@ use std::io::{copy, Read, Seek, SeekFrom, Write};
 
 use anyhow::{bail, Context, Result};
 use bincode::Options;
+use clap::crate_version;
 use serde::{Deserialize, Serialize};
-use structopt::clap::crate_version;
 use xz2::read::XzDecoder;
 use xz2::write::XzEncoder;
 

--- a/src/osmet/file.rs
+++ b/src/osmet/file.rs
@@ -18,8 +18,8 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use bincode::Options;
+use clap::crate_version;
 use serde::{Deserialize, Serialize};
-use structopt::clap::crate_version;
 use xz2::bufread::XzDecoder;
 
 use crate::io::{bincoder, BUFFER_SIZE};


### PR DESCRIPTION
clap 3 drops `...` from the help text for arguments that can be repeated, and expects applications to make repeatability clear from the arg description: https://github.com/clap-rs/clap/issues/1571#issuecomment-541313239.  I'm not sure of a good way to do that, so we're currently leaving repeatable arguments implicit.