### PR TITLE
cmdline: clarify description of `--insecure`

### DIFF
--- a/data/example-config.yaml
+++ b/data/example-config.yaml
@@ -33,7 +33,7 @@ save-partlabel: [glob, glob]
 save-partindex: [id-or-range, id-or-range]
 # Force offline installation
 offline: true
-# Skip signature verification
+# Allow unsigned image
 insecure: true
 # Allow Ignition URL without HTTPS or hash
 insecure-ignition: true

--- a/docs/cmd/download.md
+++ b/docs/cmd/download.md
@@ -19,7 +19,7 @@ OPTIONS:
     -u, --image-url <URL>          Manually specify the image URL
     -C, --directory <path>         Destination directory [default: .]
     -d, --decompress               Decompress image and don't save signature
-        --insecure                 Skip signature verification
+        --insecure                 Allow unsigned image
         --stream-base-url <URL>    Base URL for Fedora CoreOS stream metadata
         --fetch-retries <N>        Fetch retries, or "infinite" [default: 0]
     -h, --help                     Print help information

--- a/docs/cmd/install.md
+++ b/docs/cmd/install.md
@@ -111,7 +111,7 @@ ADVANCED OPTIONS:
             Force offline installation
 
         --insecure
-            Skip signature verification
+            Allow unsigned image
 
         --insecure-ignition
             Allow Ignition URL without HTTPS or hash

--- a/docs/customizing-install.md
+++ b/docs/customizing-install.md
@@ -158,7 +158,7 @@ save-partlabel: [glob, glob]
 save-partindex: [id-or-range, id-or-range]
 # Force offline installation
 offline: true
-# Skip signature verification
+# Allow unsigned image
 insecure: true
 # Allow Ignition URL without HTTPS or hash
 insecure-ignition: true

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ Major changes:
 
 Minor changes:
 
+- download/install: Clarify help text for `--insecure`
 
 Internal changes:
 

--- a/man/coreos-installer-download.8
+++ b/man/coreos-installer-download.8
@@ -37,7 +37,7 @@ Destination directory
 Decompress image and don\*(Aqt save signature
 .TP
 \fB\-\-insecure\fR
-Skip signature verification
+Allow unsigned image
 .TP
 \fB\-\-stream\-base\-url\fR=\fIURL\fR
 Base URL for Fedora CoreOS stream metadata

--- a/man/coreos-installer-install.8
+++ b/man/coreos-installer-install.8
@@ -93,7 +93,7 @@ Save partitions with this number or range
 Force offline installation
 .TP
 \fB\-\-insecure\fR
-Skip signature verification
+Allow unsigned image
 .TP
 \fB\-\-insecure\-ignition\fR
 Allow Ignition URL without HTTPS or hash

--- a/src/cmdline/install.rs
+++ b/src/cmdline/install.rs
@@ -192,7 +192,7 @@ pub struct InstallConfig {
     #[serde(skip_serializing_if = "is_default")]
     #[clap(long, help_heading = ADVANCED)]
     pub offline: bool,
-    /// Skip signature verification
+    /// Allow unsigned image
     #[serde(skip_serializing_if = "is_default")]
     #[clap(long, help_heading = ADVANCED)]
     pub insecure: bool,

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -229,7 +229,7 @@ pub struct DownloadConfig {
     /// Decompress image and don't save signature
     #[clap(short, long)]
     pub decompress: bool,
-    /// Skip signature verification
+    /// Allow unsigned image
     #[clap(long)]
     pub insecure: bool,
     /// Base URL for Fedora CoreOS stream metadata


### PR DESCRIPTION
It permits the signature to be missing, but does not permit the signature to be invalid or to be made with an unknown key.

Fixes https://github.com/coreos/coreos-installer/issues/1141.