### PR TITLE
rootmap: handle filesystems with LUKS integrity

### DIFF
--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -108,7 +108,11 @@ fn device_to_kargs(root: &Mount, device: PathBuf) -> Result<Option<Vec<String>>>
     if blktype.starts_with("raid") || blktype == "linear" {
         Ok(Some(get_raid_kargs(&device)?))
     } else if blktype == "crypt" {
-        Ok(Some(get_luks_kargs(root, &device)?))
+        if Disk::new(&device)?.is_luks_integrity()? {
+            Ok(None)
+        } else {
+            Ok(Some(get_luks_kargs(root, &device)?))
+        }
     } else if blktype == "part" || blktype == "disk" || blktype == "mpath" {
         Ok(None)
     } else {
@@ -143,27 +147,14 @@ fn split_mdadm_line(line: &str) -> Result<(String, String)> {
 }
 
 fn get_luks_kargs(root: &Mount, device: &Path) -> Result<Vec<String>> {
-    // The LUKS UUID is a property of the backing block device of *this* block device, so we have
-    // to get its parent. This is a bit awkward because we're already iterating through parents, so
-    // theoretically we could re-use the same state here. But meh... this is easier to understand.
-    let deps = get_blkdev_deps(device)?;
-    match deps.len() {
-        0 => bail!("missing parent device for {}", device.display()),
-        1 => {
-            let uuid = get_luks_uuid(&deps[0])?;
-            let name = get_luks_name(device)?;
-            let mut kargs = vec![format!("rd.luks.name={}={}", uuid, name)];
-            if crypttab_device_has_netdev(root, &name)? {
-                kargs.push("rd.neednet=1".into());
-                kargs.push("rd.luks.options=_netdev".into());
-            }
-            Ok(kargs)
-        }
-        _ => bail!(
-            "found multiple parent devices for crypt device {}",
-            device.display()
-        ),
+    let uuid = get_luks_uuid(device)?;
+    let name = get_luks_name(device)?;
+    let mut kargs = vec![format!("rd.luks.name={}={}", uuid, name)];
+    if crypttab_device_has_netdev(root, &name)? {
+        kargs.push("rd.neednet=1".into());
+        kargs.push("rd.luks.options=_netdev".into());
     }
+    Ok(kargs)
 }
 
 // crypttab is the source of truth for whether an encrypted block device requires networking.
@@ -216,9 +207,26 @@ fn get_luks_name(device: &Path) -> Result<String> {
 }
 
 fn get_luks_uuid(device: &Path) -> Result<String> {
-    Ok(runcmd_output!("cryptsetup", "luksUUID", device)?
-        .trim()
-        .into())
+    // The LUKS UUID is a property of the backing block device of *this* block device, so we have
+    // to get its parent. This is a bit awkward because we're already iterating through parents, so
+    // theoretically we could re-use the same state here. But meh... this is easier to understand and
+    // handle crypt-integrity case
+    let deps = get_blkdev_deps(device)?;
+    match deps.as_slice() {
+        [] => bail!("missing parent device for {}", device.display()),
+        [device] => {
+            if Disk::new(&device)?.is_dm_device() {
+                return get_luks_uuid(device);
+            }
+            Ok(runcmd_output!("cryptsetup", "luksUUID", device)?
+                .trim()
+                .into())
+        }
+        _ => bail!(
+            "found multiple parent devices for crypt device {}",
+            device.display()
+        ),
+    }
 }
 
 pub fn bind_boot(config: BindBootConfig) -> Result<()> {


### PR DESCRIPTION
Systems where some filesystems were luks2-encrypted with 'integrity' option have special
crypt-integrity devices:
```
NAME                 FSTYPE      FSVER LABEL        UUID
vda
|-vda3               crypto_LUKS 2     crypt_bootfs f55add4a-1351-4699-9e61-32f33a68a031
| `-crypt_bootfs_dif
|   `-crypt_bootfs   ext4        1.0   boot         3d4ed0e4-40ba-4930-99ff-35d2be907ec3
|-vda4               crypto_LUKS 2     crypt_rootfs 7c5341bf-9616-4ce1-90dc-111b03379799
| `-crypt_rootfs_dif
|   `-crypt_rootfs   xfs               root         d0bc5f93-f2ac-42f3-8b16-27b0794266c5
```

So to get 'uuid' of such devices, we have to recursively go to the underlying block device.
crypt-integrity devices on the other hand should be skipped during 'rdcore rootmap'.