### PR TITLE
rdcore/zipl: alias old `--kargs` to new `--append-karg`

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,7 +21,7 @@ Minor changes:
 
 Internal changes:
 
-- rdcore: Rename `--kargs` to `--append-karg` in `zipl` subcommand and support passing it multiple times
+- zipl: Deprecate `--kargs` in favor of new `--append-karg`, which supports multiple instances
 - Only open BLS configs in write mode when modifying
 - zipl: Support Secure Execution systems without LUKS for coreos-assembler
 

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -147,6 +147,7 @@ pub struct ZiplConfig {
 
     /// Append kernel argument
     #[clap(long, value_name = "KARG")]
+    #[clap(alias = "kargs")]
     pub append_karg: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
We need to keep providing the old alias here to make the transition
easier in cosa.

Note the semantics are a little different (before, this was an
`Option<String>`, now it's an `Option<Vec<String>>`), but it still works
for what we need here.