### PR TITLE
github/release-checklist: Remove Windows binaries from vendored sources

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -54,6 +54,7 @@ Push access to the upstream repository is required in order to publish the new t
 
 - assemble vendor archive:
   - [ ] `cargo vendor target/vendor`
+  - [ ] `rm -rf vendor/winapi*gnu*/lib/*.a`
   - [ ] `tar -czf target/coreos-installer-${RELEASE_VER}-vendor.tar.gz -C target vendor`
 
 - publish this release on GitHub:


### PR DESCRIPTION
Workaround to remove Windows specific binaries that we don't need from
the vendored sources.

See: https://github.com/rust-lang/cargo/issues/7058