### PR TITLE
Add COPR integration Makefile and add CI test for RPM building 

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,12 @@
+.PHONY: srpm
+srpm:
+	dnf install -y git rust-packaging rpm-build rpmdevtools
+	curl -LO https://src.fedoraproject.org/rpms/rust-coreos-installer/raw/rawhide/f/rust-coreos-installer.spec
+	version=$$(git describe --always --tags | sed -e 's,-,\.,g' -e 's,^v,,'); \
+	git archive --format=tar --prefix=coreos-installer-$$version/ HEAD | gzip > coreos-installer-$$version.crate; \
+	sed -ie "s,^Version:.*,Version: $$version," rust-coreos-installer.spec
+	sed -ie 's/^Patch/# Patch/g' rust-coreos-installer.spec  # we don't want any downstream patches
+	sed -ie 's/^Source1/# Source1/g' rust-coreos-installer.spec  # we don't vendor
+	spectool -g -s 2 rust-coreos-installer.spec  # fetch coreos-installer-dracut just to satisfy rpmbuild
+	rpmbuild -bs --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" --define "_rpmdir ${PWD}" --define "_buildrootdir ${PWD}/.build" rust-coreos-installer.spec
+	mv *.src.rpm $$outdir

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,34 @@
+---
+name: RPM build
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+
+jobs:
+  test-rpm-build:
+    name: "RPM build"
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+      options: --privileged
+    steps:
+      # need to install git before checkout to get a git repo
+      - name: Install packages
+        run: dnf install -y git make mock
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build RPM
+        run: |
+          mkdir rpms
+          make -f .copr/Makefile srpm outdir=rpms
+          mock --rebuild rpms/*.src.rpm
+          find /var/lib/mock -wholename '*/result/*.rpm' | xargs mv -t rpms
+      - name: Archive RPMs
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpms
+          path: rpms/


### PR DESCRIPTION
```
commit d768073f4531ee3666a5206235d49fa83609c3f0
Date:   Tue Feb 15 12:23:37 2022 -0500

    Add COPR integration Makefile

    I'd like to enable auto-builds of this repo to
    https://copr.fedorainfracloud.org/coprs/g/CoreOS/continuous/ so it could
    eventually feed into
    https://github.com/coreos/fedora-coreos-tracker/issues/910.
```
```
commit b9e7ec2b3bbe79b9dcc79d70c69b5459b92d8957
Date:   Tue Feb 15 12:31:03 2022 -0500

    workflows: make TOOLCHAIN optional

    For a future test, I'd like to ensure that we're using the Rust tooling
    from Fedora. So let's make the rustup setup optional so we don't have to
    worry about which `rustc` is actually being used.

```
```
commit 6ef95ab3a648a225a0f3874e69d611feb6ce47ec
Date:   Tue Feb 15 12:37:30 2022 -0500

    workflows: add "RPM build" test

    Verify that we can build using purely Fedora packages. This will catch
    earlier any Rust packages we need to update or add in Fedora rather than
    find out at release time.

    It also ensures that the new continuous COPR builds will not break since
    we don't vendor there either.
```