### PR TITLE
Bump clippy to 1.59

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTIONS_MSRV_TOOLCHAIN: 1.51.0
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.58.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.59.0
 
 defaults:
   run:

--- a/src/download.rs
+++ b/src/download.rs
@@ -431,7 +431,7 @@ impl<'a, R: Read> ProgressReader<'a, R> {
         });
         // disable percentage reporting for zero-length files to avoid
         // division by zero
-        let length = length.map(NonZeroU64::new).flatten();
+        let length = length.and_then(NonZeroU64::new);
         ProgressReader {
             source,
             length: length.map(|l| (l, Self::format_bytes(l.get()))),

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -297,6 +297,7 @@ pub fn iso_kargs_reset(config: IsoKargsResetConfig) -> Result<()> {
     let mut iso_file = open_live_iso(&config.input, Some(config.output.as_ref()))?;
     let mut iso = IsoConfig::for_file(&mut iso_file)?;
 
+    #[allow(clippy::unnecessary_to_owned)]
     iso.set_kargs(&iso.kargs_default()?.to_string())?;
 
     write_live_iso(&iso, &mut iso_file, config.output.as_ref())
@@ -359,6 +360,7 @@ pub fn iso_reset(config: IsoResetConfig) -> Result<()> {
 
     *iso.initrd_mut() = Initrd::default();
     if iso.kargs_supported() {
+        #[allow(clippy::unnecessary_to_owned)]
         iso.set_kargs(&iso.kargs_default()?.to_string())?;
     };
 


### PR DESCRIPTION
Clippy has some false positives on the `to_string()` calls, which are necessary to prevent mixed mutable/immutable borrows.