### PR TITLE
workflows: run clippy on tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,13 +63,13 @@ jobs:
           git-fetch-with-cli = true
           EOF
       - name: cargo build
-        run: cargo build
+        run: cargo build --all-targets
       - name: cargo test
-        run: cargo test
+        run: cargo test --all-targets
       - name: cargo build (rdcore)
-        run: cargo build --features rdcore
+        run: cargo build --all-targets --features rdcore
       - name: cargo test (rdcore)
-        run: cargo test --features rdcore
+        run: cargo test --all-targets --features rdcore
       - name: Image tests
         if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh
@@ -120,13 +120,13 @@ jobs:
           git-fetch-with-cli = true
           EOF
       - name: cargo build
-        run: cargo build
+        run: cargo build --all-targets
       - name: cargo test
-        run: cargo test
+        run: cargo test --all-targets
       - name: cargo build (rdcore)
-        run: cargo build --features rdcore
+        run: cargo build --all-targets --features rdcore
       - name: cargo test (rdcore)
-        run: cargo test --features rdcore
+        run: cargo test --all-targets --features rdcore
       - name: Image tests
         if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh
@@ -173,9 +173,9 @@ jobs:
       - name: cargo fmt (check)
         run: cargo fmt -- --check -l
       - name: cargo clippy (warnings)
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
       - name: cargo clippy (rdcore, warnings)
-        run: cargo clippy --features rdcore -- -D warnings
+        run: cargo clippy --all-targets --features rdcore -- -D warnings
   tests-other-channels:
     name: "Tests, unstable toolchain"
     runs-on: ubuntu-latest
@@ -215,13 +215,13 @@ jobs:
           git-fetch-with-cli = true
           EOF
       - name: cargo build
-        run: cargo build
+        run: cargo build --all-targets
       - name: cargo test
-        run: cargo test
+        run: cargo test --all-targets
       - name: cargo build (rdcore)
-        run: cargo build --features rdcore
+        run: cargo build --all-targets --features rdcore
       - name: cargo test (rdcore)
-        run: cargo test --features rdcore
+        run: cargo test --all-targets --features rdcore
       - name: Image tests
         if: ${{ matrix.arch == 'x86_64' }}
         run: tests/images.sh

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -1725,7 +1725,7 @@ mod tests {
         guid
     }
 
-    fn assert_partitions_eq(expected: &Vec<(u32, GPTPartitionEntry)>, found: &GPT, message: &str) {
+    fn assert_partitions_eq(expected: &[(u32, GPTPartitionEntry)], found: &GPT, message: &str) {
         assert_eq!(
             expected
                 .iter()

--- a/src/download.rs
+++ b/src/download.rs
@@ -687,8 +687,8 @@ mod tests {
         let mb: usize = 1024 * 1024;
 
         let mut data = vec![0u8; len];
-        for i in 0..data.len() {
-            data[i] = (i % 256) as u8;
+        for (i, el) in data.iter_mut().enumerate() {
+            *el = (i % 256) as u8;
         }
 
         // no saved partitions

--- a/src/io/peek.rs
+++ b/src/io/peek.rs
@@ -109,8 +109,7 @@ mod tests {
     }
 
     fn read_bytes<R: Read>(peek: &mut PeekReader<R>, amt: usize) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(amt);
-        buf.resize(amt, 0);
+        let mut buf = vec![0; amt];
         let amt = peek.read(&mut buf).unwrap();
         buf.truncate(amt);
         buf


### PR DESCRIPTION
By default, `cargo clippy` does not check tests.  Run it with `--all-targets` to fix this.  For consistency, add the same option to `cargo build` and `cargo test`.