### PR TITLE
rdcore: zipl: add support for multiple '--append-karg'

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,7 @@ Minor changes:
 - iso: Detect incomplete ISO files
 
 Internal changes:
+- rdcore: Rename `--kargs` to `--append-karg` in `zipl` subcommand and support passing it multiple times
 
 
 Packaging changes:
@@ -243,18 +244,18 @@ Major changes:
 Minor changes:
 
 - blockdev: Fix RHEL `lsblk` ordering [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1916502) by using `--nodeps` option
-- blockdev: Strengthen device mapper path detection 
+- blockdev: Strengthen device mapper path detection
 
 Internal changes:
 
-- osmet: Drop support for `--real-rootdev` option 
+- osmet: Drop support for `--real-rootdev` option
 - Add `--override-options` to `rdcore kargs` to make it easier to test kernel argument changes
 - Optionally create a file if kernel arguments are modified
 - Add declarative semantics for kernel argument modification
 
 Packaging changes:
 
-- Switch from `error-chain` to `anyhow` library 
+- Switch from `error-chain` to `anyhow` library
 
 
 ## coreos-installer 0.8.0 (2021-01-12)

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -145,9 +145,9 @@ pub struct ZiplConfig {
     #[clap(long, value_name = "HOSTKEY")]
     pub hostkey: Option<String>,
 
-    /// Extra kargs
-    #[clap(long, value_name = "KARGS")]
-    pub kargs: Option<String>,
+    /// Append kernel argument
+    #[clap(long, value_name = "KARG")]
+    pub append_karg: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/src/bin/rdcore/kargs.rs
+++ b/src/bin/rdcore/kargs.rs
@@ -99,7 +99,7 @@ pub fn zipl(config: ZiplConfig) -> Result<()> {
         boot.mountpoint(),
         config.hostkey,
         config.rootfs,
-        config.kargs,
+        config.append_karg.as_ref().map(|v| v.join(" ")),
         config.secex_mode,
     )
 }


### PR DESCRIPTION
This allows such invocation to be possible:
```
rdcore zipl --append-karg=ignition.firstboot --append-karg=lockdown=confidentiality --secex-mode=enforce --boot-mount=/boot
```

Required for:
https://github.com/coreos/coreos-assembler/pull/3002
