### PR TITLE
workflows: fix stale-docs check; sync docs

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -24,7 +24,7 @@ jobs:
         # fetch tags for versioning
         with:
           fetch-depth: 0
-      # https://github.com/actions/checkout/issues/760
+      # https://github.com/actions/checkout/issues/766
       - name: Mark git checkout as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build RPMs

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -192,7 +192,7 @@ jobs:
           ARCH: x86_64
           TOOLCHAIN: stable
       - name: Install dependencies
-        run: dnf install -y gcc openssl-devel util-linux
+        run: dnf install -y gcc git-core openssl-devel util-linux
       - name: cargo build
         run: cargo build
       - name: Help text line length
@@ -203,9 +203,9 @@ jobs:
         run: |
           rm man/*.8
           make docs
-          if [ -n "$(git status --porcelain docs)" ]; then
+          if [ -n "$(git status --porcelain docs man)" ]; then
             echo "Found local changes after regenerating docs:"
-            git --no-pager diff --color=always docs
+            git --no-pager diff --color=always docs man
             echo "Rerun 'make docs'."
             exit 1
           fi

--- a/man/coreos-installer-download.8
+++ b/man/coreos-installer-download.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-download \- Download a CoreOS image
 .SH SYNOPSIS
@@ -45,4 +45,4 @@ Base URL for Fedora CoreOS stream metadata
 \fB\-\-fetch\-retries\fR=\fIN\fR [default: 0]
 Fetch retries, or "infinite"
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-install.8
+++ b/man/coreos-installer-install.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-install \- Install Fedora CoreOS or RHEL CoreOS
 .SH SYNOPSIS
@@ -113,4 +113,4 @@ Destination device
 
 Path to the device node for the destination disk.  The beginning of the device will be overwritten without further confirmation.
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-customize.8
+++ b/man/coreos-installer-iso-customize.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-customize \- Customize a CoreOS live ISO image
 .SH SYNOPSIS
@@ -89,4 +89,4 @@ Write ISO to a new output file
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-extract-minimal-iso.8
+++ b/man/coreos-installer-iso-extract-minimal-iso.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-extract\-minimal\-iso \- Extract a minimal ISO from a CoreOS live ISO image
 .SH SYNOPSIS
@@ -27,4 +27,4 @@ ISO image
 [\fIOUTPUT_ISO\fR] [default: \-]
 Minimal ISO output file
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-extract-pxe.8
+++ b/man/coreos-installer-iso-extract-pxe.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-extract\-pxe \- Extract PXE files from an ISO image
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Output directory
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-extract.8
+++ b/man/coreos-installer-iso-extract.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-extract \- Commands to extract files from a CoreOS live ISO image
 .SH SYNOPSIS
@@ -25,4 +25,4 @@ Extract a minimal ISO from a CoreOS live ISO image
 coreos\-installer\-iso\-extract\-help(8)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-ignition-embed.8
+++ b/man/coreos-installer-iso-ignition-embed.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-ignition\-embed \- Embed an Ignition config in an ISO image
 .SH SYNOPSIS
@@ -27,4 +27,4 @@ Write ISO to a new output file
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-ignition-remove.8
+++ b/man/coreos-installer-iso-ignition-remove.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-ignition\-remove \- Remove an existing embedded Ignition config from an ISO image
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Write ISO to a new output file
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-ignition-show.8
+++ b/man/coreos-installer-iso-ignition-show.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-ignition\-show \- Show the embedded Ignition config from an ISO image
 .SH SYNOPSIS
@@ -18,4 +18,4 @@ Print version information
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-ignition.8
+++ b/man/coreos-installer-iso-ignition.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-ignition \- Embed an Ignition config in a CoreOS live ISO image
 .SH SYNOPSIS
@@ -28,4 +28,4 @@ Remove an existing embedded Ignition config from an ISO image
 coreos\-installer\-iso\-ignition\-help(8)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-kargs-modify.8
+++ b/man/coreos-installer-iso-kargs-modify.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-kargs\-modify \- Modify kernel args in an ISO image
 .SH SYNOPSIS
@@ -30,4 +30,4 @@ Write ISO to a new output file
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-kargs-reset.8
+++ b/man/coreos-installer-iso-kargs-reset.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-kargs\-reset \- Reset kernel args in an ISO image to defaults
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Write ISO to a new output file
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-kargs-show.8
+++ b/man/coreos-installer-iso-kargs-show.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-kargs\-show \- Show kernel args from an ISO image
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Show default kernel args
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-kargs.8
+++ b/man/coreos-installer-iso-kargs.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-kargs \- Modify kernel args in a CoreOS live ISO image
 .SH SYNOPSIS
@@ -28,4 +28,4 @@ Show kernel args from an ISO image
 coreos\-installer\-iso\-kargs\-help(8)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-network-embed.8
+++ b/man/coreos-installer-iso-network-embed.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-network\-embed \- Embed network settings in an ISO image
 .SH SYNOPSIS
@@ -27,4 +27,4 @@ Write ISO to a new output file
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-network-extract.8
+++ b/man/coreos-installer-iso-network-extract.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-network\-extract \- Extract embedded network settings from an ISO image
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Extract to directory instead of stdout
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-network-remove.8
+++ b/man/coreos-installer-iso-network-remove.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-network\-remove \- Remove existing network settings from an ISO image
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Write ISO to a new output file
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-network.8
+++ b/man/coreos-installer-iso-network.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-network \- Embed network settings in a CoreOS live ISO image
 .SH SYNOPSIS
@@ -28,4 +28,4 @@ Remove existing network settings from an ISO image
 coreos\-installer\-iso\-network\-help(8)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso-reset.8
+++ b/man/coreos-installer-iso-reset.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso\-reset \- Restore a CoreOS live ISO image to default settings
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Write ISO to a new output file
 <\fIISO\fR>
 ISO image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-iso.8
+++ b/man/coreos-installer-iso.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-iso \- Commands to manage a CoreOS live ISO image
 .SH SYNOPSIS
@@ -37,4 +37,4 @@ Restore a CoreOS live ISO image to default settings
 coreos\-installer\-iso\-help(8)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-list-stream.8
+++ b/man/coreos-installer-list-stream.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-list\-stream \- List available images in a Fedora CoreOS stream
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Fedora CoreOS stream
 \fB\-\-stream\-base\-url\fR=\fIURL\fR
 Base URL for Fedora CoreOS stream metadata
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-pxe-customize.8
+++ b/man/coreos-installer-pxe-customize.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-pxe\-customize \- Create a custom live PXE boot config
 .SH SYNOPSIS
@@ -71,4 +71,4 @@ Output file
 <\fIpath\fR>
 CoreOS live initramfs image
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-pxe-ignition-unwrap.8
+++ b/man/coreos-installer-pxe-ignition-unwrap.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-pxe\-ignition\-unwrap \- Show the wrapped Ignition config in an initrd image
 .SH SYNOPSIS
@@ -18,4 +18,4 @@ Print version information
 [\fIinitrd\fR]
 initrd image [default: stdin]
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-pxe-ignition-wrap.8
+++ b/man/coreos-installer-pxe-ignition-wrap.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-pxe\-ignition\-wrap \- Wrap an Ignition config in an initrd image
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Ignition config to wrap [default: stdin]
 \fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
 Write to a file instead of stdout
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-pxe-ignition.8
+++ b/man/coreos-installer-pxe-ignition.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-pxe\-ignition \- Commands to manage a live PXE Ignition config
 .SH SYNOPSIS
@@ -25,4 +25,4 @@ Show the wrapped Ignition config in an initrd image
 coreos\-installer\-pxe\-ignition\-help(8)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-pxe-network-unwrap.8
+++ b/man/coreos-installer-pxe-network-unwrap.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-pxe\-network\-unwrap \- Extract wrapped network settings from an initrd image
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ Extract to directory instead of stdout
 [\fIinitrd\fR]
 initrd image [default: stdin]
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-pxe-network-wrap.8
+++ b/man/coreos-installer-pxe-network-wrap.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-pxe\-network\-wrap \- Wrap network settings in an initrd image
 .SH SYNOPSIS
@@ -21,4 +21,4 @@ NetworkManager keyfile to embed
 \fB\-o\fR, \fB\-\-output\fR=\fIpath\fR
 Write to a file instead of stdout
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-pxe-network.8
+++ b/man/coreos-installer-pxe-network.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-pxe\-network \- Commands to manage live PXE network settings
 .SH SYNOPSIS
@@ -25,4 +25,4 @@ Extract wrapped network settings from an initrd image
 coreos\-installer\-pxe\-network\-help(8)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer-pxe.8
+++ b/man/coreos-installer-pxe.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer\-pxe \- Commands to manage a CoreOS live PXE image
 .SH SYNOPSIS
@@ -28,4 +28,4 @@ Commands to manage live PXE network settings
 coreos\-installer\-pxe\-help(8)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.13.1
+v0.14.0

--- a/man/coreos-installer.8
+++ b/man/coreos-installer.8
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH coreos-installer 8  "coreos-installer 0.13.1" 
+.TH coreos-installer 8  "coreos-installer 0.14.0" 
 .SH NAME
 coreos\-installer \- Installer for Fedora CoreOS and RHEL CoreOS
 .SH SYNOPSIS
@@ -31,4 +31,4 @@ Commands to manage a CoreOS live ISO image
 coreos\-installer\-pxe(8)
 Commands to manage a CoreOS live PXE image
 .SH VERSION
-v0.13.1
+v0.14.0


### PR DESCRIPTION
We forgot to check the diff for the `man` directory.  Also we forgot to install Git.

This slipped through because `[ -n "$(git status)" ]` was still succeeding; the bad command invocation got lost.