### PR TITLE
cargo: regenerate docs when releasing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ sign-tag = true
 push = false
 publish = false
 pre-release-commit-message = "cargo: coreos-installer release {{version}}"
+pre-release-hook = ["make", "docs", "clean"]
 tag-message = "coreos-installer v{{version}}"
 
 [features]

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ docs: all
 	PROFILE=$(PROFILE) docs/_cmd.sh
 	target/${PROFILE}/coreos-installer pack man -C man
 
+.PHONY: clean
+clean:
+	cargo clean
+
 .PHONY: install
 install: install-bin install-man install-scripts install-systemd install-dracut
 


### PR DESCRIPTION
The man pages embed the coreos-installer version number.  `cargo-release` has a mechanism for doing string replacement on files, but it's easier to just regenerate the docs.  Run `cargo clean` afterward to preserve the clean checkout contemplated by the release checklist.