### PR TITLE
Generate and install example install config file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -245,7 +245,7 @@ jobs:
         run: |
           rm man/*.8
           make docs
-          if [ -n "$(git status --porcelain docs man)" ]; then
+          if [ -n "$(git status --porcelain data docs man)" ]; then
             echo "Found local changes after regenerating docs:"
             git --no-pager diff --color=always docs man
             echo "Rerun 'make docs'."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ all-features = true
 [features]
 # rdcore is only useful inside the initrd of a CoreOS system
 rdcore = []
-mangen = ["clap_mangen"]
+docgen = ["clap_mangen"]
 
 [lib]
 name = "libcoreinst"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifeq ($(RELEASE),1)
 	STRIP_RDCORE ?= 0
 else
 	PROFILE ?= debug
-	CARGO_ARGS = --features mangen
+	CARGO_ARGS = --features docgen
 	# In debug mode (most often used by devs/CI), we default to stripping
 	# `rdcore` because it's otherwise huge and in kola's default 1G VMs can
 	# cause ENOSPC. In release mode (most often used by Koji/Brew), we don't do

--- a/Makefile
+++ b/Makefile
@@ -27,21 +27,29 @@ ifneq ($(RDCORE),1)
 endif
 
 .PHONY: docs
-docs: all
+docs: all data/example-config.yaml
 	PROFILE=$(PROFILE) docs/_cmd.sh
 	PROFILE=$(PROFILE) docs/_config-file.sh
 	target/${PROFILE}/coreos-installer pack man -C man
+
+data/example-config.yaml: target/$(PROFILE)/coreos-installer Makefile
+	echo -e "# Sample installer config file\n# Automatically generated; do not edit\n" > $@
+	$< pack example-config >> $@
 
 .PHONY: clean
 clean:
 	cargo clean
 
 .PHONY: install
-install: install-bin install-man install-scripts install-systemd install-dracut
+install: install-bin install-data install-man install-scripts install-systemd install-dracut
 
 .PHONY: install-bin
 install-bin:
 	install -D -t ${DESTDIR}/usr/bin target/${PROFILE}/coreos-installer
+
+.PHONY: install-data
+install-data:
+	install -D -m 644 -t ${DESTDIR}/usr/share/coreos-installer data/example-config.yaml
 
 .PHONY: install-man
 install-man:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ endif
 .PHONY: docs
 docs: all
 	PROFILE=$(PROFILE) docs/_cmd.sh
+	PROFILE=$(PROFILE) docs/_config-file.sh
 	target/${PROFILE}/coreos-installer pack man -C man
 
 .PHONY: clean

--- a/data/example-config.yaml
+++ b/data/example-config.yaml
@@ -1,0 +1,45 @@
+# Sample installer config file
+# Automatically generated; do not edit
+
+# Fedora CoreOS stream
+stream: name
+# Manually specify the image URL
+image-url: URL
+# Manually specify a local image file
+image-file: path
+# Embed an Ignition config from a file
+ignition-file: path
+# Embed an Ignition config from a URL
+ignition-url: URL
+# Digest (type-value) of the Ignition config
+ignition-hash: digest
+# Target CPU architecture
+architecture: name
+# Override the Ignition platform ID
+platform: name
+# Append default kernel arguments
+append-karg: [arg, arg]
+# Delete default kernel arguments
+delete-karg: [arg, arg]
+# Copy network config from install environment
+copy-network: true
+# Source directory for copy-network
+network-dir: path
+# Save partitions with this label glob
+save-partlabel: [glob, glob]
+# Save partitions with this number or range
+save-partindex: [id-or-range, id-or-range]
+# Force offline installation
+offline: true
+# Skip signature verification
+insecure: true
+# Allow Ignition URL without HTTPS or hash
+insecure-ignition: true
+# Base URL for CoreOS stream metadata
+stream-base-url: URL
+# Don't clear partition table on error
+preserve-on-error: true
+# Fetch retries, or string "infinite"
+fetch-retries: N
+# Destination device
+dest-device: path

--- a/docs/_config-file.sh
+++ b/docs/_config-file.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Regenerate example config file in customizing-install.md
+
+set -euo pipefail
+
+rootdir="$(dirname $0)/.."
+prog="${rootdir}/target/${PROFILE:-debug}/coreos-installer"
+path="${rootdir}/docs/customizing-install.md"
+
+echo "Generating $(realpath --relative-to=${rootdir} ${path})..."
+(
+    awk '/^<!-- begin example config -->$/ {print; exit} {print}' "${path}"
+    echo '```yaml'
+    ${prog} pack example-config
+    echo '```'
+    awk '/^<!-- end example config -->$/ {p=1} {if (p) print}' "${path}"
+) > "${path}.new"
+mv "${path}.new" "${path}"

--- a/docs/customizing-install.md
+++ b/docs/customizing-install.md
@@ -112,6 +112,7 @@ is parsed in order, and other command-line arguments are parsed afterward.
 
 All parameters are optional.
 
+<!-- begin example config -->
 ```yaml
 # Fedora CoreOS stream
 stream: name
@@ -125,12 +126,14 @@ ignition-file: path
 ignition-url: URL
 # Digest (type-value) of the Ignition config
 ignition-hash: digest
+# Target CPU architecture
+architecture: name
 # Override the Ignition platform ID
 platform: name
 # Append default kernel arguments
-append-karg: [arg1, arg2]
+append-karg: [arg, arg]
 # Delete default kernel arguments
-delete-karg: [arg1, arg2]
+delete-karg: [arg, arg]
 # Copy network config from install environment
 copy-network: true
 # Source directory for copy-network
@@ -145,10 +148,8 @@ offline: true
 insecure: true
 # Allow Ignition URL without HTTPS or hash
 insecure-ignition: true
-# Base URL for Fedora CoreOS stream metadata
+# Base URL for CoreOS stream metadata
 stream-base-url: URL
-# Target CPU architecture
-architecture: name
 # Don't clear partition table on error
 preserve-on-error: true
 # Fetch retries, or string "infinite"
@@ -156,6 +157,7 @@ fetch-retries: N
 # Destination device
 dest-device: path
 ```
+<!-- end example config -->
 
 ### Example manual customization via `installer.d`
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -31,6 +31,7 @@ Packaging changes:
 - Add dependency on `zstd` crate and `libzstd` shared library
 - Support `serde_yaml` 0.9
 - Remove non-Linux dependencies from vendor archive
+- Install example installer config file in `/usr/share/coreos-installer`
 
 
 ## coreos-installer 0.15.0 (2022-06-17)

--- a/src/cmdline/doc.rs
+++ b/src/cmdline/doc.rs
@@ -14,15 +14,18 @@
 
 //! Support for generating docs.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::{crate_version, Command, CommandFactory};
+use serde::{de, forward_to_deserialize_any, Deserialize};
+use std::collections::{hash_map::RandomState, HashMap};
+use std::fmt::Write as _;
 use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use crate::io::BUFFER_SIZE;
 
-use super::{Cmd, PackManConfig};
+use super::{Cmd, InstallConfig, PackExampleConfigConfig, PackManConfig};
 
 pub fn pack_man(config: PackManConfig) -> Result<()> {
     pack_one_man(&config, Cmd::command())
@@ -57,4 +60,107 @@ fn pack_one_man(config: &PackManConfig, cmd: Command) -> Result<()> {
         )?;
     }
     Ok(())
+}
+
+pub fn pack_example_config(_config: PackExampleConfigConfig) -> Result<()> {
+    // first get the field list from serde's perspective, so we omit any
+    // fields hidden from it
+    let mut fields = Vec::new();
+    // we usually skip empty fields on serialize, so we have to do this
+    // via the deserializer instead
+    InstallConfig::deserialize(&mut FieldLister {
+        fields: &mut fields,
+    })
+    .unwrap_err();
+
+    // now use that list to query clap arguments and format output
+    let mut out = String::new();
+    let cmd = InstallConfig::command();
+    // argument name -> clap::Arg
+    let arg_map: HashMap<_, _, RandomState> =
+        HashMap::from_iter(cmd.get_arguments().map(|arg| (arg.get_id(), arg)));
+    for field in &fields {
+        if let Some(arg) = arg_map.get(&**field) {
+            // output help comment
+            // we can't serialize through serde_yaml because it doesn't
+            // support comments
+            if let Some(help) = arg.get_help() {
+                let help = match field.as_ref() {
+                    // clarify YAML syntax for "infinite"
+                    "fetch-retries" => r#"Fetch retries, or string "infinite""#,
+                    // don't reference -n short option
+                    "network-dir" => "Source directory for copy-network",
+                    // "arg" => "arguments"
+                    "append-karg" => "Append default kernel arguments",
+                    "delete-karg" => "Delete default kernel arguments",
+                    _ => help,
+                };
+                writeln!(out, "# {}", help).unwrap();
+            }
+
+            // output "field: argument-description"
+            let value_names = arg.get_value_names().map(|v| v[0]);
+            let desc = if arg.is_multiple_occurrences_set() {
+                // value array
+                let value_name = match field.as_ref() {
+                    // more verbose than 80 columns will allow
+                    "save-partlabel" => "glob",
+                    "save-partindex" => "id-or-range",
+                    _ => value_names.expect("missing value name"),
+                };
+                format!("[{0}, {0}]", value_name)
+            } else if arg.is_takes_value_set() {
+                // option with argument
+                match field.as_ref() {
+                    // positional arguments have different formatting
+                    "dest-device" => "path",
+                    _ => value_names.expect("missing value name"),
+                }
+                .into()
+            } else {
+                // option flag
+                "true".into()
+            };
+            writeln!(out, "{}: {}", field, desc).unwrap();
+        } else {
+            bail!("couldn't look up field {}", field);
+        }
+    }
+
+    // since we hand-rolled YAML output, make sure it parses
+    serde_yaml::from_str::<serde_yaml::Value>(&out).context("re-parsing output")?;
+
+    print!("{}", out);
+    Ok(())
+}
+
+struct FieldLister<'a> {
+    fields: &'a mut Vec<String>,
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut FieldLister<'a> {
+    type Error = de::value::Error;
+
+    fn deserialize_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.fields.extend(fields.iter().map(|v| v.to_string()));
+        // we don't want to bother generating a default struct and throwing
+        // it away, so fail
+        Err(de::Error::custom("expected failure"))
+    }
+
+    // fill out the API contract
+    fn deserialize_any<V: de::Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        unimplemented!()
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map enum identifier ignored_any
+    }
 }

--- a/src/cmdline/doc.rs
+++ b/src/cmdline/doc.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Support for generating man pages.
+//! Support for generating docs.
 
 use anyhow::{Context, Result};
 use clap::{crate_version, Command, CommandFactory};
@@ -25,10 +25,10 @@ use crate::io::BUFFER_SIZE;
 use super::{Cmd, PackManConfig};
 
 pub fn pack_man(config: PackManConfig) -> Result<()> {
-    pack_one(&config, Cmd::command())
+    pack_one_man(&config, Cmd::command())
 }
 
-fn pack_one(config: &PackManConfig, cmd: Command) -> Result<()> {
+fn pack_one_man(config: &PackManConfig, cmd: Command) -> Result<()> {
     let name = cmd.get_name();
     let path = Path::new(&config.directory).join(format!("{}.8", name));
     println!("Generating {}...", path.display());
@@ -51,7 +51,7 @@ fn pack_one(config: &PackManConfig, cmd: Command) -> Result<()> {
 
     for subcmd in cmd.get_subcommands().filter(|c| !c.is_hide_set()) {
         let subname = format!("{}-{}", name, subcmd.get_name());
-        pack_one(
+        pack_one_man(
             config,
             subcmd.clone().name(subname).version(crate_version!()),
         )?;

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -169,6 +169,9 @@ pub enum PackCmd {
     /// Generate man pages for coreos-installer
     #[cfg(feature = "docgen")]
     Man(PackManConfig),
+    /// Generate example config file for install subcommand
+    #[cfg(feature = "docgen")]
+    ExampleConfig(PackExampleConfigConfig),
 }
 
 #[derive(Debug, Parser)]
@@ -699,6 +702,10 @@ pub struct PackManConfig {
     #[clap(short = 'C', long, value_name = "path", default_value = ".")]
     pub directory: String,
 }
+
+#[cfg(feature = "docgen")]
+#[derive(Debug, Parser)]
+pub struct PackExampleConfigConfig {}
 
 #[cfg(test)]
 mod test {

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -18,15 +18,15 @@
 use clap::{AppSettings, Parser};
 use reqwest::Url;
 
+#[cfg(feature = "docgen")]
+mod doc;
 mod install;
-#[cfg(feature = "mangen")]
-mod man;
 mod serializer;
 mod types;
 
+#[cfg(feature = "docgen")]
+pub use self::doc::*;
 pub use self::install::InstallConfig;
-#[cfg(feature = "mangen")]
-pub use self::man::*;
 pub use self::types::*;
 
 // Args are listed in --help in the order declared in these structs/enums.
@@ -167,7 +167,7 @@ pub enum PackCmd {
     /// Pack a minimal ISO into a CoreOS live ISO image
     MinimalIso(PackMinimalIsoConfig),
     /// Generate man pages for coreos-installer
-    #[cfg(feature = "mangen")]
+    #[cfg(feature = "docgen")]
     Man(PackManConfig),
 }
 
@@ -692,7 +692,7 @@ pub struct DevExtractInitrdConfig {
     pub filter: Vec<String>,
 }
 
-#[cfg(feature = "mangen")]
+#[cfg(feature = "docgen")]
 #[derive(Debug, Parser)]
 pub struct PackManConfig {
     /// Output directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
         Cmd::Pack(c) => match c {
             PackCmd::Osmet(c) => osmet::pack_osmet(c),
             PackCmd::MinimalIso(c) => live::pack_minimal_iso(c),
-            #[cfg(feature = "mangen")]
+            #[cfg(feature = "docgen")]
             PackCmd::Man(c) => cmdline::pack_man(c),
         },
         Cmd::Dev(c) => match c {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,8 @@ fn main() -> Result<()> {
             PackCmd::MinimalIso(c) => live::pack_minimal_iso(c),
             #[cfg(feature = "docgen")]
             PackCmd::Man(c) => cmdline::pack_man(c),
+            #[cfg(feature = "docgen")]
+            PackCmd::ExampleConfig(c) => cmdline::pack_example_config(c),
         },
         Cmd::Dev(c) => match c {
             DevCmd::Show(c) => match c {


### PR DESCRIPTION
If the `docgen` feature is enabled, add a subcommand to walk the `InstallConfig` struct and generate an example config file.  Use it to regenerate `customizing-install.md` and a new `example-config.yaml` when rebuilding docs.

Install `example-config.yaml` in `/usr/share/coreos-installer` for use by cosa, which can automatically add feature flags to the live image for each config option supported by the installer.