### PR TITLE
install: verify that Ignition config is valid JSON

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ Major changes:
 
 Minor changes:
 
+- install: Verify that Ignition config is valid JSON
 - install: Add long help for several options
 - download/install: Clarify help text for `--insecure`
 


### PR DESCRIPTION
If the user accidentally specifies a URL to an HTML page instead of an Ignition config, detect that before we install.

Fixes https://github.com/coreos/coreos-installer/issues/1231.