### PR TITLE
docs: Use upstream theme & update to 0.4.1

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@ kramdown:
     ndash: "--"
     mdash: "---"
 
-remote_theme: coreos/just-the-docs
+remote_theme: just-the-docs/just-the-docs@v0.4.1
 plugins:
   - jekyll-remote-theme
 


### PR DESCRIPTION
Use a fixed tag for the theme so that we can directly pull it from
upstream and skip vendoring the theme in the coreos org.