### PR TITLE
ci: skip broken kdump.crash kola test

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -17,7 +17,10 @@ cosaPod(buildroot: true, runAsUser: 0) {
     // Make sure cosa is using the binary we just built.
     shwrap("rsync -rlv install/usr/ /usr/")
 
-    fcosBuild(overlays: ["install"])
+    fcosBuild(skipKola: true, overlays: ["install"])
+    // Skipping kdump.crash due to CI failure in coreos-installer repo
+    // https://github.com/coreos/fedora-coreos-tracker/issues/1075
+    fcosKola(extraArgs: "--denylist-test ext.config.kdump.crash")
 
     stage("Build metal+live") {
         shwrap("cd /srv/fcos && cosa buildextend-metal")


### PR DESCRIPTION
ext.config.kdump.crash was failing the upstream CI for afterburn and coreos-installer repos so skipping them for these repositories.
Ref :coreos/fedora-coreos-config#1420 (comment)