### PR TITLE
s390x: prepare for the upcoming 'pvimg' tool replacing 'genprotimg'

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,7 +13,7 @@ Minor changes:
 
 
 Internal changes:
-
+- s390x: Use options and logic compatible with both C-based `genprotimg` and Rust-based `pvimg`
 
 Packaging changes:
 

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -281,6 +281,13 @@ fn generate_sdboot(
 
     // finally, Secure Execution sd-boot image
     let sdboot = mountpoint.join("sdboot");
+
+    // C 'genprotimg' tool no longer exists and was replaced by symlink to Rust 'pvimg create',
+    // which by default doesn't overwrite the output image.
+    // For backward compatibility let's silently remove the 'sdboot'.
+    let _ = std::fs::remove_file(&sdboot);
+
+    // FIXME: in F42/el10 switch to 'pvimg create' with '--overwrite' flag.
     let mut cmd = Command::new("genprotimg");
     cmd.arg("--verbose")
         .arg("--image")

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -282,15 +282,15 @@ fn generate_sdboot(
     // finally, Secure Execution sd-boot image
     let sdboot = mountpoint.join("sdboot");
     let mut cmd = Command::new("genprotimg");
-    cmd.arg("-V")
-        .arg("-i")
+    cmd.arg("--verbose")
+        .arg("--image")
         .arg(kernel)
-        .arg("-r")
+        .arg("--ramdisk")
         .arg(initrd)
-        .arg("-p")
+        .arg("--parmfile")
         .arg(cmdline.path())
         .arg("--no-verify")
-        .arg("-o")
+        .arg("--output")
         .arg(&sdboot);
     for k in hostkeys {
         cmd.arg("-k").arg(k);


### PR DESCRIPTION
Since s390-tools commit [f4cf4ae6ebb1](https://github.com/ibm-s390-linux/s390-tools/commit/195579cf0bcff320ed9ebe2cab6b59c9cc817f6e)  (Remove genprotimg-C and switch to genprotimg-Rust implementation) 
FCCOS/RHCOS may come with symlink to `pvimg create`. 
New `pvimg` made some cmdline options obsolete (`-V`) and by default doesn't overwrite the output image (`sdboot`), which leads to an issue https://github.com/openshift/os/issues/1731.

For now keep the call to `genprotomg`, even if it's symlink, but let's:
 - remove the `sdboot` before generating new one
 - use long cmdline options supported by both tool.
