### PR TITLE
systemd/coreos-installer-generator: Properly read cmdline

### DIFF
--- a/systemd/coreos-installer-generator
+++ b/systemd/coreos-installer-generator
@@ -10,7 +10,7 @@ exec 1>/dev/kmsg; exec 2>&1
 
 UNIT_DIR="${1:-/tmp}"
 
-cmdline=( $(</proc/cmdline) )
+IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
 karg() {
     local name="$1" value="$2"
     for arg in "${cmdline[@]}"; do


### PR DESCRIPTION
Fix ShellCheck warning:
```
In ./systemd/coreos-installer-generator line 13:
cmdline=( $(</proc/cmdline) )
          ^---------------^ SC2207 (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).
```

See: https://github.com/coreos/coreos-installer/pull/999
See: https://bugzilla.redhat.com/show_bug.cgi?id=1989551