### PR TITLE
cmdline: Provide dest_device when using iso/pxe customize

### DIFF
--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -260,9 +260,9 @@ pub struct CommonCustomizeConfig {
     /// Install destination device
     ///
     /// Automatically run installer, installing to the specified destination
-    /// device.  The resulting boot media will overwrite the destination
-    /// device without confirmation.
-    #[arg(long, value_name = "path")]
+    /// device that the user must provide.  The resulting boot media will
+    /// overwrite the destination device without confirmation.
+    #[arg(long, value_name = "path", required_unless_present = "installer_config")]
     pub dest_device: Option<String>,
     /// Kernel and bootloader console for dest
     ///


### PR DESCRIPTION
During the execution of coreos-installer install, users are required to provide dest-device through parameters or config file. However, when executing iso/pxe customize, it is not necessary to provide dest-device to successfully execute customize. This will obviously result in errors when using a customized image for installation. Some previous discussions can be found at: 

https://github.com/coreos/coreos-installer/issues/1469

This modification unifies the behavior of the customize command and the install command during the image install phase, requiring users to provide dest-device through parameters or config files.