### PR TITLE
workflows: update actions to current major versions

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install packages
         run: dnf install -y git make mock
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # fetch tags for versioning
         with:
           fetch-depth: 0
@@ -39,7 +39,7 @@ jobs:
           mock --rebuild rpms/*.src.rpm
           find /var/lib/mock -wholename '*/result/*.rpm' | xargs mv -t rpms
       - name: Archive RPMs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: rpms
           path: rpms/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
           - s390x
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up environment
         run: .github/workflows/env-setup
         shell: bash
@@ -47,7 +47,7 @@ jobs:
           TOOLCHAIN: stable
       - name: Cache build artifacts
         if: ${{ matrix.arch == 's390x' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: target/debug
           key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
@@ -87,7 +87,7 @@ jobs:
           - s390x
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Detect crate MSRV
         shell: bash
         run: |
@@ -103,7 +103,7 @@ jobs:
           TOOLCHAIN: ${{ env.MSRV }}
       - name: Cache build artifacts
         if: ${{ matrix.arch == 's390x' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: target/debug
           key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
@@ -143,7 +143,7 @@ jobs:
           - s390x
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up environment
         run: .github/workflows/env-setup
         shell: bash
@@ -153,7 +153,7 @@ jobs:
           COMPONENTS: rustfmt,clippy
       - name: Cache build artifacts
         if: ${{ matrix.arch == 's390x' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: target/debug
           key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}-lints
@@ -189,7 +189,7 @@ jobs:
           - x86_64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up environment
         run: .github/workflows/env-setup
         shell: bash
@@ -198,7 +198,7 @@ jobs:
           TOOLCHAIN: ${{ matrix.channel }}
       - name: Cache build artifacts
         if: ${{ matrix.arch == 's390x' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: target/debug
           key: deps-${{ runner.os }}-${{ matrix.arch }}-${{ env.INSTALLED_TOOLCHAIN }}
@@ -231,7 +231,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up environment
         run: .github/workflows/env-setup
         shell: bash


### PR DESCRIPTION
Fixes [deprecation warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for Node.js 12.