### PR TITLE
s390x: don't fail if luks isn't used

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,7 +21,7 @@ Minor changes:
 
 Internal changes:
 - rdcore: Rename `--kargs` to `--append-karg` in `zipl` subcommand and support passing it multiple times
-
+- Only open BLS configs in write mode when modifying
 
 Packaging changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,7 @@ Minor changes:
 Internal changes:
 - rdcore: Rename `--kargs` to `--append-karg` in `zipl` subcommand and support passing it multiple times
 - Only open BLS configs in write mode when modifying
+- s390x: Don't fail and skip initrd update when there is no LUKS2 keys and config
 
 Packaging changes:
 


### PR DESCRIPTION
This brings support for recent move from `LUKS2` to `dm-verity` introduced by https://github.com/coreos/coreos-assembler/pull/3039. 