### PR TITLE
install: support grub2/30_console.cfg for console replacement

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,7 @@ nav_order: 8
 
 Major changes:
 
+- Support alternative grub2/30_console.cfg location for grub console configuration
 
 Minor changes:
 


### PR DESCRIPTION
Upstream we are starting to use grub configs that are partially baked into bootupd [1] and partially baked into the image via the OS vendor (in our case a grub2/30_console.cfg file [2]). Let's look first to see if grub2/30_console.cfg exists when trying to write new console settings before falling back to grub2/grub.cfg.

[1] https://github.com/coreos/bootupd/pull/543
[2] https://github.com/coreos/fedora-coreos-config/pull/2769