### PR TITLE
rdcore: Use collect instead of manual loop

### DIFF
--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -126,12 +126,7 @@ fn get_raid_kargs(device: &Path) -> Result<Vec<String>> {
 
 fn mdadm_detail(device: &Path) -> Result<HashMap<String, String>> {
     let output = runcmd_output!("mdadm", "--detail", "--export", device)?;
-    let mut result: HashMap<String, String> = HashMap::new();
-    for line in output.lines() {
-        let (key, val) = split_mdadm_line(line)?;
-        result.insert(key, val);
-    }
-    Ok(result)
+    output.lines().map(split_mdadm_line).collect()
 }
 
 fn split_mdadm_line(line: &str) -> Result<(String, String)> {


### PR DESCRIPTION
I happened to be have this code open for an unrelated reason
and noticed that this open-coded loop can be replaced by a `collect`.
We can already generate hashmap entries from a `(key, value)` tuple,
and `collect()` also knows how to generate a `Result<T>` which
it will know to do from type inference.