### PR TITLE
workflows: bump MSRV to 1.51

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   # Minimum supported Rust version (MSRV)
-  ACTIONS_MSRV_TOOLCHAIN: 1.49.0
+  ACTIONS_MSRV_TOOLCHAIN: 1.51.0
   # Pinned toolchain for linting
   ACTIONS_LINTS_TOOLCHAIN: 1.57.0
 


### PR DESCRIPTION
bitvec 0.22 requires it.  For some reason, s390x CI caught this but x86_64 didn't.  OCP 4.10 uses 1.52 and Fedora 35 uses 1.57, so this shouldn't break anything.