### PR TITLE
templates/release-checklist: fix path to winapi vendor dir

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -54,7 +54,7 @@ Push access to the upstream repository is required in order to publish the new t
 
 - assemble vendor archive:
   - [ ] `cargo vendor target/vendor`
-  - [ ] `rm -rf vendor/winapi*gnu*/lib/*.a`
+  - [ ] `rm -r target/vendor/winapi*gnu*/lib/*.a`
   - [ ] `tar -czf target/coreos-installer-${RELEASE_VER}-vendor.tar.gz -C target vendor`
 
 - publish this release on GitHub:


### PR DESCRIPTION
Fixes a1569d3 ("github/release-checklist: Remove Windows binaries from
vendored sources").