### PR TITLE
s390x: call zipl using exact kernel, ramdisk and cmdline

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ Minor changes:
 
 Internal changes:
 
+- zipl: Directly pass kernel, initrd and kargs instead of BLS entry
 
 Packaging changes:
 


### PR DESCRIPTION
There is no need to copy `boot/loader/entries` folder and to create temporary `zipl.conf` , instead we could parse bls config and tell `zipl` which image and disk to use. This also fixes an issue when images comes with `bootprefix`.

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1667