### PR TITLE
packit: update dist_git_branches to target fedora-all

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,16 +25,14 @@ jobs:
 - job: propose_downstream
   trigger: release
   dist_git_branches:
-    - fedora-rawhide
-    - fedora-stable
+    - fedora-all
 
 - job: koji_build
   trigger: commit
   dist_git_branches:
-    - fedora-rawhide
-    - fedora-stable
+    - fedora-all
 
 - job: bodhi_update
   trigger: commit
   dist_git_branches:
-    - fedora-stable
+    - fedora-all

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,8 @@ Internal changes:
 
 Packaging changes:
 
+- Update packit's downstream targets to be `fedora-all`
+
 
 ## coreos-installer 0.21.0 (2024-02-22)
 


### PR DESCRIPTION
After the latest release we noticed that f40 was not included, this is because its not stable yet. which means that it would be ignored by packit.