### PR TITLE
Uses blkid -p instead of lsblk to bypass the cache

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,7 @@ Internal changes:
 - Support cryptsetup-2.8.0's UUIDs naming of dm-integrity devices
 - rootmap: Inject `root=/dev/disk/by-uuid/dm-mpath-$UUID` when on multipath
 - rootmap: Inject `mpath.wwid=$WWID` when on multipath
+- rootmap: Bypass cache when querying filesystem UUID for `root karg` 
 
 Packaging changes:
 

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -496,7 +496,9 @@ impl Mount {
     }
 
     pub fn get_filesystem_uuid(&self) -> Result<String> {
-        let devinfo = lsblk_single(Path::new(&self.device))?;
+        // We used to use lsblk_single, but its cache may be stale after mkfs.
+        // blkid_single doesn't use cache.
+        let devinfo = blkid_single(Path::new(&self.device))?;
         devinfo
             .get("UUID")
             .map(String::from)


### PR DESCRIPTION
**BUG REPORTED**:

  OCP 4.17 Single node subsequent reboot after initial install fails. 

**SOLUTION:**
Switch from using `lsblk` to `blkid -p` in the `get_filesystem_uuid()` function to bypass cached device information and retrieve fresh filesystem UUIDs. 