### PR TITLE
blockdev: print vendor dirs found

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -940,9 +940,10 @@ pub fn find_efi_vendor_dir(efi_mount: &Mount) -> Result<PathBuf> {
     }
     if vendor_dir.len() != 1 {
         bail!(
-            "Expected one vendor dir on {}, got {}",
+            "Expected one vendor dir on {}, got {} ({:?})",
             efi_mount.device(),
-            vendor_dir.len()
+            vendor_dir.len(),
+            vendor_dir,
         );
     }
     Ok(vendor_dir.pop().unwrap())


### PR DESCRIPTION
This can help figuring out what went wrong.

Related: https://github.com/coreos/fedora-coreos-tracker/issues/1116