### PR TITLE
workflows: disable fail-fast on Rust jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
     name: "Tests, stable toolchain"
     runs-on: ubuntu-latest
     strategy:
+      # Keep x86_64 jobs alive if s390x jobs fail
+      fail-fast: false
       matrix:
         arch:
           - x86_64
@@ -63,6 +65,8 @@ jobs:
     name: "Tests, minimum supported toolchain"
     runs-on: ubuntu-latest
     strategy:
+      # Keep x86_64 jobs alive if s390x jobs fail
+      fail-fast: false
       matrix:
         arch:
           - x86_64
@@ -108,6 +112,8 @@ jobs:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest
     strategy:
+      # Keep x86_64 jobs alive if s390x jobs fail
+      fail-fast: false
       matrix:
         arch:
           - x86_64


### PR DESCRIPTION
Keep CI usable even though the s390x jobs are failing (https://github.com/coreos/coreos-installer/issues/872).

If this lands, I'll also mark the s390x jobs as non-required.