### PR TITLE
verify-unique-fs-label: Run `blkid` with a clean cache to avoid stale devices

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,7 @@ Minor changes:
 
 Internal changes:
 
+- verify-unique-fs-label: Run `blkid` with a clean cache to avoid stale devices
 
 Packaging changes:
 

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -885,11 +885,18 @@ fn split_blkid_line(line: &str) -> HashMap<String, String> {
 }
 
 fn blkid() -> Result<Vec<HashMap<String, String>>> {
-    // Run once to gather the list of devices, and then run again with -p so
-    // that we don't rely on blkid cache:
+    // Run blkid with a clean cache to avoid collecting old devices which no
+    // longer exist.
+    // https://github.com/coreos/coreos-installer/pull/1288#discussion_r1312008111
+
+    // Run once to gather the list of devices, which we need to specify for
+    // the blkid -p below, which we use to probe the devices to not rely on
+    // the blkid cache:
     // https://github.com/coreos/fedora-coreos-config/pull/2181#issuecomment-1397386896
     let devices = {
         let mut cmd = Command::new("blkid");
+        cmd.arg("--cache-file");
+        cmd.arg("/dev/null");
         cmd.arg("-o");
         cmd.arg("device");
         cmd_output(&mut cmd)?


### PR DESCRIPTION
Boot VM failed with following logs, the reproduce rate is 2/4.
```
systemd[1]: Starting CoreOS Ensure Unique Boot Filesystem...
rdcore[1252]: blkid: error: /dev/sr0: No such file or directory
rdcore[1252]: Error: "blkid" "-p" "/dev/sdb1" "/dev/sr0"
"/dev/sda4" "/dev/sda2" "/dev/sda3" "/dev/sda1" failed with exit
status: 2
systemd[1]: coreos-ignition-unique-boot.service: Main process
exited, code=exited, status=1/FAILURE
coreos-ignition-unique-boot.service: Failed with result 'exit-code'.
Failed to start CoreOS Ensure Unique Boot Filesystem.
systemd[1]: coreos-ignition-unique-boot.service: Triggering
OnFailure= dependencies.
```
Seems `blkid` collecting old devices from cache which no longer
exist, should run with a clean cache before gathering the list of
devices.

Fixes https://issues.redhat.com/browse/OCPBUGS-17643

---

Do testing with this PR, hit the issue occasionally with low rate,
seems can not fix the issue totally.
Also need https://github.com/openshift/os/pull/1350