### PR TITLE
templates/release-checklist: delete all `.a` files from vendor dir

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -54,7 +54,7 @@ Push access to the upstream repository is required in order to publish the new t
 
 - assemble vendor archive:
   - [ ] `cargo vendor target/vendor`
-  - [ ] `rm -r target/vendor/winapi*gnu*/lib/*.a`
+  - [ ] `find target/vendor -name '*.a' -delete`
   - [ ] `tar -czf target/coreos-installer-${RELEASE_VER}-vendor.tar.gz -C target vendor`
 
 - publish this release on GitHub:


### PR DESCRIPTION
We've gained some additional Windows-specific dependencies, and `vcpkg` also has compiled libraries for Darwin and iOS.  Our vendor tarball should never need to include compiled static libs, so delete them all.