### PR TITLE
Use inline `format!` in a few places

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -216,7 +216,7 @@ impl PartTableKernel {
         let file = OpenOptions::new()
             .write(true)
             .open(path)
-            .with_context(|| format!("opening {}", path))?;
+            .with_context(|| format!("opening {path}"))?;
         Ok(Self { file })
     }
 }
@@ -917,10 +917,10 @@ pub fn find_parent_devices(device: &str) -> Result<Vec<String>> {
         let dev = split_lsblk_line(line);
         let name = dev
             .get("NAME")
-            .with_context(|| format!("device in hierarchy of {} missing NAME", device))?;
+            .with_context(|| format!("device in hierarchy of {device} missing NAME"))?;
         let kind = dev
             .get("TYPE")
-            .with_context(|| format!("device in hierarchy of {} missing TYPE", device))?;
+            .with_context(|| format!("device in hierarchy of {device} missing TYPE"))?;
         if kind == "disk" {
             parents.push(name.clone());
         } else if kind == "mpath" {
@@ -941,7 +941,7 @@ pub fn find_colocated_esps(device: &str) -> Result<Vec<String>> {
 
     // first, get the parent device
     let parent_devices = find_parent_devices(device)
-        .with_context(|| format!("while looking for colocated ESPs of '{}'", device))?;
+        .with_context(|| format!("while looking for colocated ESPs of '{device}'"))?;
 
     // now, look for all ESPs on those devices
     let mut esps = Vec::new();
@@ -1165,14 +1165,14 @@ pub fn is_dasd(device: &str, fd: Option<&mut File>) -> Result<bool> {
     let read_magic = |device: &str, disk: &mut File| -> Result<[u8; 4]> {
         let offset = disk
             .seek(SeekFrom::Current(0))
-            .with_context(|| format!("saving offset {}", device))?;
+            .with_context(|| format!("saving offset {device}"))?;
         disk.seek(SeekFrom::Start(8194))
-            .with_context(|| format!("seeking {}", device))?;
+            .with_context(|| format!("seeking {device}"))?;
         let mut lbl = [0u8; 4];
         disk.read_exact(&mut lbl)
-            .with_context(|| format!("reading label {}", device))?;
+            .with_context(|| format!("reading label {device}"))?;
         disk.seek(SeekFrom::Start(offset))
-            .with_context(|| format!("restoring offset {}", device))?;
+            .with_context(|| format!("restoring offset {device}"))?;
         Ok(lbl)
     };
     if target.to_string_lossy().starts_with("/dev/vd") {

--- a/src/cmdline/doc.rs
+++ b/src/cmdline/doc.rs
@@ -48,12 +48,12 @@ fn pack_one_man(config: &PackManConfig, cmd: Command) -> Result<()> {
         .section("8")
         .source(format!("coreos-installer {}", crate_version!()))
         .render(&mut buf)
-        .with_context(|| format!("rendering {}.8", name))?;
+        .with_context(|| format!("rendering {name}.8"))?;
     buf.flush().context("flushing man page")?;
     drop(buf);
 
     for subcmd in cmd.get_subcommands().filter(|c| !c.is_hide_set()) {
-        let subname = format!("{}-{}", name, subcmd.get_name());
+        let subname = format!("{name}-{}", subcmd.get_name());
         pack_one_man(
             config,
             subcmd.clone().name(subname).version(crate_version!()),
@@ -95,7 +95,7 @@ pub fn pack_example_config(_config: PackExampleConfigConfig) -> Result<()> {
                     "delete-karg" => "Delete default kernel arguments",
                     _ => help,
                 };
-                writeln!(out, "# {}", help).unwrap();
+                writeln!(out, "# {help}").unwrap();
             }
 
             // output "field: argument-description"
@@ -121,7 +121,7 @@ pub fn pack_example_config(_config: PackExampleConfigConfig) -> Result<()> {
                 // option flag
                 "true".into()
             };
-            writeln!(out, "{}: {}", field, desc).unwrap();
+            writeln!(out, "{field}: {desc}").unwrap();
         } else {
             bail!("couldn't look up field {}", field);
         }

--- a/src/install.rs
+++ b/src/install.rs
@@ -673,7 +673,7 @@ fn copy_network_config(mountpoint: &Path, net_config_src: &str) -> Result<()> {
     for entry in fs::read_dir(&net_config_src)
         .with_context(|| format!("reading directory {}", net_config_src))?
     {
-        let entry = entry.with_context(|| format!("reading directory {}", net_config_src))?;
+        let entry = entry.with_context(|| format!("reading directory {net_config_src}"))?;
         let srcpath = entry.path();
         let destpath = net_config_dest.join(entry.file_name());
         if srcpath.is_file() {

--- a/src/miniso.rs
+++ b/src/miniso.rs
@@ -51,12 +51,9 @@ impl Table {
         for (path, minimal_entry) in minimal_files {
             let full_entry = full_files
                 .get(path)
-                .with_context(|| format!("missing minimal file {} in full ISO", path))?;
+                .with_context(|| format!("missing minimal file {path} in full ISO"))?;
             if full_entry.length != minimal_entry.length {
-                bail!(
-                    "File {} has different lengths in full and minimal ISOs",
-                    path
-                );
+                bail!("File {path} has different lengths in full and minimal ISOs");
             }
             entries.push(TableEntry {
                 minimal: minimal_entry.address,


### PR DESCRIPTION
Just a drive by commit; I was looking at the code and I think inline format is nicer.