### PR TITLE
blockdev: fail `install --save-partindex` on MBR-formatted disks 

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,7 @@ Minor changes:
 - Add release notes to documentation
 - iso: Detect incomplete ISO files
 - Warn if console kargs could have used `--console`/`--dest-console` instead
+- install: fail if `--save-partindex` is specified on an MBR disk
 
 Internal changes:
 


### PR DESCRIPTION
`install --save-partindex` and `install --save-partlabel` both search the GPT for the specified partitions. While MBR doesn't have partition labels, it does have partition indexes. Users might try to use `--save-partindex` with an MBR disk, resulting in data loss when coreos-installer doesn't notice the specified partitions.

To address this, we'll need to detect saved MBR partitions and convert them to GPT partitions in the output. As a first step, if `--save-partindex` is specified and the disk has an MBR but no GPT, fail install to avoid data loss.

Fixes https://github.com/coreos/coreos-installer/issues/816.