### PR TITLE
cargo: coreos-installer release 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.13.0"
+version = "0.13.1"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- Add Fedora 37 signing key; drop Fedora 34 signing key

Minor changes:

- install: Drop support for `COREOS_INSTALLER_NO_MOUNT_NAMESPACE`
- install: Eliminate partition table reread delay on busy block devices

Internal changes:

- Fix packing minimal ISO with empty files
- Move build-time packing commands to new `pack` subcommand
- Move developer-related commands to new `dev` subcommand
- Add `dev show initrd` and `dev extract initrd` subcommands
- verify-unique-fs-label: Add `--rereadpt` to reread partition tables first

Packaging changes:

- Disable LTO
- Disable debug symbols in container
- Require Rust ≥ 1.51.0