### PR TITLE
workflows: cancel superseded Rust and RPM jobs

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# don't waste job slots on superseded code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-rpm-build:
     name: "Build (Fedora)"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# s390x tests are expensive; don't waste job slots on superseded code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CONTAINER: registry.fedoraproject.org/fedora:latest
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
s390x tests are expensive, and when we're merging a lot of Dependabot PRs, CI can get backed up running redundant tests on main.  We don't need to continue running tests that have been superseded by new code, either in main or in a PR branch, so add concurrency configuration to cancel them.