### PR TITLE
cargo: bump mbrman to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,13 +862,14 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "mbrman"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6f6de0b8cfc56e13dc3ac3c662d9419f8aa5e3ebceb2d0eb25abce49e00395"
+checksum = "cdee9caaf6ebb0bae8ae1cb6b591e5553b6cf5a34c7ea07bb6f24c1a80619819"
 dependencies = [
  "bincode",
  "bitvec",
  "serde",
+ "serde-big-array",
  "thiserror",
 ]
 
@@ -1519,6 +1520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ xz2 = "^0.1"
 zstd = { version = ">= 0.10.0, < 0.12.0", features = ["pkg-config"] }
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
-mbrman = { version = ">= 0.3, < 0.5", default-features = false }
+mbrman = ">= 0.5, < 0.6"
 rand = ">= 0.7, < 0.9"
 
 [dev-dependencies]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,8 @@ Internal changes:
 
 Packaging changes:
 
+- Require `mbrman` ≥ 0.5.0
+
 
 ## coreos-installer 0.16.1 (2022-09-19)
 

--- a/src/s390x/fba.rs
+++ b/src/s390x/fba.rs
@@ -39,7 +39,7 @@ pub(crate) fn fba_make_partitions(
             length: blocks * bytes_per_block as u64,
         });
         mbr[idx + 1] = MBRPartitionEntry {
-            boot: false,
+            boot: mbrman::BOOT_INACTIVE,
             first_chs: CHS::empty(),
             sys: 0x83, // MBR_LINUX_DATA_PARTITION
             last_chs: CHS::empty(),


### PR DESCRIPTION
`default-features = false` was always redundant; drop it.