### PR TITLE
cmdline: drop legacy aliases for pack commands

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -52,10 +52,6 @@ pub enum Cmd {
     ListStream(ListStreamConfig),
     /// Commands to manage a CoreOS live ISO image
     Iso(IsoCmd),
-    /// Efficient CoreOS metal disk image packing using OSTree commits
-    // users shouldn't be interacting with this command normally
-    #[structopt(setting(AppSettings::Hidden))]
-    Osmet(OsmetCmd),
     /// Commands to manage a CoreOS live PXE image
     Pxe(PxeCmd),
     /// Metadata packing commands used when building an OS image
@@ -132,17 +128,6 @@ pub enum IsoExtractCmd {
     Pxe(IsoExtractPxeConfig),
     /// Extract a minimal ISO from a CoreOS live ISO image
     MinimalIso(IsoExtractMinimalIsoConfig),
-    /// Pack a minimal ISO into a CoreOS live ISO image
-    // deprecated in favor of "pack minimal-iso"
-    #[structopt(setting(AppSettings::Hidden))]
-    PackMinimalIso(PackMinimalIsoConfig),
-}
-
-#[derive(Debug, StructOpt)]
-pub enum OsmetCmd {
-    /// Create osmet file from CoreOS block device
-    // deprecated in favor of "pack osmet"
-    Pack(PackOsmetConfig),
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,8 @@ fn main() -> Result<()> {
             IsoCmd::Extract(c) => match c {
                 IsoExtractCmd::Pxe(c) => live::iso_extract_pxe(c),
                 IsoExtractCmd::MinimalIso(c) => live::iso_extract_minimal_iso(c),
-                IsoExtractCmd::PackMinimalIso(c) => live::pack_minimal_iso(c),
             },
             IsoCmd::Reset(c) => live::iso_reset(c),
-        },
-        Cmd::Osmet(c) => match c {
-            OsmetCmd::Pack(c) => osmet::pack_osmet(c),
         },
         Cmd::Pxe(c) => match c {
             PxeCmd::Customize(c) => live::pxe_customize(c),


### PR DESCRIPTION
coreos-assembler has been updated to use the new subcommands.

Requires https://github.com/coreos/coreos-assembler/pull/2631.