### PR TITLE
download: format byte unit with 1 decimal place precision

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,9 +8,9 @@ nav_order: 8
 
 Major changes:
 
-
 Minor changes:
 
+- Restore formatting of progress reporting to pre 0.24.0 behavior.
 
 Internal changes:
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -456,9 +456,9 @@ impl<'a, R: Read> ProgressReader<'a, R> {
 
     /// Format a size in bytes.
     fn format_bytes(count: u64) -> String {
-        Byte::from_u64(count)
-            .get_appropriate_unit(byte_unit::UnitType::Binary)
-            .to_string()
+        let adjusted_byte = Byte::from_u64(count).get_appropriate_unit(byte_unit::UnitType::Binary);
+        // Get a string trimmed to 1 decimal place of precision
+        format!("{adjusted_byte:.1}")
     }
 }
 


### PR DESCRIPTION
Prior to v0.24.1 the output when processing a stream of disk image input the output would write with 1 decimal place of precision:

```
Read disk 118.2 MiB/2.6 GiB (4%)
Read disk 157.0 MiB/2.6 GiB (5%)
Read disk 300.1 MiB/2.6 GiB (11%)
Read disk 450.6 MiB/2.6 GiB (16%)
Read disk 515.2 MiB/2.6 GiB (19%)
```

After v0.24.1 it has many decimal places of precision:

```
Read disk 138.2265625 MiB/2.59765625 GiB (5%)
Read disk 265.6722106933594 MiB/2.59765625 GiB (9%)
Read disk 399.67578125 MiB/2.59765625 GiB (15%)
Read disk 519.40625 MiB/2.59765625 GiB (19%)
Read disk 597.5625 MiB/2.59765625 GiB (22%)
```

This is likely due to 68198d0. Let's get back the previous formatting.