### PR TITLE
ci: enable UEFI tests to get 4Kn tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -33,8 +33,7 @@ cosaPod(buildroot: true, runAsUser: 0) {
     stage("Test ISO") {
         // No need to run the iso-live-login/iso-as-disk scenarios
         kolaTestIso(
-            extraArgs: "--denylist-test iso-as-disk.* --denylist-test iso-live-login.*",
-            skipUEFI: true
+            extraArgs: "--denylist-test iso-as-disk.* --denylist-test iso-live-login.*"
         )
     }
     stage("Image tests") {


### PR DESCRIPTION
Previously, there was a separate `skipMetal4k` flag that governed 4Kn tests, but now those are gated by `skipUEFI`.

Fixes #1120.