### PR TITLE
WIP: s390x: run chreipl only on zVM

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ Minor changes:
 - install: Verify that Ignition config is valid JSON
 - install: Add long help for several options
 - download/install: Clarify help text for `--insecure`
+- install: Run 'chreipl' only on s390x zVM
 
 Internal changes:
 

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -14,9 +14,9 @@
 
 use crate::blockdev::Mount;
 use crate::io::{visit_bls_entry, visit_bls_entry_options, Initrd, KargsEditor};
-use crate::runcmd;
 use crate::s390x::ZiplSecexMode;
 use crate::util::cmd_output;
+use crate::{runcmd, runcmd_output};
 use anyhow::{anyhow, Context, Result};
 use nix::mount::MsFlags;
 use regex::Regex;
@@ -28,8 +28,11 @@ use tempfile::{Builder, NamedTempFile};
 
 /// Sets the boot device to `dev` using `chreipl`.
 pub fn chreipl<P: AsRef<Path>>(dev: P) -> Result<()> {
-    eprintln!("Updating re-IPL device");
-    runcmd!("chreipl", dev.as_ref())?;
+    let vm = runcmd_output!("systemd-detect-virt")?;
+    if vm == "zvm" {
+        eprintln!("Updating re-IPL device");
+        runcmd!("chreipl", dev.as_ref())?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
There is no need to re-IPL disk under QEMU/KVM