### PR TITLE
install: use console.cfg rather than 30_console.cfg

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,7 @@ nav_order: 8
 Major changes:
 
 - Add Fedora 41 signing key; drop Fedora 38 signing key
+- Switch alternative grub console config location to grub2/console.cfg
 
 Minor changes:
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -636,8 +636,8 @@ fn write_console(mountpoint: &Path, platform: Option<&str>, consoles: &[Console]
 
     // set grub commands
     if grub_commands != metal_spec.grub_commands {
-        // prefer the new grub2/30_console.cfg, but fallback to grub2/grub.cfg
-        let mut name = "grub2/30_console.cfg";
+        // prefer the new grub2/console.cfg, but fallback to grub2/grub.cfg
+        let mut name = "grub2/console.cfg";
         let mut path = mountpoint.join(name);
         if !path.exists() {
             name = "grub2/grub.cfg";


### PR DESCRIPTION
In https://github.com/coreos/fedora-coreos-tracker/issues/1671 we decided to use a non-static grub file for console configuration named console.cfg.