### PR TITLE
packit: add initial support

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,40 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+actions:
+    changelog-entry:
+        - "New upstream release"
+    post-upstream-clone:
+        - "wget https://src.fedoraproject.org/rpms/rust-coreos-installer/raw/rawhide/f/rust-coreos-installer.spec -O rust-coreos-installer.spec"
+
+specfile_path: rust-coreos-installer.spec
+
+upstream_tag_template: v{version}
+
+# add or remove files that should be synced
+files_to_sync:
+    - rust-coreos-installer.spec
+    - .packit.yaml
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: coreos-installer
+# downstream (Fedora) RPM package name
+downstream_package_name: rust-coreos-installer
+
+jobs: 
+
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - fedora-rawhide
+    - fedora-stable
+
+- job: koji_build
+  trigger: commit
+  dist_git_branches:
+    - fedora-rawhide
+    - fedora-stable
+
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-stable


### PR DESCRIPTION
This config is setup to target downstream job automation in pagure.

This change is dependent on https://src.fedoraproject.org/rpms/rust-coreos-installer/pull-request/57 landing, as it takes out the gymnastics associated with patch management on a normalized cargo.toml.


As it's difficult to test Packit locally, we will need to see the results as an experiment and at release time, capture any issues, and resolve / iterate. 