### PR TITLE
s390x: don't copy '/etc/crypttab' to sdboot

### DIFF
--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -150,20 +150,18 @@ fn generate_sdboot(
         .write_all(options.as_bytes())
         .context("writing zipl se cmdline")?;
 
-    let mut lukskeys_path = "/etc/luks/".to_string();
-    let mut crypttab_path = "/etc/crypttab".to_string();
-    let mut hostkeys_path = "/etc/se-hostkeys/".to_string();
-
     // during cosa-build rootfs includes ostree commit path
-    if let Some(ref rootfs) = rootfs {
-        lukskeys_path.insert_str(0, rootfs);
-        crypttab_path.insert_str(0, rootfs);
-        hostkeys_path.insert_str(0, rootfs);
-    }
+    let ostree_commit = if let Some(rootfs) = rootfs.as_ref() {
+        Path::new(rootfs)
+    } else {
+        Path::new("/")
+    };
+    let lukskeys_path = ostree_commit.join("etc/luks");
+    let hostkeys_path = ostree_commit.join("etc/se-hostkeys");
+
     // new initrd with LUKS keys & config
-    let mut luks_files = find_files(&lukskeys_path, |e: &DirEntry| Ok(e.metadata()?.is_file()))?;
-    luks_files.push(PathBuf::from(crypttab_path));
-    let initrd = generate_initrd(&initrd, &luks_files, rootfs)?;
+    let luks_keys = find_files(&lukskeys_path, |e: &DirEntry| Ok(e.metadata()?.is_file()))?;
+    let initrd = generate_initrd(&initrd, &luks_keys, rootfs)?;
 
     // during cosa-build we override hostkey(s) with a universal one
     let hostkeys = if let Some(hostkey) = hostkey {


### PR DESCRIPTION
We are going to use kernel's `keyring` and custom `/init` to protect luks keys. So opening of `/` and `/boot` no longer depends on `/etc/crypttab`.

/do-not-merge