### PR TITLE
Use  blkid instead of lsblk to get disk info when udev is not present

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ Minor changes:
 
 Internal changes:
 
+- osmet: Use blkid to get partition information if udev is unavailable
 
 Packaging changes:
 


### PR DESCRIPTION
 - OSBuild does not allow udev rules in loop devices, for this reason can not rely on labels on the partitions to create the osmet image, we
need to skip this part and pass only the fstype
for the it to be mounted.