### PR TITLE
cargo: require ignition-config 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ glob = "^0.3"
 # disable default-enabled cli in gptman 0.x
 gptman = { version = ">= 0.7, < 2", default-features = false }
 hex = "^0.4"
-ignition-config = ">= 0.2, < 0.4"
+ignition-config = ">= 0.3, < 0.4"
 lazy_static = "^1.4"
 libc = "^0.2"
 nix = ">= 0.24, < 0.27"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,7 @@ Packaging changes:
 
 - Require Rust ≥ 1.66.0
 - Require `base64` ≥ 0.21.0
+- Require `ignition-config` ≥ 0.3.0
 - Require `mbrman` ≥ 0.5.0
 - Require `nmstate` ≥ 2.2.3
 - Update container to Fedora 37


### PR DESCRIPTION
ignition-config 0.2 doesn't support Ignition config spec 3.4.0. coreos-installer itself doesn't care, but it'd be confusing if some coreos-installer 0.17.0 binaries supported 3.4.0 configs and some didn't. Explicitly require ignition-config 0.3 to warn downstreams.