### PR TITLE
blockdev: use `-p` when calling `blkid`

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,8 @@ Minor changes:
 
 Internal changes:
 
+- verify-unique-fs-label: Use `-p` when calling `blkid` to avoid stale cache
+
 Packaging changes:
 
 - Require `mbrman` ≥ 0.5.0
@@ -107,7 +109,7 @@ Minor changes:
 Internal changes:
 
 - bind-boot: Fix EFI vendor directory detection
-- verify-unique-fs-label: use `blkid` instead of `lsblk` to make filesystem label querying more reliable
+- verify-unique-fs-label: Use `blkid` instead of `lsblk` to make filesystem label querying more reliable
 - Delete legacy aliases for `osmet` and `minimal-iso` pack commands used by coreos-assembler
 
 Packaging changes:


### PR DESCRIPTION
By default, `blkid` will return cached data, which we don't want because
it might be stale. We need to use`-p` to make sure it directly probes
the block devices and bypasses the cache.

With `-p`, `blkid` requires passing the devices directly. Call it once
to gather the list of devices (we trust the cache enough for this) and
then again with `-p`.

We originally used `lsblk` here which uses the udev database, but this
was changed in https://github.com/coreos/coreos-installer/pull/813
because it failed to return the filesystem label in some instances. It
might be worth revisiting this at some point and find out if we were
just missing a `udevadm settle` somewhere.

See also: https://github.com/coreos/fedora-coreos-config/pull/2181#issuecomment-1397386896

