### PR TITLE
ci: migrate to new kolaTestIso()

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -33,17 +33,7 @@ cosaPod(buildroot: true, runAsUser: 0) {
     stage("Test ISO") {
         // No need to run the iso-live-login/iso-as-disk scenarios
         kolaTestIso(
-            scenarios: "pxe-install,pxe-offline-install,iso-install,iso-offline-install,miniso-install",
-            scenarios4k: "iso-install,iso-offline-install",
-            skipUEFI: true
-        )
-        // Only test ISO because kola testiso doesn't support NM keyfiles
-        // for PXE
-        kolaTestIso(
-            scenarios: "iso-install",
-            extraArgs: "--add-nm-keyfile",
-            skipMetal4k: true,
-            skipMultipath: true,
+            extraArgs: "--denylist-test iso-as-disk.* --denylist-test iso-live-login.*",
             skipUEFI: true
         )
     }


### PR DESCRIPTION
The new `kola testiso` code will test NM keyfiles by default, so there's no need to do a separate run anymore.

While we're here, just accept the new default list of tests from `kola testiso` by only denylisting the `iso-as-disk` and `iso-live-login` tests and otherwise not overriding the tests to run.

This will run more tests than before. We'll likely cut down tests we consider redundant soon, but that should be transparent to this code.