### PR TITLE
blockdev: add support for dm-integrity's new UUID naming scheme

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ Internal changes:
 
 - Add initial TMT tests and a new workflow to execute tests on PRs
 - Use release profile for smaller binaries in CI testing
+- Support cryptsetup-2.8.0's UUIDs naming of dm-integrity devices
 
 Packaging changes:
 

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -198,7 +198,7 @@ impl Disk {
         if !self.is_dm_device() {
             return Ok(false);
         }
-        Ok(runcmd_output!(
+        let dminfo = runcmd_output!(
             "dmsetup",
             "info",
             "--columns",
@@ -207,9 +207,11 @@ impl Disk {
             "uuid",
             &self.path
         )
-        .with_context(|| format!("checking if device {} is type LUKS integrity", self.path))?
-        .trim()
-        .starts_with("CRYPT-INTEGRITY-"))
+        .with_context(|| format!("checking if device {} is type LUKS integrity", self.path))?;
+
+        let uuid = dminfo.trim();
+        // since cryptsetup-2.8.0 SUBDEV is used
+        Ok(uuid.starts_with("CRYPT-INTEGRITY-") || uuid.starts_with("CRYPT-SUBDEV-"))
     }
 }
 


### PR DESCRIPTION
Cryptsetup commit 12eb040 ("Create dm-integrity with CRYPT_SUBDEV prefix.") changed UUID naming scheme for integrity-protected devices:
```
$ dmsetup info --columns --noheadings -o UUID /dev/dm-2
CRYPT-SUBDEV-ef0561fda2cf4f8eb9fd729f4cd3e0c7-root_dif
```

Before crytsetup-2.8.0:
```
$ dmsetup info --columns --noheadings -o UUID /dev/dm-2
CRYPT-INTEGRITY-bec07f15a1c540b0833fcccd6ac2459d-root_dif
```

This PR updates `is_luks_integrity()` to recognize both schemes.

https://gitlab.com/cryptsetup/cryptsetup/-/commit/12eb04094304467232348e99df0fbf95074d35b3