### PR TITLE
Dockerfile: disable cargo bundled libgit to avoid aarch64 OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:36 AS builder
-RUN dnf install -y cargo openssl-devel xz-devel
+RUN dnf install -y cargo git-core openssl-devel xz-devel
 WORKDIR /build
 COPY Cargo.* ./
 COPY src src/
@@ -8,6 +8,9 @@ RUN sed -i 's/^debug = true$/debug = false/' Cargo.toml
 # aarch64 release builds running in emulation take too long and time out the
 # GitHub Action.  Disable optimization.
 RUN if [ $(uname -p) != x86_64 ]; then sed -i "s/^debug = false$/debug = false\nopt-level = 0/" Cargo.toml; fi
+# Avoid OOM on emulated arm64
+# https://github.com/rust-lang/cargo/issues/10583
+RUN mkdir -p .cargo && echo -e '[net]\ngit-fetch-with-cli = true' > .cargo/config.toml
 RUN cargo build --release
 
 FROM registry.fedoraproject.org/fedora:36

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY src src/
 RUN sed -i 's/^debug = true$/debug = false/' Cargo.toml
 # aarch64 release builds running in emulation take too long and time out the
 # GitHub Action.  Disable optimization.
-RUN sh -c 'if [ $(uname -p) != x86_64 ]; then sed -i "s/^debug = false$/debug = false\nopt-level = 0/" Cargo.toml; fi'
+RUN if [ $(uname -p) != x86_64 ]; then sed -i "s/^debug = false$/debug = false\nopt-level = 0/" Cargo.toml; fi
 RUN cargo build --release
 
 FROM registry.fedoraproject.org/fedora:36


### PR DESCRIPTION
Container builds have been failing due to the same issue as in #872.  For now, shell out to git commands instead.