### PR TITLE
src/io/hash: update deprecated funcion, nix

### DIFF
--- a/src/io/hash.rs
+++ b/src/io/hash.rs
@@ -158,7 +158,7 @@ impl Sha256Digest {
         if unsafe { libc::posix_fadvise(f.as_raw_fd(), 0, 0, libc::POSIX_FADV_SEQUENTIAL) } < 0 {
             eprintln!(
                 "posix_fadvise(SEQUENTIAL) failed (errno {}) -- ignoring...",
-                nix::errno::errno()
+                nix::errno()
             );
         }
 


### PR DESCRIPTION
See: https://github.com/coreos/coreos-installer/pull/1476
Ref: https://github.com/coreos/coreos-installer/pull/1476#issuecomment-2271526583