### PR TITLE
build(deps): bump tokio from 1.8.0 to 1.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,11 +1337,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",


### PR DESCRIPTION
Fixes CVE-2021-45710 and CVE-2021-38191.