### PR TITLE
packit: drop CentOS packaging

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,15 +19,6 @@ packages:
         - wget https://src.fedoraproject.org/rpms/rust-coreos-installer/raw/rawhide/f/rust-coreos-installer.spec
       changelog-entry:
         - bash -c 'echo "- New upstream release"'
-  coreos-installer-centos:
-    pkg_tool: centpkg
-    specfile_path: rust-coreos-installer.spec
-    downstream_package_name: rust-coreos-installer
-    actions:
-      post-upstream-clone:
-        - wget https://gitlab.com/redhat/centos-stream/rpms/rust-coreos-installer/-/raw/c9s/rust-coreos-installer.spec
-      changelog-entry:
-        - bash -c 'echo "- New upstream release"'
 
 jobs: 
 
@@ -48,10 +39,3 @@ jobs:
   packages: [coreos-installer-fedora]
   dist_git_branches:
     - fedora-all
-
-- job: propose_downstream
-  trigger: release
-  packages: [coreos-installer-centos]
-  dist_git_branches:
-    - c9s
-    - c10s

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,13 +18,14 @@ Internal changes:
 
 Packaging changes:
 
+- Drop Packit support for c9s packaging
+
 
 ## coreos-installer 0.22.1 (2024-07-24)
 
 Packaging changes:
 
 - add downstream_package_name for each package in packit.yaml
-
 
 ## coreos-installer 0.22.0 (2024-07-23)
 


### PR DESCRIPTION
While releasing coreos-installer, we found that the current CentOS packaging did not introduce enough benefit to outweigh the process change required to keep other repos consistent. We will revisit once additional support is added for running builds/tests/ticketing.

Ref: https://github.com/packit/packit-service/issues/2106