### PR TITLE
rdcore: Juggle physical root versus deployment root

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,19 @@ nav_order: 8
 
 ## Upcoming coreos-installer 0.19.0 (unreleased)
 
+Major changes:
+
+
+Minor changes:
+
+
+Internal changes:
+
+- rootmap/bind-boot: Support root devices using composefs
+
+Packaging changes:
+
+
 
 ## coreos-installer 0.18.0 (2023-08-24)
 

--- a/src/bin/rdcore/main.rs
+++ b/src/bin/rdcore/main.rs
@@ -18,7 +18,7 @@ mod rootmap;
 mod stream_hash;
 mod unique_fs;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 
 use crate::cmdline::*;
@@ -26,8 +26,8 @@ use crate::cmdline::*;
 fn main() -> Result<()> {
     match Cmd::parse() {
         Cmd::Kargs(c) => kargs::kargs(c),
-        Cmd::Rootmap(c) => rootmap::rootmap(c),
-        Cmd::BindBoot(c) => rootmap::bind_boot(c),
+        Cmd::Rootmap(c) => rootmap::rootmap(c).context("Configuring rootmap"),
+        Cmd::BindBoot(c) => rootmap::bind_boot(c).context("Failed to bind boot"),
         Cmd::StreamHash(c) => stream_hash::stream_hash(c),
         Cmd::VerifyUniqueFsLabel(c) => unique_fs::verify_unique_fs(c),
         #[cfg(target_arch = "s390x")]


### PR DESCRIPTION

rdcore: Juggle physical root versus deployment root

This is prep for supporting composefs, where the physical root
is distinct from the deployment root.  Specifically for the LUKS
case, we can find `/etc/crypttab` only in the deployment root.

Otherwise, we suffix the passed path (usually `/sysroot`) that
was mounted in the initramfs with `/sysroot` to find the physical
root.

xref https://github.com/ostreedev/ostree/issues/2867
