### PR TITLE
Revert "workflows: temporarily enable updates-testing repo for RPM test"

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir rpms
           make -f .copr/Makefile srpm outdir=rpms
-          mock --enablerepo updates-testing --rebuild rpms/*.src.rpm
+          mock --rebuild rpms/*.src.rpm
           find /var/lib/mock -wholename '*/result/*.rpm' | xargs mv -t rpms
       - name: Archive RPMs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
We can stop using `updates-testing` now that nmstate 2.2.3 is stable in Fedora 37.