### PR TITLE
workflows: disable cargo bundled libgit to avoid s390x OOM

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,16 @@ jobs:
           path: target/debug
           key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
       - name: Install dependencies
-        run: dnf install -y gcc openssl-devel cpio diffutils jq xz
+        run: dnf install -y gcc git-core openssl-devel cpio diffutils jq xz
+      - name: Configure cargo
+        run: |
+          # Avoid OOM on emulated s390x
+          # https://github.com/rust-lang/cargo/issues/10583
+          mkdir -p .cargo
+          cat >> .cargo/config.toml <<EOF
+          [net]
+          git-fetch-with-cli = true
+          EOF
       - name: cargo build
         run: cargo build
       - name: cargo test
@@ -94,7 +103,16 @@ jobs:
           path: target/debug
           key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
       - name: Install dependencies
-        run: dnf install -y gcc openssl-devel cpio diffutils jq xz
+        run: dnf install -y gcc git-core openssl-devel cpio diffutils jq xz
+      - name: Configure cargo
+        run: |
+          # Avoid OOM on emulated s390x
+          # https://github.com/rust-lang/cargo/issues/10583
+          mkdir -p .cargo
+          cat >> .cargo/config.toml <<EOF
+          [net]
+          git-fetch-with-cli = true
+          EOF
       - name: cargo build
         run: cargo build
       - name: cargo test
@@ -135,7 +153,16 @@ jobs:
           path: target/debug
           key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}-lints
       - name: Install dependencies
-        run: dnf install -y gcc openssl-devel
+        run: dnf install -y gcc git-core openssl-devel
+      - name: Configure cargo
+        run: |
+          # Avoid OOM on emulated s390x
+          # https://github.com/rust-lang/cargo/issues/10583
+          mkdir -p .cargo
+          cat >> .cargo/config.toml <<EOF
+          [net]
+          git-fetch-with-cli = true
+          EOF
       - name: cargo fmt (check)
         run: cargo fmt -- --check -l
       - name: cargo clippy (warnings)
@@ -171,7 +198,16 @@ jobs:
           path: target/debug
           key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
       - name: Install dependencies
-        run: dnf install -y gcc openssl-devel cpio diffutils jq xz
+        run: dnf install -y gcc git-core openssl-devel cpio diffutils jq xz
+      - name: Configure cargo
+        run: |
+          # Avoid OOM on emulated s390x
+          # https://github.com/rust-lang/cargo/issues/10583
+          mkdir -p .cargo
+          cat >> .cargo/config.toml <<EOF
+          [net]
+          git-fetch-with-cli = true
+          EOF
       - name: cargo build
         run: cargo build
       - name: cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,6 @@ jobs:
     name: "Tests, stable toolchain"
     runs-on: ubuntu-latest
     strategy:
-      # Keep x86_64 jobs alive if s390x jobs fail
-      fail-fast: false
       matrix:
         arch:
           - x86_64
@@ -74,8 +72,6 @@ jobs:
     name: "Tests, minimum supported toolchain"
     runs-on: ubuntu-latest
     strategy:
-      # Keep x86_64 jobs alive if s390x jobs fail
-      fail-fast: false
       matrix:
         arch:
           - x86_64
@@ -130,8 +126,6 @@ jobs:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest
     strategy:
-      # Keep x86_64 jobs alive if s390x jobs fail
-      fail-fast: false
       matrix:
         arch:
           - x86_64


### PR DESCRIPTION
For now, shell out to git commands instead.

Fixes https://github.com/coreos/coreos-installer/issues/872.  Works around https://github.com/rust-lang/cargo/issues/10583.