### PR TITLE
cargo: update version ranges for post-1.x deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ debug = true
 anyhow = ">= 1.0.38, < 2"
 base64 = "0.13"
 bincode = "^1.3"
-bytes = ">= 1.0.1, < 1.2.0"
+bytes = ">= 1.0.1, < 2"
 byte-unit = ">= 3.1.0, < 5.0.0"
 clap = { version = "3.1", default-features = false, features = ["std", "cargo", "derive", "suggestions", "wrap_help"] }
 clap_mangen = { version = "0.1", optional = true }
@@ -69,7 +69,7 @@ libc = "^0.2"
 nix = ">= 0.24, < 0.25"
 openssl = "^0.10"
 pipe = ">= 0.3, < 0.5"
-regex = ">= 1.4, < 1.7"
+regex = ">= 1.4, < 2"
 reqwest = { version = ">= 0.10, < 0.12", features = ["blocking"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"


### PR DESCRIPTION
The idea of the explicit ranges is to exactly replicate the ranges that Cargo would allow if a bare version were specified, while convincing Dependabot not to bump the minimum version.  For major versions > 0, Cargo would allow every minor up to the next major, so we should do that too.

See discussion [here](https://src.fedoraproject.org/rpms/rust-coreos-installer/pull-request/40).