### PR TITLE
packit: fix changelog-entry

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,7 +2,7 @@
 # https://packit.dev/docs/configuration/
 actions:
     changelog-entry:
-        - "New upstream release"
+        - bash -c 'echo "- New upstream release"'
     post-upstream-clone:
         - "wget https://src.fedoraproject.org/rpms/rust-coreos-installer/raw/rawhide/f/rust-coreos-installer.spec -O rust-coreos-installer.spec"
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,7 @@ Internal changes:
 
 Packaging changes:
 
+- Fix Packit changelog entry generation
 
 
 ## coreos-installer 0.19.0 (2023-12-11)
@@ -28,6 +29,10 @@ Major changes:
 Internal changes:
 
 - rootmap/bind-boot: Support root devices using composefs
+
+Packaging changes:
+
+- Add Packit support for Fedora packaging
 
 
 ## coreos-installer 0.18.0 (2023-08-24)


### PR DESCRIPTION
The `changelog-entry` field needs a value which creates an output of the entry you want in your changelog.

fixes #1357