### PR TITLE
rdcore: add '--append-file' for 'zipl' subcommand

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,7 @@ Internal changes:
 - zipl: Deprecate `--kargs` in favor of new `--append-karg`, which supports multiple instances
 - Only open BLS configs in write mode when modifying
 - zipl: Support Secure Execution systems without LUKS for coreos-assembler
+- zipl: Remove obsolete `--rootfs`
 
 Packaging changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,7 @@ Internal changes:
 - Only open BLS configs in write mode when modifying
 - zipl: Support Secure Execution systems without LUKS for coreos-assembler
 - zipl: Remove obsolete `--rootfs`
+- zipl: Add new `--append-file`, which supports multiple instances
 
 Packaging changes:
 

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -145,6 +145,10 @@ pub struct ZiplConfig {
     #[clap(long, value_name = "KARG")]
     #[clap(alias = "kargs")]
     pub append_karg: Option<Vec<String>>,
+
+    /// Append file to sdboot image
+    #[clap(long, value_name = "FILE")]
+    pub append_file: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/src/bin/rdcore/cmdline.rs
+++ b/src/bin/rdcore/cmdline.rs
@@ -137,10 +137,6 @@ pub struct ZiplConfig {
     #[clap(long, default_value = "auto")]
     pub secex_mode: s390x::ZiplSecexMode,
 
-    /// Path to rootfs
-    #[clap(long, value_name = "ROOTFS")]
-    pub rootfs: Option<String>,
-
     /// Path to hostkey
     #[clap(long, value_name = "HOSTKEY")]
     pub hostkey: Option<String>,

--- a/src/bin/rdcore/kargs.rs
+++ b/src/bin/rdcore/kargs.rs
@@ -57,7 +57,6 @@ pub fn kargs(config: KargsConfig) -> Result<()> {
                 mount.mountpoint(),
                 None,
                 None,
-                None,
                 s390x::ZiplSecexMode::Auto,
             )?;
         }
@@ -98,7 +97,6 @@ pub fn zipl(config: ZiplConfig) -> Result<()> {
     s390x::zipl(
         boot.mountpoint(),
         config.hostkey,
-        config.rootfs,
         config.append_karg.as_ref().map(|v| v.join(" ")),
         config.secex_mode,
     )

--- a/src/bin/rdcore/kargs.rs
+++ b/src/bin/rdcore/kargs.rs
@@ -58,6 +58,7 @@ pub fn kargs(config: KargsConfig) -> Result<()> {
                 None,
                 None,
                 s390x::ZiplSecexMode::Auto,
+                None,
             )?;
         }
     }
@@ -99,5 +100,6 @@ pub fn zipl(config: ZiplConfig) -> Result<()> {
         config.hostkey,
         config.append_karg.as_ref().map(|v| v.join(" ")),
         config.secex_mode,
+        config.append_file,
     )
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -440,6 +440,7 @@ fn write_disk(
                 None,
                 None,
                 s390x::ZiplSecexMode::Disable,
+                None,
             )?;
             s390x::chreipl(device)?;
         }

--- a/src/install.rs
+++ b/src/install.rs
@@ -439,7 +439,6 @@ fn write_disk(
                 mount.mountpoint(),
                 None,
                 None,
-                None,
                 s390x::ZiplSecexMode::Disable,
             )?;
             s390x::chreipl(device)?;


### PR DESCRIPTION
In SE case we append `luks2` keys to original `initrd`. It may be also useful to append some more user-defined files to `sdboot` image. 