### PR TITLE
blockdev: use 'blkid' for reading device's UUID

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -772,13 +772,16 @@ fn read_sysfs_dev_block_value(maj: u64, min: u64, field: &str) -> Result<String>
     Ok(read_to_string(&path)?.trim_end().into())
 }
 
-pub fn lsblk_single(dev: &Path) -> Result<HashMap<String, String>> {
+pub fn get_block_device_type(dev: &Path) -> Result<String> {
     let mut devinfos = lsblk(Path::new(dev), false)?;
     if devinfos.is_empty() {
         // this should never happen because `lsblk` itself would've failed
         bail!("no lsblk results for {}", dev.display());
     }
-    Ok(devinfos.remove(0))
+    devinfos
+        .remove(0)
+        .remove("TYPE")
+        .with_context(|| format!("missing TYPE for {}", dev.display()))
 }
 
 /// Returns all available filesystems.


### PR DESCRIPTION
firstboot of RHCOS on IBM zKVM from time to time fails during "File System Check".
This happens, because systemd unit has an old filesystem's UUID from pristine qcow2 image,
not the regenerated one:

```
coreos-boot-edit: + lsblk -o NAME,LABEL,UUID --paths --pairs /dev/disk/by-label/boot
coreos-boot-edit: NAME="/dev/mapper/crypt_bootfs" LABEL="boot" UUID="96d15588-3596-4b3c-adca-a2ff7279ea63"
coreos-boot-edit: + blkid /dev/disk/by-label/boot
coreos-boot-edit: /dev/disk/by-label/boot: LABEL="boot" UUID="eee55c4f-c2df-47e9-a284-992e9e122a97" BLOCK_SIZE="1024" TYPE="ext4"
coreos-boot-edit: + rdcore bind-boot /sysroot /mnt/boot_partition
.....
coreos-boot-mount-generator: ++ cat /run/coreos/bootfs_uuid
coreos-boot-mount-generator: + bootdev=/dev/disk/by-uuid/96d15588-3596-4b3c-adca-a2ff7279ea63
```
