### PR TITLE
POC/RFC: Support reinstalls via `kexec`

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -46,6 +46,8 @@ use crate::io::IgnitionHash;
 pub enum Cmd {
     /// Install Fedora CoreOS or RHEL CoreOS
     Install(InstallConfig),
+    /// Re-Install Fedora CoreOS or RHEL CoreOS
+    Reinstall(ReinstallConfig),
     /// Download a CoreOS image
     Download(DownloadConfig),
     /// List available images in a Fedora CoreOS stream
@@ -452,6 +454,101 @@ pub enum FetchRetries {
 pub enum PartitionFilter {
     Label(glob::Pattern),
     Index(Option<NonZeroU32>, Option<NonZeroU32>),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct ReinstallConfig {
+    // These are all the options we can drive purely from kargs.
+    // XXX: should dedupe with `InstallConfig` and reuse the config-file mechanism.
+
+    // ways to specify the image source
+    /// Fedora CoreOS stream
+    #[structopt(short, long, value_name = "name")]
+    #[structopt(conflicts_with = "image-url")]
+    pub stream: Option<String>,
+    /// Manually specify the image URL
+    #[structopt(short = "u", long, value_name = "URL")]
+    #[structopt(conflicts_with = "stream")]
+    pub image_url: Option<Url>,
+
+    // postprocessing options
+    /// Embed an Ignition config from a URL
+    #[structopt(short = "I", long, value_name = "URL")]
+    #[structopt(conflicts_with = "ignition-file")]
+    pub ignition_url: Option<Url>,
+    /// Override the Ignition platform ID
+    #[structopt(short, long, value_name = "name")]
+    pub platform: Option<String>,
+    /// Save partitions with this label glob
+    #[structopt(long, value_name = "lx")]
+    // Allow argument multiple times, but one value each.  Allow "a,b" in
+    // one argument.
+    #[structopt(number_of_values = 1, require_delimiter = true)]
+    pub save_partlabel: Vec<String>,
+    /// Save partitions with this number or range
+    #[structopt(long, value_name = "id")]
+    // Allow argument multiple times, but one value each.  Allow "1-5,7" in
+    // one argument.
+    #[structopt(number_of_values = 1, require_delimiter = true)]
+    // Allow ranges like "-2".
+    #[structopt(allow_hyphen_values = true)]
+    pub save_partindex: Vec<String>,
+
+    // obscure options without short names
+    /// Skip signature verification
+    // XXX: should have independent switch for immediate vs delayed (e.g. image-url) fetches
+    #[structopt(long)]
+    pub insecure: bool,
+    /// Fetch retries, or "infinite"
+    #[structopt(long, value_name = "N", default_value)]
+    pub fetch_retries: FetchRetries,
+
+    // positional args
+    /// Destination device
+    pub dest_device: String,
+
+    // specific to `reinstall`
+    /// Skip rebooting after reinstall
+    #[structopt(long)]
+    pub skip_reboot: bool,
+    /// URL to initramfs
+    #[structopt(
+        long,
+        value_name = "URL",
+        conflicts_with = "initramfs-file",
+        requires = "rootfs-url"
+    )]
+    pub initramfs_url: Option<Url>,
+    /// Local path to initramfs
+    #[structopt(
+        long,
+        value_name = "PATH",
+        conflicts_with = "initramfs-url",
+        requires = "rootfs-file"
+    )]
+    pub initramfs_file: Option<String>,
+    /// URL to rootfs
+    #[structopt(
+        long,
+        value_name = "URL",
+        conflicts_with = "rootfs-file",
+        requires = "initramfs-url"
+    )]
+    pub rootfs_url: Option<Url>,
+    /// Local path to rootfs
+    #[structopt(
+        long,
+        value_name = "PATH",
+        conflicts_with = "rootfs-url",
+        requires = "initramfs-file"
+    )]
+    pub rootfs_file: Option<String>,
+    /// Use `coreos.live.rootfs_url` instead of appending.
+    #[structopt(long, conflicts_with = "rootfs-file")]
+    pub defer_rootfs: bool,
+    /// Serial console to use
+    #[structopt(long, value_name = "KARG", default_value = "ttyS0")]
+    pub console: String,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> Result<()> {
     match Cmd::from_args() {
         Cmd::Download(c) => download::download(c),
         Cmd::Install(c) => install::install(c),
+        Cmd::Reinstall(c) => install::reinstall(c),
         Cmd::ListStream(c) => source::list_stream(c),
         Cmd::Iso(c) => match c {
             IsoCmd::Customize(c) => live::iso_customize(c),


### PR DESCRIPTION
This is a proof-of-concept showing how we can use `kexec` to support reinstalling assuming we have access to the rootfs image (this is strongly related to or exactly the same as https://github.com/coreos/fedora-coreos-tracker/issues/399 depending on which flavour of "reset" we're talking about).

Demo:

```
$ coreos-installer reinstall /dev/vda --platform qemu --insecure
Downloading https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.10/410.84.202112091617-0/x86_64/rhcos-410.84.20.
Downloading https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.10/410.84.202112091617-0/x86_64/rhcos-410.84.202112091617-0-live-rootfs.x86_64.img...
Loading kernel and initramfs with arguments:  coreos.inst.install_dev=/dev/vda console=ttyS0 coreos.inst.platform_id=qemu coreos.inst.insecure
Pivoting
[ 1259.444402] kexec_core: Starting new kernel
[    0.000000] Linux version 4.18.0-305.28.1.el8_4.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com) (gcc version 8.4.1 20200928 (Re1
[    0.000000] Command line:  coreos.inst.install_dev=/dev/vda console=ttyS0 coreos.inst.platform_id=qemu coreos.inst.insecure
[   15.495212] coreos-installer-service[1066]: coreos-installer install /dev/vda --platform qemu --insecure --fetch-retries infinite
[   15.660528] coreos-installer-service[1066]: Installing Red Hat Enterprise Linux CoreOS 410.84.202112091617-0 (Ootpa) x86_64 (512-byte)
[   15.951946]  vda: vda1 vda2 vda3 vda4
[   15.960578]  vda: vda1 vda2 vda3 vda4
[   16.955472] coreos-installer-service[1066]: Read disk 43.7 MiB/3.7 GiB (1%)
[  100.914384] coreos-installer-service[1066]: Read disk 3.7 GiB/3.7 GiB (100%)
[  106.201139] coreos-installer-service[1066]: Install complete.
[  107.902354] reboot: Restarting system
[  107.907561] reboot: machine restart
...
Red Hat Enterprise Linux CoreOS 410.84.202112091617-0 (Ootpa) 4.10
Ignition: ran on 2021/12/10 23:10:41 UTC (this boot)
Ignition: user-provided config was applied

[core@cosa-devsh ~]$ journalctl --list-boots --no-pager
 0 5588b683714241839237799c72ca28c6 Fri 2021-12-10 23:10:33 UTC—Fri 2021-12-10 23:12:01 UTC
```

(I've cut out a lot of stuff from the logs there to concentrate on the interesting bits; see [this attachment](https://github.com/coreos/coreos-installer/files/7706947/log.txt) for the full output if you're curious.)

It also supports specifying the target Ignition config, image URL, using a local live initramfs and live rootfs, etc...

FCOS is also supported though for there seems to be a bug in the kexec code there.