### PR TITLE
workflows: build and push container from GitHub Actions

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,23 +1,30 @@
----
 name: Containers
 
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 
 permissions:
   contents: read
 
+# avoid races when pushing containers built from main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
-  build-fedora-image:
-    name: "Build container image (Fedora)"
+  build:
+    name: Build container image
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build container image
-        uses: docker/build-push-action@v2
+      - name: Build and push container
+        uses: coreos/actions-lib/build-container@main
         with:
-          file: ./Dockerfile
+          credentials: ${{ secrets.QUAY_AUTH }}
+          push: quay.io/coreos/coreos-installer
+          # Speed up PR CI by skipping arm64
+          pr-arches: amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ COPY Cargo.* ./
 COPY src src/
 # Debug symbols are nice but they're not 100+ MB of nice
 RUN sed -i 's/^debug = true$/debug = false/' Cargo.toml
+# aarch64 release builds running in emulation take too long and time out the
+# GitHub Action.  Disable optimization.
+RUN sh -c 'if [ $(uname -p) != x86_64 ]; then sed -i "s/^debug = false$/debug = false\nopt-level = 0/" Cargo.toml; fi'
 RUN cargo build --release
 
 FROM registry.fedoraproject.org/fedora:35


### PR DESCRIPTION
Quay builds are amd64-only and haven't been especially reliable.  Use GitHub Actions to build both amd64 and arm64 containers for the main branch and for tags, and push them to Quay.  Continue building but not pushing containers on PR.  Requires the `QUAY_AUTH` repo secret to be set to a Docker credential.

Disable optimization in non-amd64 container builds to prevent the build job from timing out.

The build-container action doesn't cache build artifacts, unlike the Rust test job.  Skip the arm64 container in PRs to speed up CI.

Fixes https://github.com/coreos/coreos-installer/issues/793.