### PR TITLE
workflows/rpm: do full git clone and reword workflow and job name

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,5 +1,5 @@
 ---
-name: RPM build
+name: RPMs
 on:
   push:
     branches: [main]
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test-rpm-build:
-    name: "RPM build"
+    name: "Build (Fedora)"
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/fedora:latest
@@ -24,7 +24,7 @@ jobs:
         # fetch tags for versioning
         with:
           fetch-depth: 0
-      - name: Build RPM
+      - name: Build RPMs
         run: |
           mkdir rpms
           make -f .copr/Makefile srpm outdir=rpms

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -21,6 +21,9 @@ jobs:
         run: dnf install -y git make mock
       - name: Checkout repository
         uses: actions/checkout@v2
+        # fetch tags for versioning
+        with:
+          fetch-depth: 0
       - name: Build RPM
         run: |
           mkdir rpms


### PR DESCRIPTION
```
commit ed6b2a260bc109bec1ae5823cdbfec8f68646560
Date:   Tue Feb 22 09:51:14 2022 -0500

    workflows/rpm: do full git clone

    Notably, we want the tags so that the `git describe`-derived version is
    valid. For CI test purposes, this doesn't really matter, but it makes
    the artifacts archived more useful.
```

```
commit 64c5c9fb12011c9878e696163c8bdf582d808941
Date:   Tue Feb 22 09:53:36 2022 -0500

    workflows/rpm: reword workflow and job name

    It's verbose to have them both be "RPM build". Make the workflow "RPMs"
    and the specific job "Build (Fedora)". This makes it more consistent
    with the "Containers" workflow.
```