### PR TITLE
Silence some errors when output is closed; fix tests not to do that

### DIFF
--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -24,6 +24,7 @@ use crate::cmdline::*;
 use crate::io::*;
 use crate::iso9660::{self, IsoFs};
 use crate::miniso;
+use crate::util::set_die_on_sigpipe;
 
 mod customize;
 mod embed;
@@ -95,6 +96,7 @@ pub fn iso_ignition_embed(config: IsoIgnitionEmbedConfig) -> Result<()> {
 }
 
 pub fn iso_ignition_show(config: IsoIgnitionShowConfig) -> Result<()> {
+    set_die_on_sigpipe()?;
     let mut iso_file = open_live_iso(&config.input, None)?;
     let iso = IsoConfig::for_file(&mut iso_file)?;
     if !iso.have_ignition() {
@@ -181,6 +183,7 @@ pub fn pxe_ignition_wrap(config: PxeIgnitionWrapConfig) -> Result<()> {
 }
 
 pub fn pxe_ignition_unwrap(config: PxeIgnitionUnwrapConfig) -> Result<()> {
+    set_die_on_sigpipe()?;
     let stdin = io::stdin();
     let mut f: Box<dyn Read> = if let Some(path) = &config.input {
         Box::new(
@@ -265,6 +268,7 @@ fn initrd_network_extract(initrd: &Initrd, directory: Option<&String>) -> Result
             println!("{}", path.display());
         }
     } else {
+        set_die_on_sigpipe()?;
         for (i, (path, contents)) in files.iter().enumerate() {
             if i > 0 {
                 println!();
@@ -304,6 +308,7 @@ pub fn iso_kargs_reset(config: IsoKargsResetConfig) -> Result<()> {
 }
 
 pub fn iso_kargs_show(config: IsoKargsShowConfig) -> Result<()> {
+    set_die_on_sigpipe()?;
     let mut iso_file = open_live_iso(&config.input, None)?;
     let iso = IsoConfig::for_file(&mut iso_file)?;
     let kargs = if config.default {
@@ -456,6 +461,7 @@ struct DevShowIsoOutput {
 }
 
 pub fn dev_show_iso(config: DevShowIsoConfig) -> Result<()> {
+    set_die_on_sigpipe()?;
     let mut iso_file = open_live_iso(&config.input, None)?;
     let stdout = io::stdout();
     let mut out = stdout.lock();
@@ -487,6 +493,7 @@ pub fn dev_show_iso(config: DevShowIsoConfig) -> Result<()> {
 }
 
 pub fn dev_show_initrd(config: DevShowInitrdConfig) -> Result<()> {
+    set_die_on_sigpipe()?;
     let initrd = read_initrd(&config.input, &config.filter)?;
     for path in initrd.find(&ALL_GLOB).keys() {
         println!("{}", path);

--- a/src/source.rs
+++ b/src/source.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 
 use crate::cmdline::*;
 use crate::osmet::*;
+use crate::util::set_die_on_sigpipe;
 
 /// Completion timeout for HTTP requests (4 hours).
 const HTTP_COMPLETION_TIMEOUT: Duration = Duration::from_secs(4 * 60 * 60);
@@ -420,6 +421,7 @@ pub fn list_stream(config: ListStreamConfig) -> Result<()> {
     }
 
     // report results
+    set_die_on_sigpipe()?;
     for row in &rows {
         println!(
             "{:3$}  {:4$}  {}",

--- a/tests/images/dev-initrd.sh
+++ b/tests/images/dev-initrd.sh
@@ -33,6 +33,13 @@ check() {
     popd >/dev/null
 }
 
+grepq() {
+    # Emulate grep -q without actually using it, to avoid propagating write
+    # errors to the writer after a match, which would cause problems with
+    # -o pipefail
+    grep "$@" > /dev/null
+}
+
 # dev show initrd
 coreos-installer dev show initrd compressed.img > out
 files | diff - out
@@ -48,7 +55,7 @@ files | grep -E 'gzip|xz' | diff - out
 # dev extract initrd
 coreos-installer dev extract initrd compressed.img
 check . gzip uncompressed-1 uncompressed-2 xz
-(coreos-installer dev extract initrd compressed.img 2>&1 ||:) | grep -q exists
+(coreos-installer dev extract initrd compressed.img 2>&1 ||:) | grepq exists
 rm -r gzip uncompressed-[12] xz
 coreos-installer dev extract initrd -C d - < compressed.img
 check d gzip uncompressed-1 uncompressed-2 xz
@@ -64,9 +71,9 @@ check d gzip xz
 [ -e d/uncompressed-2 ] && exit 1
 rm -r d
 (coreos-installer dev extract initrd \
-    "${fixtures}/initrd/traversal-absolute.img" 2>&1 ||:) | grep -q traversal
+    "${fixtures}/initrd/traversal-absolute.img" 2>&1 ||:) | grepq traversal
 (coreos-installer dev extract initrd \
-    "${fixtures}/initrd/traversal-relative.img" 2>&1 ||:) | grep -q traversal
+    "${fixtures}/initrd/traversal-relative.img" 2>&1 ||:) | grepq traversal
 
 # Done
 echo "Success."

--- a/tests/images/unsupported.sh
+++ b/tests/images/unsupported.sh
@@ -21,43 +21,50 @@ try() {
     (coreos-installer "$@" 2>&1 ||:)
 }
 
+grepq() {
+    # Emulate grep -q without actually using it, to avoid propagating write
+    # errors to the writer after a match, which would cause problems with
+    # -o pipefail
+    grep "$@" > /dev/null
+}
+
 # iso customize feature handling is tested in customize.sh
 
 # no Ignition embed area
 echo '{"ignition": {"version": "3.0.0"}' |
     try iso ignition embed synthetic.iso |
-    grep -q "Unrecognized CoreOS ISO image"
+    grepq "Unrecognized CoreOS ISO image"
 
 # no kargs embed area
 try iso kargs modify -a foobar embed-areas-2020-09.iso |
-     grep -q "No karg embed areas found"
+     grepq "No karg embed areas found"
 try iso kargs modify -a foobar embed-areas-2020-09.iso -o out.iso |
-     grep -q "No karg embed areas found"
+     grepq "No karg embed areas found"
 try iso kargs modify -a foobar embed-areas-2020-09.iso -o - |
-     grep -q "No karg embed areas found"
+     grepq "No karg embed areas found"
 try iso kargs show embed-areas-2020-09.iso |
-     grep -q "No karg embed areas found"
+     grepq "No karg embed areas found"
 try iso kargs show --default embed-areas-2020-09.iso |
-     grep -q "No karg embed areas found"
+     grepq "No karg embed areas found"
 try iso kargs reset embed-areas-2020-09.iso -o - |
-     grep -q "No karg embed areas found"
+     grepq "No karg embed areas found"
 try iso kargs reset embed-areas-2020-09.iso -o out.iso |
-     grep -q "No karg embed areas found"
+     grepq "No karg embed areas found"
 try iso kargs reset embed-areas-2020-09.iso |
-     grep -q "No karg embed areas found"
+     grepq "No karg embed areas found"
 
 # no network settings support
 try iso network embed -k "${fixtures}/customize/installer-test.nmconnection" \
     embed-areas-2021-09.iso |
-    grep -q "does not support customizing network settings"
+    grepq "does not support customizing network settings"
 
 # no miniso support
 try iso extract minimal-iso embed-areas-2021-09.iso minimal.iso |
-    grep -q "does not support extracting a minimal ISO"
+    grepq "does not support extracting a minimal ISO"
 
 # no PXE images
 try iso extract pxe synthetic.iso |
-    grep -q "Unrecognized CoreOS ISO image"
+    grepq "Unrecognized CoreOS ISO image"
 
 # Done
 echo "Success."


### PR DESCRIPTION
Rust ignores `SIGPIPE` by default, which causes verbose failures when our output is piped to a program that exits.  In simple reporting and debugging commands where there's no need to clean up after execution, avoid this by resetting the `SIGPIPE` handler to `SIG_DFL`.

In the image tests, if `grep -q` exits while the writer has more data to write, the writer will die on `SIGPIPE` or otherwise exit nonzero, and then the test will fail because we set `-o pipefail`.  Use `grep > /dev/null` instead.  Fixes intermittent failures in CI.

