### PR TITLE
OCPBUGS-56597: Fix multipath configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ maplit = "^1.0"
 # In CoreOS CI we test installation from a compressed image created with
 # `cosa compress --fast`.  This is unacceptably slow if the gunzip inner
 # loops are compiled unoptimized.
-[profile.dev.package.adler]
+[profile.dev.package.adler2]
 opt-level = 3
 [profile.dev.package.crc32fast]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ hex = "^0.4"
 ignition-config = ">= 0.3, < 0.6"
 lazy_static = "^1.4"
 libc = "^0.2"
-nix = { version = ">= 0.29, < 0.30", "default_features" = false, "features" = [ "dir", "ioctl", "mount", "process", "sched", "signal", "user"] }
+nix = { version = ">= 0.29, < 0.30", default-features = false, features = [ "dir", "ioctl", "mount", "process", "sched", "signal", "user"] }
 nmstate = { version = ">= 2.2.3, < 3", default-features = false, features = ["gen_conf"] }
 openssl = "^0.10"
 pipe = ">= 0.3, < 0.5"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,7 @@ Internal changes:
 - Use release profile for smaller binaries in CI testing
 - Support cryptsetup-2.8.0's UUIDs naming of dm-integrity devices
 - rootmap: Inject `root=/dev/disk/by-uuid/dm-mpath-$UUID` when on multipath
+- rootmap: Inject `mpath.wwid=$WWID` when on multipath
 
 Packaging changes:
 

--- a/src/bin/rdcore/rootmap.rs
+++ b/src/bin/rdcore/rootmap.rs
@@ -349,7 +349,7 @@ fn get_multipath_kargs(device: &Path) -> Result<Vec<String>> {
     let devices: HashMap<&str, &str> = mpathd_output
         .lines()
         .filter_map(|s| {
-            let mut parts = s.trim().split_whitespace();
+            let mut parts = s.split_whitespace();
             Some((parts.next()?, parts.next()?))
         })
         .collect();

--- a/src/install.rs
+++ b/src/install.rs
@@ -643,10 +643,10 @@ fn write_console(mountpoint: &Path, platform: Option<&str>, consoles: &[Console]
             name = "grub2/grub.cfg";
             path = mountpoint.join(name);
         }
-        let grub_cfg = fs::read_to_string(&path).with_context(|| format!("reading {}", name))?;
+        let grub_cfg = fs::read_to_string(&path).with_context(|| format!("reading {name}"))?;
         let new_grub_cfg = update_grub_cfg_console_settings(&grub_cfg, &grub_commands)
-            .with_context(|| format!("updating {}", name))?;
-        fs::write(&path, new_grub_cfg).with_context(|| format!("writing {}", name))?;
+            .with_context(|| format!("updating {name}"))?;
+        fs::write(&path, new_grub_cfg).with_context(|| format!("writing {name}"))?;
     }
     Ok(())
 }

--- a/src/io/initrd.rs
+++ b/src/io/initrd.rs
@@ -349,8 +349,8 @@ mod tests {
         assert_eq!(
             Initrd::from_reader(&*archive).unwrap().members,
             btreemap! {
-                "dir/hello".into() => std::iter::repeat(b'z').take(5000).collect(),
-                "dir/world".into() => std::iter::repeat(b'q').take(4500).collect(),
+                "dir/hello".into() => std::iter::repeat_n(b'z', 5000).collect(),
+                "dir/world".into() => std::iter::repeat_n(b'q', 4500).collect(),
             }
         );
     }

--- a/src/io/limit.rs
+++ b/src/io/limit.rs
@@ -42,10 +42,10 @@ impl<R: Read> Read for LimitReader<R> {
             // reached the limit; only error if we're not at EOF
             return match self.source.read(&mut buf[..1]) {
                 Ok(0) => Ok(0),
-                Ok(_) => Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("collision with {} at offset {}", self.conflict, self.length),
-                )),
+                Ok(_) => Err(io::Error::other(format!(
+                    "collision with {} at offset {}",
+                    self.conflict, self.length
+                ))),
                 Err(e) => Err(e),
             };
         }
@@ -83,10 +83,10 @@ impl<W: Write> Write for LimitWriter<W> {
         }
         let allowed = self.remaining.min(buf.len() as u64);
         if allowed == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("collision with {} at offset {}", self.conflict, self.length),
-            ));
+            return Err(io::Error::other(format!(
+                "collision with {} at offset {}",
+                self.conflict, self.length
+            )));
         }
         let count = self.sink.write(&buf[..allowed as usize])?;
         self.remaining = self

--- a/src/iso9660.rs
+++ b/src/iso9660.rs
@@ -71,7 +71,7 @@ impl IsoFs {
         Ok(primary.root.clone())
     }
 
-    pub fn walk(&mut self) -> Result<IsoFsWalkIterator> {
+    pub fn walk(&mut self) -> Result<IsoFsWalkIterator<'_>> {
         let root_dir = self.get_root_directory()?;
         let buf = self.list_dir(&root_dir)?;
         Ok(IsoFsWalkIterator {

--- a/src/live/embed.rs
+++ b/src/live/embed.rs
@@ -20,7 +20,6 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{copy, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
-use std::iter::repeat;
 
 use crate::io::*;
 use crate::iso9660::{self, IsoFs};
@@ -609,7 +608,7 @@ impl InitrdEmbedArea {
                 capacity
             )
         }
-        data.extend(repeat(0).take(capacity - data.len()));
+        data.extend(std::iter::repeat_n(0, capacity - data.len()));
         region.contents = data;
         Ok(region)
     }

--- a/src/osmet/unpacker.rs
+++ b/src/osmet/unpacker.rs
@@ -14,7 +14,7 @@
 
 use std::ffi::OsStr;
 use std::fs::{File, OpenOptions};
-use std::io::{self, copy, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::io::{self, copy, Read, Seek, SeekFrom, Write};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 use std::thread;
@@ -78,10 +78,7 @@ impl Read for OsmetUnpacker {
             if let Some(thread_handle) = self.thread_handle.take() {
                 return match thread_handle.join().expect("joining thread") {
                     Ok(_) => Ok(0),
-                    Err(e) => Err(io::Error::new(
-                        ErrorKind::Other,
-                        format!("while unpacking: {e}"),
-                    )),
+                    Err(e) => Err(io::Error::other(format!("while unpacking: {e}"))),
                 };
             }
         }


### PR DESCRIPTION
- To ensure multipath continues working even if a path fails, the WWID must be specified both as a
kernel argument and in /etc/multipath/wwids.
Without these, multipath may fail to detect
devices when paths go down, leading to device
mapping issues.
- This PR adds mpath.wwid kernel argument needed for the installer.