### PR TITLE
cargo: coreos-installer release 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "coreos-installer"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -180,7 +180,7 @@ dependencies = [
  "libc",
  "maplit",
  "mbrman",
- "nix 0.23.1",
+ "nix",
  "openssl",
  "pipe",
  "rand",
@@ -424,7 +424,7 @@ checksum = "f5a6ef4b3fdbdf3d312de4fb312ea65d2e58cc046a7554742dbf8eccc49eb0c5"
 dependencies = [
  "bincode",
  "crc",
- "nix 0.22.3",
+ "nix",
  "serde",
  "thiserror",
 ]
@@ -760,19 +760,6 @@ name = "nix"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.56.0"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
-version = "0.13.1"
+version = "0.14.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Major changes:

- Add aarch64 support to container image
- Add generated manpages

Minor changes:

- Silence error from reporting commands like `iso ignition show` and `pxe ignition unwrap` if output pipe is closed
- docs: Document `dest-device` config file field
- docs: Document `iso/pxe customize` commands
- docs: Drop documentation of pre/post installation hooks

Internal changes:

- bind-boot: Fix EFI vendor directory detection
- verify-unique-fs-label: use `blkid` instead of `lsblk` to make filesystem label querying more reliable
- Delete legacy aliases for `osmet` and `minimal-iso` pack commands used by coreos-assembler

Packaging changes:

- Require Rust ≥ 1.56.0
- Migrate from `structopt` to `clap` 3
- Add `clap_mangen` dependency
- Drop `openat-ext` dependency
- Remove Windows binaries from vendor archive