### PR TITLE
docs/release-notes: note support for Ignition spec 3.4.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@ Major changes:
 
 Minor changes:
 
+- customize: Support Ignition config spec 3.4.0
 - customize: Avoid disabling ISO autologin when only changing live kargs
 - install: Avoid osmet performance regression in debug builds on Rust 1.64+
 - install: Avoid network fetch timeout when low-level formatting ECKD DASD


### PR DESCRIPTION
#1117 added support but it wasn't noted at the time.