### PR TITLE
Revert "Revert "workflows: disable fail-fast on Rust jobs""

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
     name: "Tests, stable toolchain"
     runs-on: ubuntu-latest
     strategy:
+      # Keep x86_64 jobs alive if s390x jobs fail
+      fail-fast: false
       matrix:
         arch:
           - x86_64
@@ -72,6 +74,8 @@ jobs:
     name: "Tests, minimum supported toolchain"
     runs-on: ubuntu-latest
     strategy:
+      # Keep x86_64 jobs alive if s390x jobs fail
+      fail-fast: false
       matrix:
         arch:
           - x86_64
@@ -126,6 +130,8 @@ jobs:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest
     strategy:
+      # Keep x86_64 jobs alive if s390x jobs fail
+      fail-fast: false
       matrix:
         arch:
           - x86_64


### PR DESCRIPTION
s390x jobs are failing again.

This reverts commit 4e536b6109601ccb1d71af9863edf6ef8fbdc42a.