### PR TITLE
Consolidate build/debug commands/options into separate command hierarchies

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -62,6 +62,10 @@ pub enum Cmd {
     // users shouldn't be interacting with this command normally
     #[structopt(setting(AppSettings::Hidden))]
     Pack(PackCmd),
+    /// Development commands (unstable)
+    // users shouldn't be interacting with this command normally
+    #[structopt(setting(AppSettings::Hidden))]
+    Dev(DevCmd),
 }
 
 #[derive(Debug, StructOpt)]
@@ -86,10 +90,6 @@ pub enum IsoCmd {
     Network(IsoNetworkCmd),
     /// Modify kernel args in a CoreOS live ISO image
     Kargs(IsoKargsCmd),
-    /// Inspect the CoreOS live ISO image
-    // for testing and debugging purposes only
-    #[structopt(setting(AppSettings::Hidden))]
-    Inspect(IsoInspectConfig),
     /// Commands to extract files from a CoreOS live ISO image
     Extract(IsoExtractCmd),
     /// Restore a CoreOS live ISO image to default settings
@@ -143,10 +143,6 @@ pub enum OsmetCmd {
     /// Create osmet file from CoreOS block device
     // deprecated in favor of "pack osmet"
     Pack(PackOsmetConfig),
-    /// Generate raw metal image from osmet file and OSTree repo
-    Unpack(OsmetUnpackConfig),
-    /// Print file extent mapping of specific file
-    Fiemap(OsmetFiemapConfig),
 }
 
 #[derive(Debug, StructOpt)]
@@ -181,6 +177,28 @@ pub enum PackCmd {
     Osmet(PackOsmetConfig),
     /// Pack a minimal ISO into a CoreOS live ISO image
     MinimalIso(PackMinimalIsoConfig),
+}
+
+#[derive(Debug, StructOpt)]
+pub enum DevCmd {
+    /// Commands to show metadata
+    Show(DevShowCmd),
+    /// Commands to extract data
+    Extract(DevExtractCmd),
+}
+
+#[derive(Debug, StructOpt)]
+pub enum DevShowCmd {
+    /// Inspect the CoreOS live ISO image
+    Iso(DevShowIsoConfig),
+    /// Print file extent mapping of specific file
+    Fiemap(DevShowFiemapConfig),
+}
+
+#[derive(Debug, StructOpt)]
+pub enum DevExtractCmd {
+    /// Generate raw metal image from osmet file and OSTree repo
+    Osmet(DevExtractOsmetConfig),
 }
 
 // As a special case, this struct supports Serialize and Deserialize for
@@ -739,7 +757,7 @@ pub struct IsoKargsShowConfig {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct IsoInspectConfig {
+pub struct DevShowIsoConfig {
     /// ISO image
     #[structopt(value_name = "ISO")]
     pub input: String,
@@ -818,7 +836,7 @@ pub struct PackOsmetConfig {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct OsmetUnpackConfig {
+pub struct DevExtractOsmetConfig {
     /// osmet file
     #[structopt(long, required = true, value_name = "PATH")]
     pub osmet: String,
@@ -831,7 +849,7 @@ pub struct OsmetUnpackConfig {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct OsmetFiemapConfig {
+pub struct DevShowFiemapConfig {
     /// File to map
     #[structopt(value_name = "PATH")]
     pub file: String,

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -660,9 +660,6 @@ pub struct IsoIgnitionShowConfig {
     /// ISO image
     #[structopt(value_name = "ISO")]
     pub input: String,
-    /// Show ISO header (for debugging/testing only)
-    #[structopt(long, hidden = true)]
-    pub header: bool,
 }
 
 #[derive(Debug, StructOpt)]
@@ -748,9 +745,6 @@ pub struct IsoKargsShowConfig {
     /// Show default kernel args
     #[structopt(short, long)]
     pub default: bool,
-    /// Show ISO header (for debugging/testing only)
-    #[structopt(long, hidden = true)]
-    pub header: bool,
     /// ISO image
     #[structopt(value_name = "ISO")]
     pub input: String,
@@ -758,6 +752,12 @@ pub struct IsoKargsShowConfig {
 
 #[derive(Debug, StructOpt)]
 pub struct DevShowIsoConfig {
+    /// Show Ignition embed area parameters
+    #[structopt(long, conflicts_with = "kargs")]
+    pub ignition: bool,
+    /// Show kargs embed area parameters
+    #[structopt(long, conflicts_with = "ignition")]
+    pub kargs: bool,
     /// ISO image
     #[structopt(value_name = "ISO")]
     pub input: String,

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -813,6 +813,8 @@ pub struct IsoResetConfig {
 }
 
 #[derive(Debug, StructOpt)]
+// default usage line lists all mandatory options and so exceeds 80 characters
+#[structopt(usage = "coreos-installer pack osmet [OPTIONS]")]
 pub struct PackOsmetConfig {
     /// Path to osmet file to write
     // could output to stdout if missing?

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -58,6 +58,10 @@ pub enum Cmd {
     Osmet(OsmetCmd),
     /// Commands to manage a CoreOS live PXE image
     Pxe(PxeCmd),
+    /// Metadata packing commands used when building an OS image
+    // users shouldn't be interacting with this command normally
+    #[structopt(setting(AppSettings::Hidden))]
+    Pack(PackCmd),
 }
 
 #[derive(Debug, StructOpt)]
@@ -128,17 +132,17 @@ pub enum IsoExtractCmd {
     Pxe(IsoExtractPxeConfig),
     /// Extract a minimal ISO from a CoreOS live ISO image
     MinimalIso(IsoExtractMinimalIsoConfig),
-    // This doesn't really make sense under `extract`, but it's hidden and conceptually feels
-    // cleaner being alongside `coreos-installer iso extract minimal-iso`.
     /// Pack a minimal ISO into a CoreOS live ISO image
+    // deprecated in favor of "pack minimal-iso"
     #[structopt(setting(AppSettings::Hidden))]
-    PackMinimalIso(IsoExtractPackMinimalIsoConfig),
+    PackMinimalIso(PackMinimalIsoConfig),
 }
 
 #[derive(Debug, StructOpt)]
 pub enum OsmetCmd {
     /// Create osmet file from CoreOS block device
-    Pack(OsmetPackConfig),
+    // deprecated in favor of "pack osmet"
+    Pack(PackOsmetConfig),
     /// Generate raw metal image from osmet file and OSTree repo
     Unpack(OsmetUnpackConfig),
     /// Print file extent mapping of specific file
@@ -169,6 +173,14 @@ pub enum PxeNetworkCmd {
     Wrap(PxeNetworkWrapConfig),
     /// Extract wrapped network settings from an initrd image
     Unwrap(PxeNetworkUnwrapConfig),
+}
+
+#[derive(Debug, StructOpt)]
+pub enum PackCmd {
+    /// Create osmet file from CoreOS block device
+    Osmet(PackOsmetConfig),
+    /// Pack a minimal ISO into a CoreOS live ISO image
+    MinimalIso(PackMinimalIsoConfig),
 }
 
 // As a special case, this struct supports Serialize and Deserialize for
@@ -760,7 +772,7 @@ pub struct IsoExtractMinimalIsoConfig {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct IsoExtractPackMinimalIsoConfig {
+pub struct PackMinimalIsoConfig {
     /// ISO image
     #[structopt(value_name = "FULL_ISO")]
     pub full: String,
@@ -783,7 +795,7 @@ pub struct IsoResetConfig {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct OsmetPackConfig {
+pub struct PackOsmetConfig {
     /// Path to osmet file to write
     // could output to stdout if missing?
     #[structopt(long, required = true, value_name = "FILE")]

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -581,7 +581,7 @@ pub fn iso_extract_minimal_iso(config: IsoExtractMinimalIsoConfig) -> Result<()>
     Ok(())
 }
 
-pub fn iso_pack_minimal_iso(config: IsoExtractPackMinimalIsoConfig) -> Result<()> {
+pub fn pack_minimal_iso(config: PackMinimalIsoConfig) -> Result<()> {
     let mut full_iso = IsoFs::from_file(open_live_iso(&config.full, Some(None))?)?;
     let mut minimal_iso = IsoFs::from_file(open_live_iso(&config.minimal, None)?)?;
 

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -456,27 +456,26 @@ pub fn pxe_customize(config: PxeCustomizeConfig) -> Result<()> {
 }
 
 #[derive(Serialize)]
-struct IsoInspectOutput {
+struct DevShowIsoOutput {
     header: IsoFs,
     records: Vec<String>,
 }
 
-pub fn iso_inspect(config: IsoInspectConfig) -> Result<()> {
+pub fn dev_show_iso(config: DevShowIsoConfig) -> Result<()> {
     let mut iso = IsoFs::from_file(open_live_iso(&config.input, None)?)?;
     let records = iso
         .walk()?
         .map(|r| r.map(|(path, _)| path))
         .collect::<Result<Vec<String>>>()
         .context("while walking ISO filesystem")?;
-    let inspect_out = IsoInspectOutput {
+    let info = DevShowIsoOutput {
         header: iso,
         records,
     };
 
     let stdout = io::stdout();
     let mut out = stdout.lock();
-    serde_json::to_writer_pretty(&mut out, &inspect_out)
-        .context("failed to serialize ISO metadata")?;
+    serde_json::to_writer_pretty(&mut out, &info).context("failed to serialize ISO metadata")?;
     out.write_all(b"\n").context("failed to write newline")?;
     Ok(())
 }

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -51,7 +51,6 @@ pub fn iso_show(config: IsoShowConfig) -> Result<()> {
     eprintln!("`iso show` is deprecated; use `iso ignition show`.  Continuing.");
     iso_ignition_show(IsoIgnitionShowConfig {
         input: config.input,
-        header: false,
     })
 }
 
@@ -93,23 +92,18 @@ pub fn iso_ignition_embed(config: IsoIgnitionEmbedConfig) -> Result<()> {
 pub fn iso_ignition_show(config: IsoIgnitionShowConfig) -> Result<()> {
     let mut iso_file = open_live_iso(&config.input, None)?;
     let iso = IsoConfig::for_file(&mut iso_file)?;
+    if !iso.have_ignition() {
+        bail!("No embedded Ignition config.");
+    }
     let stdout = io::stdout();
     let mut out = stdout.lock();
-    if config.header {
-        out.write_all(&iso.initrd_header_json()?)
-            .context("failed to write header")?;
-    } else {
-        if !iso.have_ignition() {
-            bail!("No embedded Ignition config.");
-        }
-        out.write_all(
-            iso.initrd()
-                .get(INITRD_IGNITION_PATH)
-                .context("couldn't find Ignition config in archive")?,
-        )
-        .context("writing output")?;
-        out.flush().context("flushing output")?;
-    }
+    out.write_all(
+        iso.initrd()
+            .get(INITRD_IGNITION_PATH)
+            .context("couldn't find Ignition config in archive")?,
+    )
+    .context("writing output")?;
+    out.flush().context("flushing output")?;
     Ok(())
 }
 
@@ -306,19 +300,12 @@ pub fn iso_kargs_reset(config: IsoKargsResetConfig) -> Result<()> {
 pub fn iso_kargs_show(config: IsoKargsShowConfig) -> Result<()> {
     let mut iso_file = open_live_iso(&config.input, None)?;
     let iso = IsoConfig::for_file(&mut iso_file)?;
-    if config.header {
-        io::stdout()
-            .lock()
-            .write_all(&iso.kargs_header_json()?)
-            .context("failed to write header")?;
+    let kargs = if config.default {
+        iso.kargs_default()?
     } else {
-        let kargs = if config.default {
-            iso.kargs_default()?
-        } else {
-            iso.kargs()?
-        };
-        println!("{}", kargs);
-    }
+        iso.kargs()?
+    };
+    println!("{}", kargs);
     Ok(())
 }
 
@@ -462,21 +449,33 @@ struct DevShowIsoOutput {
 }
 
 pub fn dev_show_iso(config: DevShowIsoConfig) -> Result<()> {
-    let mut iso = IsoFs::from_file(open_live_iso(&config.input, None)?)?;
-    let records = iso
-        .walk()?
-        .map(|r| r.map(|(path, _)| path))
-        .collect::<Result<Vec<String>>>()
-        .context("while walking ISO filesystem")?;
-    let info = DevShowIsoOutput {
-        header: iso,
-        records,
-    };
-
+    let mut iso_file = open_live_iso(&config.input, None)?;
     let stdout = io::stdout();
     let mut out = stdout.lock();
-    serde_json::to_writer_pretty(&mut out, &info).context("failed to serialize ISO metadata")?;
-    out.write_all(b"\n").context("failed to write newline")?;
+    if config.ignition || config.kargs {
+        let iso = IsoConfig::for_file(&mut iso_file)?;
+        let data = if config.ignition {
+            iso.initrd_header_json()?
+        } else {
+            iso.kargs_header_json()?
+        };
+        out.write_all(&data).context("failed to write header")?;
+    } else {
+        let mut iso = IsoFs::from_file(iso_file)?;
+        let records = iso
+            .walk()?
+            .map(|r| r.map(|(path, _)| path))
+            .collect::<Result<Vec<String>>>()
+            .context("while walking ISO filesystem")?;
+        let info = DevShowIsoOutput {
+            header: iso,
+            records,
+        };
+
+        serde_json::to_writer_pretty(&mut out, &info)
+            .context("failed to serialize ISO metadata")?;
+        out.write_all(b"\n").context("failed to write newline")?;
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,13 +48,13 @@ fn main() -> Result<()> {
             IsoCmd::Extract(c) => match c {
                 IsoExtractCmd::Pxe(c) => live::iso_extract_pxe(c),
                 IsoExtractCmd::MinimalIso(c) => live::iso_extract_minimal_iso(c),
-                IsoExtractCmd::PackMinimalIso(c) => live::iso_pack_minimal_iso(c),
+                IsoExtractCmd::PackMinimalIso(c) => live::pack_minimal_iso(c),
             },
             IsoCmd::Reset(c) => live::iso_reset(c),
         },
         Cmd::Osmet(c) => match c {
             OsmetCmd::Fiemap(c) => osmet::osmet_fiemap(c),
-            OsmetCmd::Pack(c) => osmet::osmet_pack(c),
+            OsmetCmd::Pack(c) => osmet::pack_osmet(c),
             OsmetCmd::Unpack(c) => osmet::osmet_unpack(c),
         },
         Cmd::Pxe(c) => match c {
@@ -67,6 +67,10 @@ fn main() -> Result<()> {
                 PxeNetworkCmd::Wrap(c) => live::pxe_network_wrap(c),
                 PxeNetworkCmd::Unwrap(c) => live::pxe_network_unwrap(c),
             },
+        },
+        Cmd::Pack(c) => match c {
+            PackCmd::Osmet(c) => osmet::pack_osmet(c),
+            PackCmd::MinimalIso(c) => live::pack_minimal_iso(c),
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,6 @@ fn main() -> Result<()> {
                 IsoKargsCmd::Reset(c) => live::iso_kargs_reset(c),
                 IsoKargsCmd::Show(c) => live::iso_kargs_show(c),
             },
-            IsoCmd::Inspect(c) => live::iso_inspect(c),
             IsoCmd::Extract(c) => match c {
                 IsoExtractCmd::Pxe(c) => live::iso_extract_pxe(c),
                 IsoExtractCmd::MinimalIso(c) => live::iso_extract_minimal_iso(c),
@@ -53,9 +52,7 @@ fn main() -> Result<()> {
             IsoCmd::Reset(c) => live::iso_reset(c),
         },
         Cmd::Osmet(c) => match c {
-            OsmetCmd::Fiemap(c) => osmet::osmet_fiemap(c),
             OsmetCmd::Pack(c) => osmet::pack_osmet(c),
-            OsmetCmd::Unpack(c) => osmet::osmet_unpack(c),
         },
         Cmd::Pxe(c) => match c {
             PxeCmd::Customize(c) => live::pxe_customize(c),
@@ -71,6 +68,15 @@ fn main() -> Result<()> {
         Cmd::Pack(c) => match c {
             PackCmd::Osmet(c) => osmet::pack_osmet(c),
             PackCmd::MinimalIso(c) => live::pack_minimal_iso(c),
+        },
+        Cmd::Dev(c) => match c {
+            DevCmd::Show(c) => match c {
+                DevShowCmd::Iso(c) => live::dev_show_iso(c),
+                DevShowCmd::Fiemap(c) => osmet::dev_show_fiemap(c),
+            },
+            DevCmd::Extract(c) => match c {
+                DevExtractCmd::Osmet(c) => osmet::dev_extract_osmet(c),
+            },
         },
     }
 }

--- a/src/osmet/mod.rs
+++ b/src/osmet/mod.rs
@@ -79,7 +79,7 @@ struct FiemapOutput {
     extents: Vec<Extent>,
 }
 
-pub fn osmet_fiemap(config: OsmetFiemapConfig) -> Result<()> {
+pub fn dev_show_fiemap(config: DevShowFiemapConfig) -> Result<()> {
     let output = FiemapOutput {
         extents: fiemap_path(config.file.as_str().as_ref())?,
     };
@@ -154,7 +154,7 @@ pub fn pack_osmet(config: PackOsmetConfig) -> Result<()> {
     Ok(())
 }
 
-pub fn osmet_unpack(config: OsmetUnpackConfig) -> Result<()> {
+pub fn dev_extract_osmet(config: DevExtractOsmetConfig) -> Result<()> {
     // open output device for writing
     let mut dev = OpenOptions::new()
         .write(true)

--- a/src/osmet/mod.rs
+++ b/src/osmet/mod.rs
@@ -90,7 +90,7 @@ pub fn osmet_fiemap(config: OsmetFiemapConfig) -> Result<()> {
     Ok(())
 }
 
-pub fn osmet_pack(config: OsmetPackConfig) -> Result<()> {
+pub fn pack_osmet(config: PackOsmetConfig) -> Result<()> {
     // First, mount the two main partitions we want to suck out data from: / and /boot. Note
     // MS_RDONLY; this also ensures that the partition isn't already mounted rw elsewhere.
     let disk = Disk::new(&config.device)?;

--- a/tests/help.sh
+++ b/tests/help.sh
@@ -39,6 +39,8 @@ hidden=1
 checklen iso embed
 checklen iso show
 checklen iso remove
+checklen pack
+checklen dev
 
 if [ "${fail}" = 1 ]; then
     exit 1

--- a/tests/images.sh
+++ b/tests/images.sh
@@ -31,7 +31,7 @@ if [ -n "${1:-}" ]; then
     call iso-ignition.sh "${basedir}"/*.iso
     call iso-network.sh "${basedir}"/*.iso
     call iso-kargs.sh "${basedir}"/*.iso
-    call iso-inspect.sh "${basedir}"/*.iso
+    call dev-show-iso.sh "${basedir}"/*.iso
     call iso-extract-pxe.sh "${basedir}"
     call customize.sh "${basedir}"
 else

--- a/tests/images/dev-show-iso.sh
+++ b/tests/images/dev-show-iso.sh
@@ -14,7 +14,7 @@ tmpd=$(mktemp -d)
 trap 'rm -rf "${tmpd}"' EXIT
 cd "${tmpd}"
 
-coreos-installer iso inspect "${iso}" | tee inspect.json
+coreos-installer dev show iso "${iso}" | tee inspect.json
 
 # check that we found the descriptors
 jq -e '.header.descriptors|length > 0' inspect.json

--- a/tests/images/iso-ignition.sh
+++ b/tests/images/iso-ignition.sh
@@ -48,8 +48,8 @@ if [ "${stdout_hash}" != "${hash}" ]; then
 fi
 
 # Check the actual file bits.
-offset=$(coreos-installer iso ignition show --header "${iso}" | jq -r .offset)
-length=$(coreos-installer iso ignition show --header "${iso}" | jq -r .length)
+offset=$(coreos-installer dev show iso --ignition "${iso}" | jq -r .offset)
+length=$(coreos-installer dev show iso --ignition "${iso}" | jq -r .length)
 if [ "${config}" != "$(dd if=${iso} skip=${offset} count=${length} bs=1 status=none | xzcat | cpio -i --to-stdout --quiet)" ]; then
     fatal "Failed to manually round-trip Ignition config"
 fi
@@ -82,7 +82,7 @@ fi
 
 # Test an overlarge Ignition config.  Get some random data from /dev/urandom
 # to ensure it's sufficiently incompressible.
-embed_size=$(coreos-installer iso ignition show --header "${iso}" | jq .length)
+embed_size=$(coreos-installer dev show iso --ignition "${iso}" | jq .length)
 set +x
 random=$(dd if=/dev/urandom bs=1 count=${embed_size} status=none | base64 -w0)
 set -x

--- a/tests/images/iso-kargs.sh
+++ b/tests/images/iso-kargs.sh
@@ -75,7 +75,7 @@ fi
 
 # Test the largest karg; we get the full area length from --header and subtract
 # the default kargs size to get the size of the overflow embed area.
-embed_size=$(coreos-installer iso kargs show --header "${iso}" | jq .length)
+embed_size=$(coreos-installer dev show iso --kargs "${iso}" | jq .length)
 embed_default_kargs_size=$(coreos-installer iso kargs show --default "${iso}" | wc -c)
 embed_usable_size=$((${embed_size} - ${embed_default_kargs_size} - 1))
 
@@ -110,8 +110,8 @@ fi
 
 # Check modification against expected ground truth.
 coreos-installer iso kargs modify -a foobar=val "${iso}"
-offset=$(coreos-installer iso kargs show --header "${iso}" | jq -r .kargs[0].offset)
-length=$(coreos-installer iso kargs show --header "${iso}" | jq -r .kargs[0].length)
+offset=$(coreos-installer dev show iso --kargs "${iso}" | jq -r .kargs[0].offset)
+length=$(coreos-installer dev show iso --kargs "${iso}" | jq -r .kargs[0].length)
 expected_args="$(coreos-installer iso kargs show --default "${iso}") foobar=val"
 expected_args_len="$(echo -n "${expected_args}" | wc -c)"
 filler="$(printf '%*s' $((${length} - ${expected_args_len} - 1)) | tr ' ' '#')"

--- a/tests/images/iso-network.sh
+++ b/tests/images/iso-network.sh
@@ -111,8 +111,8 @@ coreos-installer iso ignition show "${iso}" | grep -q "version"
 (coreos-installer iso network extract "${iso}" 2>&1 ||:) | grep -q "No embedded network settings"
 coreos-installer iso ignition remove "${iso}"
 # verify we haven't written an empty cpio archive
-offset=$(coreos-installer iso ignition show --header "${iso}" | jq -r .offset)
-length=$(coreos-installer iso ignition show --header "${iso}" | jq -r .length)
+offset=$(coreos-installer dev show iso --ignition "${iso}" | jq -r .offset)
+length=$(coreos-installer dev show iso --ignition "${iso}" | jq -r .length)
 dd if="${iso}" skip="${offset}" count="${length}" bs=1 status=none | cmp -n "${length}" - /dev/zero
 rm "${out_iso}"
 


### PR DESCRIPTION
We've gradually accumulated hidden commands and options throughout the subcommand tree.  Some of these are deprecated, which is legitimate, but the rest are build-time/debug commands/options which developers might want to know about.  Since they're individually hidden, there's no discoverability other than by reading the source code.  And in the case of the debug options, the implementation is commingled with user-facing code.

Add a new `pack` command hierarchy for osmet and miniso packing (which form a private API with cosa) and a `dev` hierarchy for development commands (which have no stability at all).  Move everything relevant into them.  For the `pack` commands, leave the original commands as aliases until cosa can be updated.