### PR TITLE
opencode: add signing-key-rotation and release-prep skills

### DIFF
--- a/.opencode/skills/release-prep/SKILL.md
+++ b/.opencode/skills/release-prep/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: release-prep
+description: Prepare a coreos-installer pre-release PR with dependency updates and release notes
+---
+
+# Release Prep
+
+## What it does
+
+1. Creates a `pre-release-{VERSION}` branch from main
+2. Shows `Cargo.toml` diff since last release for version bound review
+3. Runs `cargo update` and commits the lockfile change
+4. Drafts release notes by analyzing commits since the last release
+5. Formats the release notes into the proper section structure in `docs/release-notes.md`
+6. Commits the release notes
+7. Optionally pushes the branch and opens a PR
+
+## Prerequisites
+
+- Git repository is `coreos-installer`
+- On `main` branch (or will checkout to it)
+- `cargo` is available
+- `docs/release-notes.md` exists with an "Upcoming" unreleased section at the top
+
+## Usage
+
+```bash
+# Prepare release for a specific version
+/release-prep 0.27.0
+
+# Prepare release, automatically determining the next version
+/release-prep
+```
+
+## Workflow
+
+### Step 1: Determine the release version
+
+If the user provided a version number, use that. Otherwise, read the current version from the top of `docs/release-notes.md` — it will have a line like:
+
+```
+## Upcoming coreos-installer X.Y.Z (unreleased)
+```
+
+Extract `X.Y.Z` as the `RELEASE_VER`.
+
+Validate:
+- Version follows semver format (X.Y.Z)
+- The "Upcoming" section in `docs/release-notes.md` matches this version
+
+```bash
+# Extract version from release notes
+head -10 docs/release-notes.md
+```
+
+### Step 2: Ensure we're on a clean, up-to-date main
+
+```bash
+# Check current branch and status
+git status
+
+# If not on main, ask user before switching
+git checkout main
+git pull origin main
+```
+
+If there are uncommitted changes, STOP and warn the user.
+
+### Step 3: Create the pre-release branch
+
+```bash
+git checkout -b pre-release-${RELEASE_VER}
+```
+
+### Step 4: Check Cargo.toml for version bound changes
+
+Show the diff of `Cargo.toml` since the last release tag so the user can review for unintended version bound increases:
+
+```bash
+git diff $(git describe --abbrev=0) Cargo.toml
+```
+
+Present this diff to the user and ask if everything looks correct. If the user identifies issues, STOP and let them fix manually.
+
+### Step 5: Update dependencies
+
+```bash
+cargo update
+```
+
+Then commit the lockfile:
+
+```bash
+git add Cargo.lock && git commit -m "cargo: update dependencies"
+```
+
+If `Cargo.toml` was also modified (e.g., resolver changes), include it:
+
+```bash
+git add Cargo.lock Cargo.toml && git commit -m "cargo: update dependencies"
+```
+
+### Step 6: Analyze commits for release notes
+
+Get all commits since the last release tag, excluding merge commits and automated Sync/dependabot commits:
+
+```bash
+# Find the last release tag
+git describe --abbrev=0
+
+# List commits since then
+git log --oneline --no-merges $(git describe --abbrev=0)..HEAD
+```
+
+Categorize each commit into one of four buckets based on these rules:
+
+**Major changes** — User-facing features or significant behavior changes:
+- Signing key additions/removals (`signing-keys:`)
+- New commands or subcommands
+- Changes to install behavior that affect users
+- Commits whose messages mention user-visible features
+
+**Minor changes** — Small user-facing improvements or fixes:
+- Bug fixes (`fix`, `Fix`)
+- Small UX improvements (formatting, messages)
+- Documentation changes in user-facing docs (`docs:` but not internal)
+- Commits with `install:` prefix that are small fixes
+
+**Internal changes** — Changes that don't affect users directly:
+- CI/workflow changes (`ci:`, `workflows/`, `.cci.`)
+- Test additions (`test`, `tests/`)
+- Refactoring (`tree:`, `clippy`)
+- Internal component changes (`rootmap:`, `osmet:`, `blockdev:`, `zipl:`)
+- Build system changes that don't affect packaging
+
+**Packaging changes** — Dependency and build configuration changes:
+- MSRV bumps (`bump MSRV`, `rust-version`)
+- Dockerfile updates (`dockerfile:`)
+- Dependency version requirement changes in Cargo.toml
+
+**Skip entirely** — Do not include in release notes:
+- `Sync repo templates` commits
+- `build(deps): bump` commits (Dependabot auto-updates)
+- The `cargo: update dependencies` commit we just created
+- Merge commits
+- `release-notes:` commits (meta, already captured)
+
+For each non-skipped commit, write a concise release note bullet point. Use the commit message as a starting point but rewrite for clarity from a user's perspective. Follow the style of existing release notes entries — see examples below.
+
+### Release notes style guide
+
+Based on historical entries in `docs/release-notes.md`:
+
+- Start with a lowercase verb or component prefix: `install:`, `iso:`, `rootmap:`
+- Use backticks for CLI flags, commands, paths, and crate names
+- Be concise — one line per item
+- Use the component prefix from the commit message when relevant
+- For signing keys: `Add Fedora {N} signing key; drop Fedora {M} signing key`
+- For MSRV: `Bump minimum supported Rust version (MSRV) to {version}`
+- For container updates: `Update container to Fedora {N}`
+- For dependency bumps: `Require \`{crate}\` >= {version}` (only when Cargo.toml lower bounds changed)
+
+**Examples from past releases:**
+
+```
+Major changes:
+- Add Fedora 45 signing key; drop Fedora 42 signing key
+
+Minor changes:
+- install: Don't require the network by default
+- Restore formatting of progress reporting to pre 0.24.0 behavior.
+
+Internal changes:
+- install: Simplify firstboot-args handling in config file expansion
+- s390x: Use options and logic compatible with both C-based `genprotimg` and Rust-based `pvimg`
+- Add initial TMT tests and a new workflow to execute tests on PRs
+
+Packaging changes:
+- Bump minimum supported Rust version (MSRV) to 1.85.0
+- Update container to Fedora 42
+- Updated core dependencies, including a major upgrade to `clap` from v3 to v4 and new versions of `nix`, `pnet`, and `sha2`.
+```
+
+### Step 7: Draft the release notes
+
+Present the drafted release notes to the user organized by category:
+
+```
+Here are the drafted release notes for {RELEASE_VER}:
+
+Major changes:
+- {items}
+
+Minor changes:
+- {items}
+
+Internal changes:
+- {items}
+
+Packaging changes:
+- {items}
+
+Please review and let me know if any changes are needed.
+```
+
+Wait for user confirmation or edits before proceeding.
+
+### Step 8: Update `docs/release-notes.md`
+
+Once the user approves the release notes, edit `docs/release-notes.md`:
+
+1. **Change the "Upcoming" header** from:
+   ```
+   ## Upcoming coreos-installer {RELEASE_VER} (unreleased)
+   ```
+   to:
+   ```
+   ## Upcoming coreos-installer {NEXT_VER} (unreleased)
+   ```
+   where `NEXT_VER` is the next minor version (increment Y in X.Y.Z).
+
+2. **Insert a new empty section** for the next unreleased version right after `# Release notes`:
+   ```markdown
+   ## Upcoming coreos-installer {NEXT_VER} (unreleased)
+
+   Major changes:
+
+
+   Minor changes:
+
+
+   Internal changes:
+
+
+   Packaging changes:
+
+   ```
+
+3. **Update the current release header** to include today's date:
+   ```
+   ## coreos-installer {RELEASE_VER} ({YYYY-MM-DD})
+   ```
+   Note: Remove "Upcoming" prefix and add the date.
+
+4. **Fill in the release notes content** under each category heading. If a category has no entries, leave it empty (blank line after the heading). Make sure any existing content that was already written in the unreleased section (e.g., signing key entries added earlier) is preserved and merged with the new content.
+
+### Step 9: Commit the release notes
+
+```bash
+git add docs/release-notes.md
+git commit -m "docs/release-notes: update for release ${RELEASE_VER}"
+```
+
+### Step 10: Show summary and next steps
+
+Present a summary to the user:
+
+```
+Pre-release prep complete for coreos-installer {RELEASE_VER}!
+
+Branch: pre-release-{RELEASE_VER}
+Commits:
+  1. cargo: update dependencies
+  2. docs/release-notes: update for release {RELEASE_VER}
+
+Next steps from the release checklist:
+  1. Push and open a PR:
+     git push origin pre-release-{RELEASE_VER}
+     Then open a PR for review.
+
+  2. After PR merges, continue with the release checklist:
+     - git checkout main && git pull origin main
+     - cargo vendor-filterer target/vendor
+     - cargo test --all-features --config 'source.crates-io.replace-with="vv"' --config 'source.vv.directory="target/vendor"'
+     - cargo clean && git clean -fd
+     - git checkout -b release-{RELEASE_VER}
+     - cargo release --execute {RELEASE_VER}
+
+  Full checklist: https://github.com/coreos/coreos-installer/issues/new?labels=release&template=release-checklist.md
+```
+
+Ask the user if they want to push the branch and open the PR now.
+
+### Step 11: Optionally push and open PR
+
+If the user confirms:
+
+```bash
+git push origin pre-release-${RELEASE_VER}
+```
+
+Then use `gh pr create`:
+
+```bash
+gh pr create --title "Pre-release: coreos-installer ${RELEASE_VER}" --body "$(cat <<'EOF'
+## Pre-release prep for coreos-installer {RELEASE_VER}
+
+### Changes
+- Updated dependencies (`cargo update`)
+- Updated release notes for {RELEASE_VER}
+
+### Release checklist
+After this PR merges, continue with the [release checklist](https://github.com/coreos/coreos-installer/issues/new?labels=release&template=release-checklist.md).
+EOF
+)"
+```
+
+## Checklist Coverage
+
+This skill automates these items from the release checklist:
+
+- [x] `git checkout -b pre-release-${RELEASE_VER}` — branch creation
+- [x] `git diff $(git describe --abbrev=0) Cargo.toml` — version bound check
+- [x] `cargo update` + commit — dependency update
+- [x] Write release notes in `docs/release-notes.md` — drafts from git history
+- [x] Commit release notes — `docs/release-notes: update for release ${RELEASE_VER}`
+- [x] Push branch and open PR (optional)
+
+## What's NOT covered
+
+- [ ] `cargo release --execute` — requires interactive GPG signing
+- [ ] `cargo publish` — requires crates.io auth
+- [ ] `cargo vendor-filterer` / `cargo test` — post-merge verification
+- [ ] GitHub release creation — requires uploading vendor archive
+- [ ] Quay.io tag update — web UI only
+- [ ] Fedora/CentOS packaging — separate repos and auth
+- [ ] PR review and merge — human process
+
+## References
+
+- Release checklist template: `.github/ISSUE_TEMPLATE/release-checklist.md`
+- Release notes: `docs/release-notes.md`
+- Development docs: `DEVELOPMENT.md` (references release process)
+- New release ticket: `https://github.com/coreos/coreos-installer/issues/new?labels=release&template=release-checklist.md`

--- a/.opencode/skills/signing-key-rotation/SKILL.md
+++ b/.opencode/skills/signing-key-rotation/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: signing-key-rotation
+description: Add a new Fedora signing key and drop the oldest one in coreos-installer
+---
+
+# Fedora Signing Key Rotation
+
+## What it does
+
+1. Downloads the new Fedora GPG signing key from src.fedoraproject.org
+2. Appends it to `src/signing-keys.asc`
+3. Updates `docs/release-notes.md` with the addition
+4. Creates a commit: `signing-keys: add Fedora {N} key`
+5. Removes the oldest Fedora key (N-3) from `src/signing-keys.asc`
+6. Updates `docs/release-notes.md` with the removal
+7. Creates a commit: `signing-keys: drop Fedora {N-3} key`
+
+## Prerequisites
+
+- Git repository is `coreos-installer`
+- `src/signing-keys.asc` exists with current signing keys
+- `docs/release-notes.md` exists with an unreleased section at the top
+- Network access to download the key from src.fedoraproject.org
+
+## Usage
+
+```bash
+# Rotate keys for a new Fedora version
+/signing-key-rotation 46
+
+# Specify a custom old version to drop (default: NEW - 3)
+/signing-key-rotation 46 --drop 43
+
+# Include a tracker issue reference for the drop commit
+/signing-key-rotation 46 --tracker https://github.com/coreos/fedora-coreos-tracker/issues/XXXX
+```
+
+## Workflow
+
+### Step 1: Parse arguments and validate
+
+Extract the new Fedora version number from the user's invocation. If not provided, ask for it.
+
+```
+NEW_VERSION = (from user input)
+OLD_VERSION = NEW_VERSION - 3  (unless --drop is specified)
+TRACKER_URL = (from --tracker, optional)
+```
+
+Run these validation checks:
+
+```bash
+# Verify signing-keys.asc exists
+ls src/signing-keys.asc
+
+# Check what keys are currently present
+grep "Comment:" src/signing-keys.asc
+
+# Verify the old key exists
+grep "RPM-GPG-KEY-fedora-${OLD_VERSION}-primary" src/signing-keys.asc
+
+# Verify the new key does NOT already exist
+grep "RPM-GPG-KEY-fedora-${NEW_VERSION}-primary" src/signing-keys.asc
+```
+
+If the new key already exists, STOP and inform the user.
+If the old key does not exist, STOP and inform the user.
+
+### Step 2: Download the new GPG key
+
+Fetch the key from Fedora's package sources:
+
+```
+URL: https://src.fedoraproject.org/rpms/fedora-repos/blob/rawhide/f/RPM-GPG-KEY-fedora-{NEW_VERSION}-primary
+```
+
+Use the WebFetch tool to download the page, then extract the raw PGP key block between `-----BEGIN PGP PUBLIC KEY BLOCK-----` and `-----END PGP PUBLIC KEY BLOCK-----` (inclusive).
+
+If the page is not found or doesn't contain a PGP key block, STOP and inform the user that the key may not exist yet.
+
+### Step 3: Add the new key to `src/signing-keys.asc`
+
+Using the Edit tool, append to the end of `src/signing-keys.asc`:
+
+1. A blank line after the last `-----END PGP PUBLIC KEY BLOCK-----`
+2. The complete PGP key block (from `-----BEGIN PGP PUBLIC KEY BLOCK-----` through `-----END PGP PUBLIC KEY BLOCK-----`)
+
+Make sure the file ends with a newline.
+
+### Step 4: Update release notes for the addition
+
+Using the Edit tool on `docs/release-notes.md`, find the first "Major changes:" section (the unreleased version at the top) and add:
+
+```
+- Add Fedora {NEW_VERSION} signing key
+```
+
+The entry goes right after the "Major changes:" line. If there are already entries there, add it as the first bullet point. If the section is empty (just blank lines between "Major changes:" and the next heading), add it on the blank line.
+
+### Step 5: Create the "add" commit
+
+Do NOT commit unless the user has asked you to commit. If they have, create the commit:
+
+```bash
+git add src/signing-keys.asc docs/release-notes.md
+git commit -m "signing-keys: add Fedora {NEW_VERSION} key
+
+Fedora {NEW_VERSION - 1} branched from rawhide, so rawhide is now F{NEW_VERSION}.
+
+Ref: https://src.fedoraproject.org/rpms/fedora-repos/blob/rawhide/f/RPM-GPG-KEY-fedora-{NEW_VERSION}-primary"
+```
+
+### Step 6: Remove the old key from `src/signing-keys.asc`
+
+Using the Edit tool, find and remove the entire PGP key block that contains:
+
+```
+Comment: RPM-GPG-KEY-fedora-{OLD_VERSION}-primary
+```
+
+Remove from the blank line before `-----BEGIN PGP PUBLIC KEY BLOCK-----` through the `-----END PGP PUBLIC KEY BLOCK-----` line (inclusive). Also remove any trailing blank line that was part of the separator between key blocks.
+
+### Step 7: Update release notes for the removal
+
+Using the Edit tool on `docs/release-notes.md`, change:
+
+```
+- Add Fedora {NEW_VERSION} signing key
+```
+
+to:
+
+```
+- Add Fedora {NEW_VERSION} signing key; drop Fedora {OLD_VERSION} signing key
+```
+
+### Step 8: Create the "drop" commit
+
+Do NOT commit unless the user has asked you to commit. If they have:
+
+If a tracker URL was provided:
+
+```bash
+git add src/signing-keys.asc docs/release-notes.md
+git commit -m "signing-keys: drop Fedora {OLD_VERSION} key
+
+Ref: {TRACKER_URL}"
+```
+
+If no tracker URL:
+
+```bash
+git add src/signing-keys.asc docs/release-notes.md
+git commit -m "signing-keys: drop Fedora {OLD_VERSION} key"
+```
+
+### Step 9: Verify
+
+Run verification checks:
+
+```bash
+# Confirm exactly 4 key blocks (1 RHEL + 3 Fedora)
+grep "Comment:" src/signing-keys.asc
+
+# Verify the new key is present
+grep "RPM-GPG-KEY-fedora-${NEW_VERSION}-primary" src/signing-keys.asc
+
+# Verify the old key is gone
+grep "RPM-GPG-KEY-fedora-${OLD_VERSION}-primary" src/signing-keys.asc
+# (should return no match)
+
+# Show the git log
+git log --oneline -2
+```
+
+Optionally run `cargo check` to verify the build still works.
+
+### Step 10: Report results
+
+Present the user with a summary:
+
+```
+Signing key rotation complete:
+
+  Added:   Fedora {NEW_VERSION} signing key
+  Dropped: Fedora {OLD_VERSION} signing key
+
+  Current keys in src/signing-keys.asc:
+    - RPM-GPG-KEY-redhat-release
+    - RPM-GPG-KEY-fedora-{OLD_VERSION + 1}-primary
+    - RPM-GPG-KEY-fedora-{OLD_VERSION + 2}-primary
+    - RPM-GPG-KEY-fedora-{NEW_VERSION}-primary
+
+  Commits created:
+    1. signing-keys: add Fedora {NEW_VERSION} key
+    2. signing-keys: drop Fedora {OLD_VERSION} key
+
+  Files modified:
+    - src/signing-keys.asc
+    - docs/release-notes.md
+
+  Next steps:
+    1. Push to a branch and open a PR
+    2. Get review and merge
+```
+
+## Checklist Coverage
+
+This skill automates the following from the manual process:
+
+- [x] Download new Fedora GPG key
+- [x] Append key to `src/signing-keys.asc`
+- [x] Remove old key from `src/signing-keys.asc`
+- [x] Update `docs/release-notes.md`
+- [x] Create properly formatted commits
+- [x] Verify key count and correctness
+
+## What's NOT covered
+
+- [ ] Creating the PR on GitHub (user can do this manually or ask)
+- [ ] Determining the tracker issue URL (user must provide if desired)
+- [ ] Running full CI (`cargo test`) - only `cargo check` is optionally run
+- [ ] Pushing to a remote branch
+
+## Example Output
+
+```
+$ /signing-key-rotation 46
+
+Validating inputs...
+  NEW_VERSION: 46
+  OLD_VERSION: 43 (46 - 3)
+  Current keys: redhat-release, fedora-43, fedora-44, fedora-45
+
+Downloading Fedora 46 key from src.fedoraproject.org...
+  Found PGP key block (31 lines)
+
+Adding Fedora 46 key to src/signing-keys.asc...
+  Appended key block to end of file
+
+Updating docs/release-notes.md...
+  Added "Add Fedora 46 signing key" to Major changes
+
+Created commit: signing-keys: add Fedora 46 key
+
+Removing Fedora 43 key from src/signing-keys.asc...
+  Removed key block with Comment: RPM-GPG-KEY-fedora-43-primary
+
+Updating docs/release-notes.md...
+  Updated to "Add Fedora 46 signing key; drop Fedora 43 signing key"
+
+Created commit: signing-keys: drop Fedora 43 key
+
+Verification:
+  Keys present: redhat-release, fedora-44, fedora-45, fedora-46
+  Key count: 4 (correct)
+  cargo check: passed
+
+Signing key rotation complete!
+```
+
+## References
+
+- Design doc: `.opencode/skills/signing-key-rotation/DESIGN.md`
+- Example 1 (F45/F42): `.opencode/skills/signing-key-rotation/examples/example-1-add-f45-drop-f42.md`
+- Example 2 (F43/F40): `.opencode/skills/signing-key-rotation/examples/example-2-add-f43-drop-f40.md`
+- Key source: `https://src.fedoraproject.org/rpms/fedora-repos/blob/rawhide/f/RPM-GPG-KEY-fedora-{N}-primary`
+- Tracker: `https://github.com/coreos/fedora-coreos-tracker/issues`


### PR DESCRIPTION
Add two OpenCode automation skills:

- signing-key-rotation: automates adding/dropping Fedora signing keys in src/signing-keys.asc and docs/release-notes.md
- release-prep: automates pre-release PR preparation including dependency updates and release notes drafting