### PR TITLE
Add man page generation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -201,6 +201,7 @@ jobs:
         run: tests/docs-config-file.sh
       - name: Command-line docs
         run: |
+          rm man/*.8
           make docs
           if [ -n "$(git status --porcelain docs)" ]; then
             echo "Found local changes after regenerating docs:"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_mangen"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900e313b78fbb118c46d130c1a979a1f4eab0d9a8f7f139975ff0c38063f431f"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +169,7 @@ dependencies = [
  "byte-unit",
  "bytes",
  "clap",
+ "clap_mangen",
  "cpio",
  "flate2",
  "glob",
@@ -1021,6 +1032,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustversion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tag-message = "coreos-installer v{{version}}"
 [features]
 # rdcore is only useful inside the initrd of a CoreOS system
 rdcore = []
+mangen = ["clap_mangen"]
 
 [lib]
 name = "libcoreinst"
@@ -45,6 +46,7 @@ bincode = "^1.3"
 bytes = ">= 1.0.1, < 1.2.0"
 byte-unit = ">= 3.1.0, < 5.0.0"
 clap = { version = "3.1", default-features = false, features = ["std", "cargo", "derive", "suggestions", "wrap_help"] }
+clap_mangen = { version = "0.1", optional = true }
 cpio = "0.2.1"
 flate2 = "^1.0"
 glob = "^0.3"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(RELEASE),1)
 	CARGO_ARGS = --release
 else
 	PROFILE ?= debug
-	CARGO_ARGS =
+	CARGO_ARGS = --features mangen
 endif
 ifeq ($(RDCORE),1)
 	CARGO_ARGS := $(CARGO_ARGS) --features rdcore
@@ -19,6 +19,7 @@ all:
 .PHONY: docs
 docs: all
 	PROFILE=$(PROFILE) docs/_cmd.sh
+	target/${PROFILE}/coreos-installer pack man -C man
 
 .PHONY: install
 install: install-bin install-scripts install-systemd install-dracut

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ install-bin: all
 	install -D -t ${DESTDIR}/usr/bin target/${PROFILE}/coreos-installer
 
 .PHONY: install-scripts
-install-scripts: all
+install-scripts:
 	install -D -t $(DESTDIR)/usr/libexec scripts/coreos-installer-disable-device-auto-activation scripts/coreos-installer-service
 
 .PHONY: install-systemd
-install-systemd: all
+install-systemd:
 	install -D -m 644 -t $(DESTDIR)/usr/lib/systemd/system systemd/*.{service,target}
 	install -D -t $(DESTDIR)/usr/lib/systemd/system-generators systemd/coreos-installer-generator
 

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,16 @@ docs: all
 	target/${PROFILE}/coreos-installer pack man -C man
 
 .PHONY: install
-install: install-bin install-scripts install-systemd install-dracut
+install: install-bin install-man install-scripts install-systemd install-dracut
 
 .PHONY: install-bin
 install-bin: all
 	install -D -t ${DESTDIR}/usr/bin target/${PROFILE}/coreos-installer
+
+.PHONY: install-man
+install-man:
+	install -d ${DESTDIR}/usr/share/man/man8
+	$(foreach src,$(wildcard man/*.8),gzip -9c $(src) > ${DESTDIR}/usr/share/man/man8/$(notdir $(src)).gz && ) :
 
 .PHONY: install-scripts
 install-scripts:

--- a/man/coreos-installer-download.8
+++ b/man/coreos-installer-download.8
@@ -1,0 +1,48 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-download \- Download a CoreOS image
+.SH SYNOPSIS
+\fBcoreos\-installer\-download\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-s\fR|\fB\-\-stream\fR] [\fB\-a\fR|\fB\-\-architecture\fR] [\fB\-p\fR|\fB\-\-platform\fR] [\fB\-f\fR|\fB\-\-format\fR] [\fB\-u\fR|\fB\-\-image\-url\fR] [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-d\fR|\fB\-\-decompress\fR] [\fB\-\-insecure\fR] [\fB\-\-stream\-base\-url\fR] [\fB\-\-fetch\-retries\fR] 
+.SH DESCRIPTION
+Download a CoreOS image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-s\fR, \fB\-\-stream\fR=\fIname\fR [default: stable]
+Fedora CoreOS stream
+.TP
+\fB\-a\fR, \fB\-\-architecture\fR=\fIname\fR [default: x86_64]
+Target CPU architecture
+.TP
+\fB\-p\fR, \fB\-\-platform\fR=\fIname\fR [default: metal]
+Fedora CoreOS platform name
+.TP
+\fB\-f\fR, \fB\-\-format\fR=\fIname\fR [default: raw.xz]
+Image format
+.TP
+\fB\-u\fR, \fB\-\-image\-url\fR=\fIURL\fR
+Manually specify the image URL
+.TP
+\fB\-C\fR, \fB\-\-directory\fR=\fIpath\fR [default: .]
+Destination directory
+.TP
+\fB\-d\fR, \fB\-\-decompress\fR
+Decompress image and don\*(Aqt save signature
+.TP
+\fB\-\-insecure\fR
+Skip signature verification
+.TP
+\fB\-\-stream\-base\-url\fR=\fIURL\fR
+Base URL for Fedora CoreOS stream metadata
+.TP
+\fB\-\-fetch\-retries\fR=\fIN\fR [default: 0]
+Fetch retries, or "infinite"
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-install.8
+++ b/man/coreos-installer-install.8
@@ -1,0 +1,116 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-install \- Install Fedora CoreOS or RHEL CoreOS
+.SH SYNOPSIS
+\fBcoreos\-installer\-install\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-c\fR|\fB\-\-config\-file\fR] [\fB\-s\fR|\fB\-\-stream\fR] [\fB\-u\fR|\fB\-\-image\-url\fR] [\fB\-f\fR|\fB\-\-image\-file\fR] [\fB\-i\fR|\fB\-\-ignition\-file\fR] [\fB\-I\fR|\fB\-\-ignition\-url\fR] [\fB\-\-ignition\-hash\fR] [\fB\-a\fR|\fB\-\-architecture\fR] [\fB\-p\fR|\fB\-\-platform\fR] [\fB\-\-append\-karg\fR] [\fB\-\-delete\-karg\fR] [\fB\-n\fR|\fB\-\-copy\-network\fR] [\fB\-\-network\-dir\fR] [\fB\-\-save\-partlabel\fR] [\fB\-\-save\-partindex\fR] [\fB\-\-offline\fR] [\fB\-\-insecure\fR] [\fB\-\-insecure\-ignition\fR] [\fB\-\-stream\-base\-url\fR] [\fB\-\-preserve\-on\-error\fR] [\fB\-\-fetch\-retries\fR] [\fIDEST_DEVICE\fR] 
+.SH DESCRIPTION
+Install Fedora CoreOS or RHEL CoreOS
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-c\fR, \fB\-\-config\-file\fR=\fIpath\fR
+YAML config file with install options
+
+Load additional config options from the specified YAML config file. Later config files override earlier ones, and command\-line options override config files.
+
+Config file keys are long option names without the leading "\-\-". Values are strings for non\-repeatable options, arrays of strings for repeatable options, and "true" for flags.  The destination device can be specified with the "dest\-device" key.
+.TP
+\fB\-s\fR, \fB\-\-stream\fR=\fIname\fR
+Fedora CoreOS stream
+
+The name of the Fedora CoreOS stream to install, such as "stable", "testing", or "next".
+.TP
+\fB\-u\fR, \fB\-\-image\-url\fR=\fIURL\fR
+Manually specify the image URL
+.TP
+\fB\-f\fR, \fB\-\-image\-file\fR=\fIpath\fR
+Manually specify a local image file
+.TP
+\fB\-i\fR, \fB\-\-ignition\-file\fR=\fIpath\fR
+Embed an Ignition config from a file
+.TP
+\fB\-I\fR, \fB\-\-ignition\-url\fR=\fIURL\fR
+Embed an Ignition config from a URL
+
+Immediately fetch the Ignition config from the URL and embed it in the installed system.
+.TP
+\fB\-\-ignition\-hash\fR=\fIdigest\fR
+Digest (type\-value) of the Ignition config
+
+Verify that the Ignition config matches the specified digest, formatted as <type>\-<hexvalue>.  <type> can be sha256 or sha512.
+.TP
+\fB\-a\fR, \fB\-\-architecture\fR=\fIname\fR [default: x86_64]
+Target CPU architecture
+
+Create an install disk for a different CPU architecture than the host.
+.TP
+\fB\-p\fR, \fB\-\-platform\fR=\fIname\fR
+Override the Ignition platform ID
+
+Install a system that will run on the specified cloud or virtualization platform, such as "vmware".
+.TP
+\fB\-\-append\-karg\fR=\fIarg\fR
+Append default kernel arg
+
+Add a kernel argument to the installed system.
+.TP
+\fB\-\-delete\-karg\fR=\fIarg\fR
+Delete default kernel arg
+
+Delete a default kernel argument from the installed system.
+.TP
+\fB\-n\fR, \fB\-\-copy\-network\fR
+Copy network config from install environment
+
+Copy NetworkManager keyfiles from the install environment to the installed system.
+.TP
+\fB\-\-network\-dir\fR=\fIpath\fR [default: /etc/NetworkManager/system\-connections/]
+Override NetworkManager keyfile dir for \-n
+
+Specify the path to NetworkManager keyfiles to be copied with \-\-copy\-network.
+
+[default: /etc/NetworkManager/system\-connections/]
+.TP
+\fB\-\-save\-partlabel\fR=\fIlx\fR
+Save partitions with this label glob
+.TP
+\fB\-\-save\-partindex\fR=\fIid\fR
+Save partitions with this number or range
+.TP
+\fB\-\-offline\fR
+Force offline installation
+.TP
+\fB\-\-insecure\fR
+Skip signature verification
+.TP
+\fB\-\-insecure\-ignition\fR
+Allow Ignition URL without HTTPS or hash
+.TP
+\fB\-\-stream\-base\-url\fR=\fIURL\fR
+Base URL for CoreOS stream metadata
+
+Override the base URL for fetching CoreOS stream metadata. The default is "https://builds.coreos.fedoraproject.org/streams/".
+.TP
+\fB\-\-preserve\-on\-error\fR
+Don\*(Aqt clear partition table on error
+
+If installation fails, coreos\-installer normally clears the destination\*(Aqs partition table to prevent booting from invalid boot media.  Skip clearing the partition table as a debugging aid.
+.TP
+\fB\-\-fetch\-retries\fR=\fIN\fR [default: 0]
+Fetch retries, or "infinite"
+
+Number of times to retry network fetches, or the string "infinite" to retry indefinitely.
+.TP
+[\fIDEST_DEVICE\fR]
+Destination device
+
+Path to the device node for the destination disk.  The beginning of the device will be overwritten without further confirmation.
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-customize.8
+++ b/man/coreos-installer-iso-customize.8
@@ -1,0 +1,92 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-customize \- Customize a CoreOS live ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-customize\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-\-dest\-ignition\fR] [\fB\-\-dest\-device\fR] [\fB\-\-dest\-karg\-append\fR] [\fB\-\-dest\-karg\-delete\fR] [\fB\-\-network\-keyfile\fR] [\fB\-\-ignition\-ca\fR] [\fB\-\-pre\-install\fR] [\fB\-\-post\-install\fR] [\fB\-\-installer\-config\fR] [\fB\-\-live\-ignition\fR] [\fB\-\-live\-karg\-append\fR] [\fB\-\-live\-karg\-delete\fR] [\fB\-\-live\-karg\-replace\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-o\fR|\fB\-\-output\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Customize a CoreOS live ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-\-dest\-ignition\fR=\fIpath\fR
+Ignition config fragment for dest sys
+
+Automatically run installer and merge the specified Ignition config into the config for the destination system.
+.TP
+\fB\-\-dest\-device\fR=\fIpath\fR
+Install destination device
+
+Automatically run installer, installing to the specified destination device.  The resulting boot media will overwrite the destination device without confirmation.
+.TP
+\fB\-\-dest\-karg\-append\fR=\fIarg\fR
+Destination kernel argument to append
+
+Automatically run installer, adding the specified kernel argument for every boot of the destination system.
+.TP
+\fB\-\-dest\-karg\-delete\fR=\fIarg\fR
+Destination kernel argument to delete
+
+Automatically run installer, deleting the specified kernel argument for every boot of the destination system.
+.TP
+\fB\-\-network\-keyfile\fR=\fIpath\fR
+NetworkManager keyfile for live & dest
+
+Configure networking using the specified NetworkManager keyfile. Network settings will be applied in the live environment, including when Ignition is run.  If installer is enabled via additional options, network settings will also be applied in the destination system, including when Ignition is run.
+.TP
+\fB\-\-ignition\-ca\fR=\fIpath\fR
+Ignition PEM CA bundle for live & dest
+
+Specify additional TLS certificate authorities to be trusted by Ignition, in PEM format.  Authorities will be trusted by Ignition in the live environment and, if installer is enabled via additional options, in the destination system.
+.TP
+\fB\-\-pre\-install\fR=\fIpath\fR
+Script to run before installation
+
+If installer is run at boot, run this script before installation. If the script fails, the live environment will stop at an emergency shell.
+.TP
+\fB\-\-post\-install\fR=\fIpath\fR
+Script to run after installation
+
+If installer is run at boot, run this script after installation. If the script fails, the live environment will stop at an emergency shell.
+.TP
+\fB\-\-installer\-config\fR=\fIpath\fR
+Installer config file
+
+Automatically run coreos\-installer and apply the specified installer config file.  Config files are applied in the order that they are specified.
+.TP
+\fB\-\-live\-ignition\fR=\fIpath\fR
+Ignition config fragment for live env
+
+Merge the specified Ignition config into the config for the live environment.
+.TP
+\fB\-\-live\-karg\-append\fR=\fIarg\fR
+Live kernel argument to append
+
+Kernel argument to append to boots of the live environment.
+.TP
+\fB\-\-live\-karg\-delete\fR=\fIarg\fR
+Live kernel argument to delete
+
+Kernel argument to delete from boots of the live environment.
+.TP
+\fB\-\-live\-karg\-replace\fR=\fIk=o=n\fR
+Live kernel argument to replace
+
+Kernel argument to replace for boots of the live environment, in the form key=old=new.  For a default argument "a=b", specifying "\-\-live\-karg\-replace a=b=c" will produce the argument "a=c".
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Overwrite existing customizations
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Write ISO to a new output file
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-extract-minimal-iso.8
+++ b/man/coreos-installer-iso-extract-minimal-iso.8
@@ -1,0 +1,30 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-extract\-minimal\-iso \- Extract a minimal ISO from a CoreOS live ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-extract\-minimal\-iso\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-\-output\-rootfs\fR] [\fB\-\-rootfs\-url\fR] <\fIISO\fR> [\fIOUTPUT_ISO\fR] 
+.SH DESCRIPTION
+Extract a minimal ISO from a CoreOS live ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-\-output\-rootfs\fR=\fIPATH\fR
+Extract rootfs image as well
+.TP
+\fB\-\-rootfs\-url\fR=\fIURL\fR
+Inject rootfs URL karg into minimal ISO
+.TP
+<\fIISO\fR>
+ISO image
+.TP
+[\fIOUTPUT_ISO\fR] [default: \-]
+Minimal ISO output file
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-extract-pxe.8
+++ b/man/coreos-installer-iso-extract-pxe.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-extract\-pxe \- Extract PXE files from an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-extract\-pxe\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-o\fR|\fB\-\-output\-dir\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Extract PXE files from an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-o\fR, \fB\-\-output\-dir\fR=\fIPATH\fR [default: .]
+Output directory
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-extract.8
+++ b/man/coreos-installer-iso-extract.8
@@ -1,0 +1,28 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-extract \- Commands to extract files from a CoreOS live ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-extract\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Commands to extract files from a CoreOS live ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-iso\-extract\-pxe(8)
+Extract PXE files from an ISO image
+.TP
+coreos\-installer\-iso\-extract\-minimal\-iso(8)
+Extract a minimal ISO from a CoreOS live ISO image
+.TP
+coreos\-installer\-iso\-extract\-help(8)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-ignition-embed.8
+++ b/man/coreos-installer-iso-ignition-embed.8
@@ -1,0 +1,30 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-ignition\-embed \- Embed an Ignition config in an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-ignition\-embed\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-i\fR|\fB\-\-ignition\-file\fR] [\fB\-o\fR|\fB\-\-output\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Embed an Ignition config in an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Overwrite an existing Ignition config
+.TP
+\fB\-i\fR, \fB\-\-ignition\-file\fR=\fIpath\fR
+Ignition config to embed [default: stdin]
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Write ISO to a new output file
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-ignition-remove.8
+++ b/man/coreos-installer-iso-ignition-remove.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-ignition\-remove \- Remove an existing embedded Ignition config from an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-ignition\-remove\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-o\fR|\fB\-\-output\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Remove an existing embedded Ignition config from an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Write ISO to a new output file
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-ignition-show.8
+++ b/man/coreos-installer-iso-ignition-show.8
@@ -1,0 +1,21 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-ignition\-show \- Show the embedded Ignition config from an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-ignition\-show\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Show the embedded Ignition config from an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-ignition.8
+++ b/man/coreos-installer-iso-ignition.8
@@ -1,0 +1,31 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-ignition \- Embed an Ignition config in a CoreOS live ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-ignition\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Embed an Ignition config in a CoreOS live ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-iso\-ignition\-embed(8)
+Embed an Ignition config in an ISO image
+.TP
+coreos\-installer\-iso\-ignition\-show(8)
+Show the embedded Ignition config from an ISO image
+.TP
+coreos\-installer\-iso\-ignition\-remove(8)
+Remove an existing embedded Ignition config from an ISO image
+.TP
+coreos\-installer\-iso\-ignition\-help(8)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-kargs-modify.8
+++ b/man/coreos-installer-iso-kargs-modify.8
@@ -1,0 +1,33 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-kargs\-modify \- Modify kernel args in an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-kargs\-modify\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-a\fR|\fB\-\-append\fR] [\fB\-d\fR|\fB\-\-delete\fR] [\fB\-r\fR|\fB\-\-replace\fR] [\fB\-o\fR|\fB\-\-output\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Modify kernel args in an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-a\fR, \fB\-\-append\fR=\fIKARG\fR
+Kernel argument to append
+.TP
+\fB\-d\fR, \fB\-\-delete\fR=\fIKARG\fR
+Kernel argument to delete
+.TP
+\fB\-r\fR, \fB\-\-replace\fR=\fIKARG=OLDVAL=NEWVAL\fR
+Kernel argument to replace
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIPATH\fR
+Write ISO to a new output file
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-kargs-reset.8
+++ b/man/coreos-installer-iso-kargs-reset.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-kargs\-reset \- Reset kernel args in an ISO image to defaults
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-kargs\-reset\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-o\fR|\fB\-\-output\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Reset kernel args in an ISO image to defaults
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIPATH\fR
+Write ISO to a new output file
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-kargs-show.8
+++ b/man/coreos-installer-iso-kargs-show.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-kargs\-show \- Show kernel args from an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-kargs\-show\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-d\fR|\fB\-\-default\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Show kernel args from an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-d\fR, \fB\-\-default\fR
+Show default kernel args
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-kargs.8
+++ b/man/coreos-installer-iso-kargs.8
@@ -1,0 +1,31 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-kargs \- Modify kernel args in a CoreOS live ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-kargs\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Modify kernel args in a CoreOS live ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-iso\-kargs\-modify(8)
+Modify kernel args in an ISO image
+.TP
+coreos\-installer\-iso\-kargs\-reset(8)
+Reset kernel args in an ISO image to defaults
+.TP
+coreos\-installer\-iso\-kargs\-show(8)
+Show kernel args from an ISO image
+.TP
+coreos\-installer\-iso\-kargs\-help(8)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-network-embed.8
+++ b/man/coreos-installer-iso-network-embed.8
@@ -1,0 +1,30 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-network\-embed \- Embed network settings in an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-network\-embed\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fB\-k\fR|\fB\-\-keyfile\fR> [\fB\-f\fR|\fB\-\-force\fR] [\fB\-o\fR|\fB\-\-output\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Embed network settings in an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-k\fR, \fB\-\-keyfile\fR=\fIpath\fR
+NetworkManager keyfile to embed
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Overwrite existing network settings
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Write ISO to a new output file
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-network-extract.8
+++ b/man/coreos-installer-iso-network-extract.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-network\-extract \- Extract embedded network settings from an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-network\-extract\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-C\fR|\fB\-\-directory\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Extract embedded network settings from an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-C\fR, \fB\-\-directory\fR=\fIpath\fR
+Extract to directory instead of stdout
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-network-remove.8
+++ b/man/coreos-installer-iso-network-remove.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-network\-remove \- Remove existing network settings from an ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-network\-remove\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-o\fR|\fB\-\-output\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Remove existing network settings from an ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Write ISO to a new output file
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-network.8
+++ b/man/coreos-installer-iso-network.8
@@ -1,0 +1,31 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-network \- Embed network settings in a CoreOS live ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-network\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Embed network settings in a CoreOS live ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-iso\-network\-embed(8)
+Embed network settings in an ISO image
+.TP
+coreos\-installer\-iso\-network\-extract(8)
+Extract embedded network settings from an ISO image
+.TP
+coreos\-installer\-iso\-network\-remove(8)
+Remove existing network settings from an ISO image
+.TP
+coreos\-installer\-iso\-network\-help(8)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso-reset.8
+++ b/man/coreos-installer-iso-reset.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso\-reset \- Restore a CoreOS live ISO image to default settings
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\-reset\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-o\fR|\fB\-\-output\fR] <\fIISO\fR> 
+.SH DESCRIPTION
+Restore a CoreOS live ISO image to default settings
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Write ISO to a new output file
+.TP
+<\fIISO\fR>
+ISO image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-iso.8
+++ b/man/coreos-installer-iso.8
@@ -1,0 +1,40 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-iso \- Commands to manage a CoreOS live ISO image
+.SH SYNOPSIS
+\fBcoreos\-installer\-iso\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Commands to manage a CoreOS live ISO image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-iso\-customize(8)
+Customize a CoreOS live ISO image
+.TP
+coreos\-installer\-iso\-ignition(8)
+Embed an Ignition config in a CoreOS live ISO image
+.TP
+coreos\-installer\-iso\-network(8)
+Embed network settings in a CoreOS live ISO image
+.TP
+coreos\-installer\-iso\-kargs(8)
+Modify kernel args in a CoreOS live ISO image
+.TP
+coreos\-installer\-iso\-extract(8)
+Commands to extract files from a CoreOS live ISO image
+.TP
+coreos\-installer\-iso\-reset(8)
+Restore a CoreOS live ISO image to default settings
+.TP
+coreos\-installer\-iso\-help(8)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-list-stream.8
+++ b/man/coreos-installer-list-stream.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-list\-stream \- List available images in a Fedora CoreOS stream
+.SH SYNOPSIS
+\fBcoreos\-installer\-list\-stream\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-s\fR|\fB\-\-stream\fR] [\fB\-\-stream\-base\-url\fR] 
+.SH DESCRIPTION
+List available images in a Fedora CoreOS stream
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-s\fR, \fB\-\-stream\fR=\fIname\fR [default: stable]
+Fedora CoreOS stream
+.TP
+\fB\-\-stream\-base\-url\fR=\fIURL\fR
+Base URL for Fedora CoreOS stream metadata
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-pxe-customize.8
+++ b/man/coreos-installer-pxe-customize.8
@@ -1,0 +1,74 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-pxe\-customize \- Create a custom live PXE boot config
+.SH SYNOPSIS
+\fBcoreos\-installer\-pxe\-customize\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-\-dest\-ignition\fR] [\fB\-\-dest\-device\fR] [\fB\-\-dest\-karg\-append\fR] [\fB\-\-dest\-karg\-delete\fR] [\fB\-\-network\-keyfile\fR] [\fB\-\-ignition\-ca\fR] [\fB\-\-pre\-install\fR] [\fB\-\-post\-install\fR] [\fB\-\-installer\-config\fR] [\fB\-\-live\-ignition\fR] <\fB\-o\fR|\fB\-\-output\fR> <\fIpath\fR> 
+.SH DESCRIPTION
+Create a custom live PXE boot config
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-\-dest\-ignition\fR=\fIpath\fR
+Ignition config fragment for dest sys
+
+Automatically run installer and merge the specified Ignition config into the config for the destination system.
+.TP
+\fB\-\-dest\-device\fR=\fIpath\fR
+Install destination device
+
+Automatically run installer, installing to the specified destination device.  The resulting boot media will overwrite the destination device without confirmation.
+.TP
+\fB\-\-dest\-karg\-append\fR=\fIarg\fR
+Destination kernel argument to append
+
+Automatically run installer, adding the specified kernel argument for every boot of the destination system.
+.TP
+\fB\-\-dest\-karg\-delete\fR=\fIarg\fR
+Destination kernel argument to delete
+
+Automatically run installer, deleting the specified kernel argument for every boot of the destination system.
+.TP
+\fB\-\-network\-keyfile\fR=\fIpath\fR
+NetworkManager keyfile for live & dest
+
+Configure networking using the specified NetworkManager keyfile. Network settings will be applied in the live environment, including when Ignition is run.  If installer is enabled via additional options, network settings will also be applied in the destination system, including when Ignition is run.
+.TP
+\fB\-\-ignition\-ca\fR=\fIpath\fR
+Ignition PEM CA bundle for live & dest
+
+Specify additional TLS certificate authorities to be trusted by Ignition, in PEM format.  Authorities will be trusted by Ignition in the live environment and, if installer is enabled via additional options, in the destination system.
+.TP
+\fB\-\-pre\-install\fR=\fIpath\fR
+Script to run before installation
+
+If installer is run at boot, run this script before installation. If the script fails, the live environment will stop at an emergency shell.
+.TP
+\fB\-\-post\-install\fR=\fIpath\fR
+Script to run after installation
+
+If installer is run at boot, run this script after installation. If the script fails, the live environment will stop at an emergency shell.
+.TP
+\fB\-\-installer\-config\fR=\fIpath\fR
+Installer config file
+
+Automatically run coreos\-installer and apply the specified installer config file.  Config files are applied in the order that they are specified.
+.TP
+\fB\-\-live\-ignition\fR=\fIpath\fR
+Ignition config fragment for live env
+
+Merge the specified Ignition config into the config for the live environment.
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Output file
+.TP
+<\fIpath\fR>
+CoreOS live initramfs image
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-pxe-ignition-unwrap.8
+++ b/man/coreos-installer-pxe-ignition-unwrap.8
@@ -1,0 +1,21 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-pxe\-ignition\-unwrap \- Show the wrapped Ignition config in an initrd image
+.SH SYNOPSIS
+\fBcoreos\-installer\-pxe\-ignition\-unwrap\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIinitrd\fR] 
+.SH DESCRIPTION
+Show the wrapped Ignition config in an initrd image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+[\fIinitrd\fR]
+initrd image [default: stdin]
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-pxe-ignition-wrap.8
+++ b/man/coreos-installer-pxe-ignition-wrap.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-pxe\-ignition\-wrap \- Wrap an Ignition config in an initrd image
+.SH SYNOPSIS
+\fBcoreos\-installer\-pxe\-ignition\-wrap\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-i\fR|\fB\-\-ignition\-file\fR] [\fB\-o\fR|\fB\-\-output\fR] 
+.SH DESCRIPTION
+Wrap an Ignition config in an initrd image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-i\fR, \fB\-\-ignition\-file\fR=\fIpath\fR
+Ignition config to wrap [default: stdin]
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Write to a file instead of stdout
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-pxe-ignition.8
+++ b/man/coreos-installer-pxe-ignition.8
@@ -1,0 +1,28 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-pxe\-ignition \- Commands to manage a live PXE Ignition config
+.SH SYNOPSIS
+\fBcoreos\-installer\-pxe\-ignition\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Commands to manage a live PXE Ignition config
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-pxe\-ignition\-wrap(8)
+Wrap an Ignition config in an initrd image
+.TP
+coreos\-installer\-pxe\-ignition\-unwrap(8)
+Show the wrapped Ignition config in an initrd image
+.TP
+coreos\-installer\-pxe\-ignition\-help(8)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-pxe-network-unwrap.8
+++ b/man/coreos-installer-pxe-network-unwrap.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-pxe\-network\-unwrap \- Extract wrapped network settings from an initrd image
+.SH SYNOPSIS
+\fBcoreos\-installer\-pxe\-network\-unwrap\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-C\fR|\fB\-\-directory\fR] [\fIinitrd\fR] 
+.SH DESCRIPTION
+Extract wrapped network settings from an initrd image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-C\fR, \fB\-\-directory\fR=\fIpath\fR
+Extract to directory instead of stdout
+.TP
+[\fIinitrd\fR]
+initrd image [default: stdin]
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-pxe-network-wrap.8
+++ b/man/coreos-installer-pxe-network-wrap.8
@@ -1,0 +1,24 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-pxe\-network\-wrap \- Wrap network settings in an initrd image
+.SH SYNOPSIS
+\fBcoreos\-installer\-pxe\-network\-wrap\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fB\-k\fR|\fB\-\-keyfile\fR> [\fB\-o\fR|\fB\-\-output\fR] 
+.SH DESCRIPTION
+Wrap network settings in an initrd image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.TP
+\fB\-k\fR, \fB\-\-keyfile\fR=\fIpath\fR
+NetworkManager keyfile to embed
+.TP
+\fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
+Write to a file instead of stdout
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-pxe-network.8
+++ b/man/coreos-installer-pxe-network.8
@@ -1,0 +1,28 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-pxe\-network \- Commands to manage live PXE network settings
+.SH SYNOPSIS
+\fBcoreos\-installer\-pxe\-network\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Commands to manage live PXE network settings
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-pxe\-network\-wrap(8)
+Wrap network settings in an initrd image
+.TP
+coreos\-installer\-pxe\-network\-unwrap(8)
+Extract wrapped network settings from an initrd image
+.TP
+coreos\-installer\-pxe\-network\-help(8)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer-pxe.8
+++ b/man/coreos-installer-pxe.8
@@ -1,0 +1,31 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer\-pxe \- Commands to manage a CoreOS live PXE image
+.SH SYNOPSIS
+\fBcoreos\-installer\-pxe\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Commands to manage a CoreOS live PXE image
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-pxe\-customize(8)
+Create a custom live PXE boot config
+.TP
+coreos\-installer\-pxe\-ignition(8)
+Commands to manage a live PXE Ignition config
+.TP
+coreos\-installer\-pxe\-network(8)
+Commands to manage live PXE network settings
+.TP
+coreos\-installer\-pxe\-help(8)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.13.1

--- a/man/coreos-installer.8
+++ b/man/coreos-installer.8
@@ -1,0 +1,34 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.SH NAME
+coreos\-installer \- Installer for Fedora CoreOS and RHEL CoreOS
+.SH SYNOPSIS
+\fBcoreos\-installer\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Installer for Fedora CoreOS and RHEL CoreOS
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help information
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information
+.SH SUBCOMMANDS
+.TP
+coreos\-installer\-install(8)
+Install Fedora CoreOS or RHEL CoreOS
+.TP
+coreos\-installer\-download(8)
+Download a CoreOS image
+.TP
+coreos\-installer\-list\-stream(8)
+List available images in a Fedora CoreOS stream
+.TP
+coreos\-installer\-iso(8)
+Commands to manage a CoreOS live ISO image
+.TP
+coreos\-installer\-pxe(8)
+Commands to manage a CoreOS live PXE image
+.SH VERSION
+v0.13.1

--- a/src/cmdline/man.rs
+++ b/src/cmdline/man.rs
@@ -1,0 +1,60 @@
+// Copyright 2022 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Support for generating man pages.
+
+use anyhow::{Context, Result};
+use clap::{crate_version, Command, CommandFactory};
+use std::fs::OpenOptions;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use crate::io::BUFFER_SIZE;
+
+use super::{Cmd, PackManConfig};
+
+pub fn pack_man(config: PackManConfig) -> Result<()> {
+    pack_one(&config, Cmd::command())
+}
+
+fn pack_one(config: &PackManConfig, cmd: Command) -> Result<()> {
+    let name = cmd.get_name();
+    let path = Path::new(&config.directory).join(format!("{}.8", name));
+    println!("Generating {}...", path.display());
+
+    let out = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    let mut buf = BufWriter::with_capacity(BUFFER_SIZE, out);
+    clap_mangen::Man::new(cmd.clone())
+        .title("coreos-installer")
+        .section("8")
+        .source(format!("coreos-installer {}", crate_version!()))
+        .render(&mut buf)
+        .with_context(|| format!("rendering {}.8", name))?;
+    buf.flush().context("flushing man page")?;
+    drop(buf);
+
+    for subcmd in cmd.get_subcommands().filter(|c| !c.is_hide_set()) {
+        let subname = format!("{}-{}", name, subcmd.get_name());
+        pack_one(
+            config,
+            subcmd.clone().name(subname).version(crate_version!()),
+        )?;
+    }
+    Ok(())
+}

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -19,10 +19,14 @@ use clap::{AppSettings, Parser};
 use reqwest::Url;
 
 mod install;
+#[cfg(feature = "mangen")]
+mod man;
 mod serializer;
 mod types;
 
 pub use self::install::InstallConfig;
+#[cfg(feature = "mangen")]
+pub use self::man::*;
 pub use self::types::*;
 
 // Args are listed in --help in the order declared in these structs/enums.
@@ -162,6 +166,9 @@ pub enum PackCmd {
     Osmet(PackOsmetConfig),
     /// Pack a minimal ISO into a CoreOS live ISO image
     MinimalIso(PackMinimalIsoConfig),
+    /// Generate man pages for coreos-installer
+    #[cfg(feature = "mangen")]
+    Man(PackManConfig),
 }
 
 #[derive(Debug, Parser)]
@@ -674,6 +681,14 @@ pub struct DevExtractInitrdConfig {
     /// Files or globs to list
     #[clap(value_name = "glob")]
     pub filter: Vec<String>,
+}
+
+#[cfg(feature = "mangen")]
+#[derive(Debug, Parser)]
+pub struct PackManConfig {
+    /// Output directory
+    #[clap(short = 'C', long, value_name = "path", default_value = ".")]
+    pub directory: String,
 }
 
 #[cfg(test)]

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -28,6 +28,7 @@ pub use self::types::*;
 // Args are listed in --help in the order declared in these structs/enums.
 // Please keep the entire help text to 80 columns.
 
+/// Installer for Fedora CoreOS and RHEL CoreOS
 #[derive(Debug, Parser)]
 #[clap(version)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,8 @@ fn main() -> Result<()> {
         Cmd::Pack(c) => match c {
             PackCmd::Osmet(c) => osmet::pack_osmet(c),
             PackCmd::MinimalIso(c) => live::pack_minimal_iso(c),
+            #[cfg(feature = "mangen")]
+            PackCmd::Man(c) => cmdline::pack_man(c),
         },
         Cmd::Dev(c) => match c {
             DevCmd::Show(c) => match c {


### PR DESCRIPTION
Have `make docs` generate subcommand man pages using a `pack` subcommand, and store them in the repo alongside the Markdown docs.  Since we don't need the generation code at runtime, gate it (and its deps) behind an optional Cargo feature, and have `make` enable the feature when building with the debug profile.

These are mostly useful for distribution packages; the container doesn't have a good way to expose them.  Also, the output isn't completely clean, but at least we get man pages.