### PR TITLE
blockdev: rework EFI vendor dir checking

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -930,13 +930,13 @@ pub fn find_efi_vendor_dir(efi_mount: &Mount) -> Result<PathBuf> {
     let mut vendor_dir: Vec<PathBuf> = Vec::new();
     for ent in p.read_dir()? {
         let ent = ent.with_context(|| format!("reading directory entry in {}", p.display()))?;
-        if ent.file_name() == "BOOT" {
-            continue;
-        }
         if !ent.file_type()?.is_dir() {
             continue;
         }
-        vendor_dir.push(ent.path());
+        let path = ent.path();
+        if path.join("grub.cfg").is_file() {
+            vendor_dir.push(path);
+        }
     }
     if vendor_dir.len() != 1 {
         bail!(


### PR DESCRIPTION
On some Dell machines at least, something (UEFI firmware?) creates a
`Dell` directory in the `EFI` dir. This throws off our logic here which
expects only a single vendor dir.

Let's tweak the logic so that we only consider a "vendor dir" a
directory which has a `grub.cfg`.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1116