### PR TITLE
cargo: bump MSRV to 1.66.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "coreos-installer"
 repository = "https://github.com/coreos/coreos-installer"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.66.0"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/Dockerfile"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "Installer for Fedora CoreOS and RHEL CoreOS"
@@ -31,7 +31,7 @@ all-features = true
 [features]
 # rdcore is only useful inside the initrd of a CoreOS system
 rdcore = []
-docgen = ["clap_mangen"]
+docgen = ["dep:clap_mangen"]
 
 [lib]
 name = "libcoreinst"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,7 @@ Internal changes:
 
 Packaging changes:
 
+- Require Rust ≥ 1.66.0
 - Require `mbrman` ≥ 0.5.0
 - Require `nmstate` ≥ 2.2.3
 - Update container to Fedora 37


### PR DESCRIPTION
We no longer need to support older Rust versions.

Use the new `dep:` syntax to avoid creating an implicit `clap_mangen` feature.