### PR TITLE
docs/customizing-install: update for `iso/pxe customize`

### DIFF
--- a/docs/customizing-install.md
+++ b/docs/customizing-install.md
@@ -110,6 +110,8 @@ architecture: name
 preserve-on-error: true
 # Fetch retries, or string "infinite"
 fetch-retries: N
+# Destination device
+dest-device: path
 ```
 
 ## Hooking coreos-installer at boot time

--- a/docs/customizing-install.md
+++ b/docs/customizing-install.md
@@ -103,46 +103,6 @@ All config files in the `installer.d` directory are evaluated in
 alphabetical order, and any `coreos.inst` kernel command line arguments are
 evaluated afterward.
 
-### Example manual customization via `installer.d`
-
-This is an example procedure for configuring an ISO or PXE installation to
-`/dev/zda` using an installer config file.  The ISO procedure matches the
-steps performed by `coreos-installer iso customize --dest-device`, and the
-PXE procedure produces the same result as `coreos-installer pxe customize
---dest-device` via a slightly different path.
-
-Write a Butane config that installs to `/dev/zda`:
-
-```
-variant: fcos
-version: 1.4.0
-storage:
-  files:
-    - path: /etc/coreos/installer.d/custom.yaml
-      contents:
-        inline: |
-          dest-device: /dev/zda
-```
-
-Convert this Butane config to an Ignition config with:
-
-```
-butane < install.bu > install.ign
-```
-
-For live ISO booting, embed the resulting config in the live ISO:
-
-```
-coreos-installer iso ignition embed -i install.ign fedora-coreos-35.20211029.3.0-live.x86_64.iso
-```
-
-For live PXE booting, use only the Ignition first-boot arguments in the
-kernel argument list:
-
-```
-ignition.config.url=https://example.com/install.ign ignition.firstboot ignition.platform.id=metal
-```
-
 ### Config file format
 
 Config files in `/etc/coreos/installer.d` (or specified by `--config-file`)
@@ -195,4 +155,44 @@ preserve-on-error: true
 fetch-retries: N
 # Destination device
 dest-device: path
+```
+
+### Example manual customization via `installer.d`
+
+This is an example procedure for configuring an ISO or PXE installation to
+`/dev/zda` using an installer config file.  The ISO procedure matches the
+steps performed by `coreos-installer iso customize --dest-device`, and the
+PXE procedure produces the same result as `coreos-installer pxe customize
+--dest-device` via a slightly different path.
+
+Write a Butane config that installs to `/dev/zda`:
+
+```
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+    - path: /etc/coreos/installer.d/custom.yaml
+      contents:
+        inline: |
+          dest-device: /dev/zda
+```
+
+Convert this Butane config to an Ignition config with:
+
+```
+butane < install.bu > install.ign
+```
+
+For live ISO booting, embed the resulting config in the live ISO:
+
+```
+coreos-installer iso ignition embed -i install.ign fedora-coreos-35.20211029.3.0-live.x86_64.iso
+```
+
+For live PXE booting, use only the Ignition first-boot arguments in the
+kernel argument list:
+
+```
+ignition.config.url=https://example.com/install.ign ignition.firstboot ignition.platform.id=metal
 ```

--- a/docs/customizing-install.md
+++ b/docs/customizing-install.md
@@ -8,10 +8,85 @@ nav_order: 5
 1. TOC
 {:toc}
 
+## Creating customized ISO and PXE images
+
+The [`iso customize`](cmd/iso.md#coreos-installer-iso-customize) and
+[`pxe customize`](cmd/pxe.md#coreos-installer-pxe-customize) commands can be
+used to create customized ISO and PXE images with site-specific
+configuration, including the ability to perform unattended installations.
+This is the recommended method for automatically running coreos-installer at
+boot.
+
+For example:
+
+```bash
+# Create customized.iso which:
+# - Automatically installs to /dev/sda
+# - Provisions the installed system with config.ign
+# - Uses network configuration from static-ip.nmconnection
+# - Trusts HTTPS certificates signed by ca.pem
+# - Runs post.sh after installing
+coreos-installer iso customize \
+    --dest-device /dev/sda \
+    --dest-ignition config.ign \
+    --network-keyfile static-ip.nmconnection \
+    --ignition-ca ca.pem \
+    --post-install post.sh \
+    -o custom.iso input.iso
+# Same, but create a customized PXE initramfs image
+coreos-installer pxe customize \
+    --dest-device /dev/sda \
+    --dest-ignition config.ign \
+    --network-keyfile static-ip.nmconnection \
+    --ignition-ca ca.pem \
+    --post-install post.sh \
+    -o custom-initramfs.img input-initramfs.img
+```
+
+### Customize options
+
+Available customizations include:
+
+- Specifying an Ignition config to be applied to the installed system
+  (`--dest-ignition`) or to the live environment where the installer runs
+  (`--live-ignition`).
+- Specifying the device to which the operating system will be installed
+  (`--dest-device`).  If an ISO or PXE image has been customized with
+  `--dest-device`, booting that image will automatically install to the
+  specified disk and reboot the system.
+- Specifying network configuration for both the installed system and the
+  live environment via
+  [NetworkManager keyfiles](https://developer.gnome.org/NetworkManager/stable/nm-settings-keyfile.html)
+  (`--network-keyfile`).  The configuration is applied before Ignition runs,
+  so this option is useful for specifying network settings that are needed
+  for Ignition to fetch remote resources.
+- Specifying HTTPS certificate authorities to be trusted by Ignition, in
+  both the installed system and the live environment (`--ignition-ca`).
+- Modifying kernel arguments of the installed system (`--dest-karg-append`,
+  `--dest-karg-delete`) or the live ISO environment (`--live-karg-append`,
+  `--live-karg-replace`, `--live-karg-delete`).  These options are useful if
+  the machine will not boot at all without certain kernel arguments,
+  preventing use of the Ignition `kernel_arguments` directives.  There are
+  no `--live-karg` options for the PXE image; modify the PXE boot
+  configuration instead.
+- Running scripts before or after installation (`--pre-install`,
+  `--post-install`).  For example, a pre-install script might run a
+  container that performs hardware validation, or a post-install script
+  might use IPMI to configure the machine to boot from the local disk
+  instead of the network.  Pre-install scripts can change the options
+  processed by coreos-installer, including the choice of destination device,
+  by writing an installer config file to `/etc/coreos/installer.d` (see
+  below).
+- Specifying arbitrary options to `coreos-installer install` via an
+  installer config file (see below).
+
+All options except `--dest-device` can be specified multiple times.
+
 ## Customizing coreos-installer invocation
 
-coreos-installer can run automatically during boot of a CoreOS live image
-(ISO or PXE) using either kernel command-line arguments or a config file.
+Alternatively, coreos-installer can be run automatically during boot of a
+CoreOS live image (ISO or PXE) using either kernel command-line arguments
+or a config file.
 
 [Kernel arguments](getting-started.md#kernel-command-line-options-for-coreos-installer-running-as-a-service)
 are easier for simple cases, but not all coreos-installer parameters can be
@@ -24,7 +99,19 @@ To do this, specify an Ignition config to the live boot that runs the
 installer.  This config is distinct from the Ignition config that governs
 the installed system.
 
-This is a sample Butane config that installs to `/dev/zda`:
+All config files in the `installer.d` directory are evaluated in
+alphabetical order, and any `coreos.inst` kernel command line arguments are
+evaluated afterward.
+
+### Example manual customization via `installer.d`
+
+This is an example procedure for configuring an ISO or PXE installation to
+`/dev/zda` using an installer config file.  The ISO procedure matches the
+steps performed by `coreos-installer iso customize --dest-device`, and the
+PXE procedure produces the same result as `coreos-installer pxe customize
+--dest-device` via a slightly different path.
+
+Write a Butane config that installs to `/dev/zda`:
 
 ```
 variant: fcos
@@ -55,10 +142,6 @@ kernel argument list:
 ```
 ignition.config.url=https://example.com/install.ign ignition.firstboot ignition.platform.id=metal
 ```
-
-All config files in the `installer.d` directory are evaluated in
-alphabetical order, and any `coreos.inst` kernel command line arguments are
-evaluated afterward.
 
 ### Config file format
 
@@ -112,92 +195,4 @@ preserve-on-error: true
 fetch-retries: N
 # Destination device
 dest-device: path
-```
-
-## Hooking coreos-installer at boot time
-
-When coreos-installer is run automatically from a CoreOS live image (ISO or
-PXE), additional custom code can be run before or after the installer.  To
-do this, specify an Ignition config to the live boot that runs the
-installer.  This can be useful for automated hardware probing or interacting
-with a provisioning system, e.g. to automatically select the target install
-disk.
-
-This is a sample Butane config with hooks that run both before and
-after the installer:
-
-```
-variant: fcos
-version: 1.1.0
-
-storage:
-  files:
-    - path: /usr/local/bin/pre-install-hook
-      mode: 0755
-      contents:
-        inline: |
-          #!/bin/bash
-
-          set -euo pipefail
-          sleep 10
-          echo "pre-hook"
-    - path: /usr/local/bin/post-install-hook
-      mode: 0755
-      contents:
-        inline: |
-          #!/bin/bash
-
-          set -euo pipefail
-          sleep 10
-          echo "post-hook"
-
-systemd:
-  units:
-    - name: pre-install-hook.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Run before install
-        After=coreos-installer-pre.target
-        Before=coreos-installer.service
-
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/local/bin/pre-install-hook
-
-        [Install]
-        RequiredBy=coreos-installer.service
-    - name: post-install-hook.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Run after install
-        After=coreos-installer.service
-        Before=coreos-installer.target
-
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/local/bin/post-install-hook
-
-        [Install]
-        RequiredBy=coreos-installer.target
-```
-
-Convert this Butane config to an Ignition config with:
-
-```
-butane < hooks.bu > hooks.ign
-```
-
-For live ISO booting, embed the resulting config in the live ISO:
-
-```
-coreos-installer iso ignition embed -i hooks.ign fedora-coreos-35.20211029.3.0-live.x86_64.iso
-```
-
-For live PXE booting, add Ignition first-boot arguments to the kernel argument
-list:
-
-```
-coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=https://example.com/install-config.ign ignition.config.url=https://example.com/hooks.ign ignition.firstboot ignition.platform.id=metal
 ```


### PR DESCRIPTION
Deemphasize customizing via kernel arguments and manual Ignition embedding, since `iso/pxe customize` has better UX.

Drop documentation of manual pre/post hooks, since it's very clunky and `iso/pxe customize` can handle this.