### PR TITLE
Configure `cargo vendor-filterer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,15 @@ pre-release-commit-message = "cargo: coreos-installer release {{version}}"
 pre-release-hook = ["make", "docs", "clean"]
 tag-message = "coreos-installer v{{version}}"
 
+# See https://github.com/cgwalters/cargo-vendor-filterer
+[package.metadata.vendor-filter]
+# Right now the vendor filter doesn't support wildcards, so use this as a stand-in.
+# xref https://github.com/cgwalters/cargo-vendor-filterer/issues/23
+# Note that architecture-specific crate dependencies (apart from wasm32) are uncommon
+# in the ecosystem, but this project actually does have s390x-specific dependencies (below).
+platforms = ["x86_64-unknown-linux-gnu", "s390x-unknown-linux-gnu"]
+all-features = true
+
 [features]
 # rdcore is only useful inside the initrd of a CoreOS system
 rdcore = []


### PR DESCRIPTION
See https://github.com/cgwalters/cargo-vendor-filterer

This project also only targets CoreOS/Linux so we don't need
any other platform dependencies.  Most notably this obsoletes
the manual step to strip all the large prebuilt static `.a` files
for the windows crates.

```
$ du -sh vendor-filtered vendor
54M     vendor-filtered
135M    vendor
```

(And that's after the `find vendor -name '*.a' -delete`)

Checklist update in https://github.com/coreos/repo-templates/pull/4.