### PR TITLE
workflows: fix installation of `qemu-s390x-static`

### DIFF
--- a/.github/workflows/env-setup
+++ b/.github/workflows/env-setup
@@ -11,7 +11,7 @@ x86_64)
     # causes segfaults in rustup-init.  Luckily it's statically linked, so
     # extract the working Fedora package.
     podman run --rm -v $HOME:/pwd -w /pwd "${CONTAINER}" \
-        sh -c "dnf install -y python3-dnf-plugins-core && dnf download qemu-user-static.x86_64"
+        sh -c "dnf install -y python3-dnf-plugins-core && dnf download qemu-user-static-s390x.x86_64"
     rpm2cpio ~/qemu-user-static-*.x86_64.rpm |
         sudo cpio -D / -i --make-directories
     sudo systemctl restart systemd-binfmt


### PR DESCRIPTION
We install `qemu-s390x-static` by downloading and extracting a single Fedora binary package into an Ubuntu system, without respecting package dependencies.  As a consequence, when `qemu-user-static` was converted to a metapackage for https://github.com/coreos/fedora-coreos-tracker/issues/1088, we stopped actually installing the emulator.  Use the correct subpackage instead.

I've opted not to revert c3b3d49d4195c6016d3bececbf1c8012f21bc020 for now.  By leaving fail-fast disabled, we avoid wasting resources for successful jobs when we rerun failed ones after a flake, and make it easier to get CI signal if the s390x jobs break again in the future.  The downside is some CI resource waste when a PR has correlated job failures.