### PR TITLE
tests/images: only test installed binary if env var set

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -14,6 +14,8 @@ cosaPod(buildroot: true, runAsUser: 0) {
 
     unstash name: 'build'
 
+    // Delete the OS copy of coreos-installer so we don't test it by mistake
+    shwrap("rm /usr/bin/coreos-installer")
     // Make sure cosa is using the binary we just built.
     shwrap("rsync -rlv install/usr/ /usr/")
 

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -37,6 +37,6 @@ cosaPod(buildroot: true, runAsUser: 0) {
         )
     }
     stage("Image tests") {
-        shwrap("tests/images.sh /srv/coreos/builds/latest/x86_64")
+        shwrap("COREOS_INSTALLER_TEST_INSTALLED_BINARY=1 tests/images.sh /srv/coreos/builds/latest/x86_64")
     }
 }

--- a/tests/images.sh
+++ b/tests/images.sh
@@ -3,8 +3,20 @@
 set -euo pipefail
 
 export PATH
-if [[ -d "$(realpath "$(dirname "$0")/../target")" ]]; then
-    PATH="$(realpath "$(dirname "$0")/../target/${PROFILE:-debug}"):$PATH"
+bindir="$(realpath -m "$(dirname "$0")/../target/${PROFILE:-debug}")"
+if [[ -x "$bindir/coreos-installer" ]]; then
+    PATH="$bindir:$PATH"
+elif command -v coreos-installer >/dev/null; then
+    echo "$bindir/coreos-installer not found"
+    if [[ -n "${COREOS_INSTALLER_TEST_INSTALLED_BINARY:-}" ]]; then
+        echo "COREOS_INSTALLER_TEST_INSTALLED_BINARY set; testing $(command -v coreos-installer)"
+    else
+        echo "Found $(command -v coreos-installer) but COREOS_INSTALLER_TEST_INSTALLED_BINARY not set; aborting"
+        exit 1
+    fi
+else
+    echo "coreos-installer not found.  Do you need to set PROFILE?"
+    exit 1
 fi
 fixturesdir="$(realpath "$(dirname "$0")"/../fixtures)"
 


### PR DESCRIPTION
In general, we want to test the binary built in the source tree and raise an error if that binary is missing.  Historically we failed to notice this case and fell back to testing the installed binary, if present. CoreOS CI took advantage of this.

Fail if the coreos-installer binary isn't in the source tree, unless `COREOS_INSTALLER_TEST_INSTALLED_BINARY` is set, in which case print a warning and continue.

Also have CI delete the OS copy of coreos-installer before overwriting it with rsync.  This ensures we don't test the wrong thing if the OS copy is elsewhere in `PATH`, or if coreos-installer is missing from the install tree.

Followup to https://github.com/coreos/coreos-installer/pull/999#discussion_r1004688601.