### PR TITLE
live: warn when `pxe customize` output requires Ignition kargs

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ Minor changes:
 
 - customize: Support Ignition config spec 3.4.0
 - customize: Avoid disabling ISO autologin when only changing live kargs
+- customize: Warn when customized PXE image requires Ignition kargs
 - install: Avoid osmet performance regression in debug builds on Rust 1.64+
 - install: Avoid network fetch timeout when low-level formatting ECKD DASD
 

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -432,6 +432,11 @@ pub fn pxe_customize(config: PxeCustomizeConfig) -> Result<()> {
 
     let live = LiveInitrd::from_common(&config.common, features)?;
     let initrd = live.into_initrd()?;
+    if initrd.get(INITRD_IGNITION_PATH).is_some() {
+        eprintln!(
+            "PXE configuration must include kernel arguments:\n\tignition.firstboot ignition.platform.id=metal"
+        );
+    }
 
     // append customizations to output
     let do_write = |writer: &mut dyn Write| -> Result<()> {


### PR DESCRIPTION
When installing with `coreos.inst` kargs, Ignition kargs are not normally used.  However, when a customized PXE initrd embeds a live Ignition config, Ignition kargs are required.  Warn the user in this case.

For https://github.com/coreos/fedora-coreos-tracker/issues/1426.