### PR TITLE
packit: downstream_package_name is not inherited by packages

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,12 +9,11 @@ files_to_sync:
 
 # name in upstream package repository or registry (e.g. in PyPI)
 upstream_package_name: coreos-installer
-# downstream (Fedora) RPM package name
-downstream_package_name: rust-coreos-installer
 
 packages:
   coreos-installer-fedora:
     specfile_path: rust-coreos-installer.spec
+    downstream_package_name: rust-coreos-installer
     actions:
       post-upstream-clone:
         - wget https://src.fedoraproject.org/rpms/rust-coreos-installer/raw/rawhide/f/rust-coreos-installer.spec
@@ -23,6 +22,7 @@ packages:
   coreos-installer-centos:
     pkg_tool: centpkg
     specfile_path: rust-coreos-installer.spec
+    downstream_package_name: rust-coreos-installer
     actions:
       post-upstream-clone:
         - wget https://gitlab.com/redhat/centos-stream/rpms/rust-coreos-installer/-/raw/c9s/rust-coreos-installer.spec

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,8 @@ Internal changes:
 
 Packaging changes:
 
+- add downstream_package_name for each package in packit.yaml
+
 
 ## coreos-installer 0.22.0 (2024-07-23)
 


### PR DESCRIPTION
Declare downstream_package_name for each package; i.e fedora and centos.