### PR TITLE
Revert "osmet: avoid install performance regression in debug mode on Rust 1.64+"

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,7 +16,6 @@ Minor changes:
 - customize: Support Ignition config spec 3.4.0
 - customize: Avoid disabling ISO autologin when only changing live kargs
 - customize: Warn when customized PXE image requires Ignition kargs
-- install: Avoid osmet performance regression in debug builds on Rust 1.64+
 - install: Avoid network fetch timeout when low-level formatting ECKD DASD
 
 Internal changes:


### PR DESCRIPTION
The Rust regression was fixed by https://github.com/rust-lang/rust/pull/102760, which is in Rust 1.66+. Our MSRV is 1.66.0, so we can drop this.

This reverts commit 1ccb9b091afddca29fe64135882a48b7295e6ab8.