### PR TITLE
install: low-level format ECKD DASD before initiating fetch

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ Major changes:
 Minor changes:
 
 - install: Avoid osmet performance regression in debug builds on Rust 1.64+
+- install: Avoid network fetch timeout when low-level formatting ECKD DASD
 
 Internal changes:
 


### PR DESCRIPTION
Normally we want to check the install image before starting to do I/O to the destination disk.  However, low-level formatting an ECKD DASD can take a long time, and if we initiate download of the install image first, the TCP connection will sit without any bytes being read and may eventually time out.  Avoid this by doing the low-level format before starting the fetch.

Fixes https://github.com/coreos/coreos-installer/issues/431.