### PR TITLE
blockdev: exclude RAID member devices from filesystem label search

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ Major changes:
 
 Minor changes:
 
+- verify-unique-fs-label: Fix false failure on RAID1 mirrored boot setups
 
 Internal changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@ Major changes:
 Minor changes:
 
 - verify-unique-fs-label: Fix false failure on RAID1 mirrored boot setups
+- verify-unique-fs-label: Improve diagnostics for unassembled RAID arrays
 
 Internal changes:
 

--- a/src/bin/rdcore/unique_fs.rs
+++ b/src/bin/rdcore/unique_fs.rs
@@ -21,6 +21,18 @@ pub fn verify_unique_fs(config: VerifyUniqueFsLabelConfig) -> Result<()> {
     let pts = get_filesystems_with_label(&config.label, config.rereadpt)?;
     let count = pts.len();
     if count != 1 {
+        if count == 0 {
+            // rereadpt already done by get_filesystems_with_label above
+            let raid_members = get_raid_members_with_label(&config.label, false)?;
+            if !raid_members.is_empty() {
+                bail!(
+                    "No assembled filesystem labeled '{}', but found RAID member \
+                     devices {:?}. Is the RAID array degraded or failed to assemble?",
+                    config.label,
+                    raid_members
+                );
+            }
+        }
         bail!(
             "System has {} devices with a filesystem labeled '{}': {:?}",
             count,

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -857,11 +857,16 @@ fn get_all_filesystems(rereadpt: bool) -> Result<Vec<HashMap<String, String>>> {
 
 /// Returns filesystems with given label.
 /// If multiple filesystems with the label have the same UUID, we only return one of them.
+/// RAID member devices are excluded since they carry the assembled array's label
+/// but are not directly usable filesystems.
 pub fn get_filesystems_with_label(label: &str, rereadpt: bool) -> Result<Vec<String>> {
     let mut uuids = HashSet::new();
     let result = get_all_filesystems(rereadpt)?
         .iter()
         .filter(|v| v.get("LABEL").map(|l| l.as_str()) == Some(label))
+        // Exclude RAID member devices whose superblocks carry the
+        // assembled array's filesystem label (e.g. /dev/sdb1 vs /dev/md127).
+        .filter(|v| v.get("USAGE").map(|u| u.as_str()) != Some("raid"))
         .filter(|v| match v.get("UUID") {
             Some(uuid) => {
                 if !uuid.is_empty() {
@@ -1343,6 +1348,39 @@ mod tests {
                 String::from("TYPE") => String::from("crypto_LUKS"),
                 String::from("PARTLABEL") => String::from("root"),
                 String::from("PARTUUID") => String::from("835753cb-d7f0-465e-84db-07860d3da2f6"),
+            }
+        );
+    }
+
+    #[test]
+    fn blkid_split_raid_member() {
+        assert_eq!(
+            split_blkid_line(
+                r#"/dev/sdb1: LABEL="boot" UUID="12345678-1234-1234-1234-123456789abc" TYPE="linux_raid_member" USAGE="raid""#
+            ),
+            hashmap! {
+                String::from("NAME") => String::from("/dev/sdb1"),
+                String::from("LABEL") => String::from("boot"),
+                String::from("UUID") => String::from("12345678-1234-1234-1234-123456789abc"),
+                String::from("TYPE") => String::from("linux_raid_member"),
+                String::from("USAGE") => String::from("raid"),
+            }
+        );
+    }
+
+    #[test]
+    fn blkid_split_filesystem_usage() {
+        assert_eq!(
+            split_blkid_line(
+                r#"/dev/md127: LABEL="boot" UUID="abcdef01-2345-6789-abcd-ef0123456789" BLOCK_SIZE="4096" TYPE="ext4" USAGE="filesystem""#
+            ),
+            hashmap! {
+                String::from("NAME") => String::from("/dev/md127"),
+                String::from("LABEL") => String::from("boot"),
+                String::from("UUID") => String::from("abcdef01-2345-6789-abcd-ef0123456789"),
+                String::from("BLOCK_SIZE") => String::from("4096"),
+                String::from("TYPE") => String::from("ext4"),
+                String::from("USAGE") => String::from("filesystem"),
             }
         );
     }

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -882,6 +882,19 @@ pub fn get_filesystems_with_label(label: &str, rereadpt: bool) -> Result<Vec<Str
     Ok(result)
 }
 
+/// Returns RAID member devices with the given filesystem label.
+/// Used to produce better diagnostics when an expected filesystem is missing
+/// but RAID members carrying its label exist (e.g. array failed to assemble).
+pub fn get_raid_members_with_label(label: &str, rereadpt: bool) -> Result<Vec<String>> {
+    let result = get_all_filesystems(rereadpt)?
+        .iter()
+        .filter(|v| v.get("LABEL").map(|l| l.as_str()) == Some(label))
+        .filter(|v| v.get("USAGE").map(|u| u.as_str()) == Some("raid"))
+        .filter_map(|v| v.get("NAME").map(<_>::to_owned))
+        .collect();
+    Ok(result)
+}
+
 pub fn lsblk(dev: &Path, with_deps: bool) -> Result<Vec<HashMap<String, String>>> {
     let mut cmd = Command::new("lsblk");
     // Older lsblk, e.g. in CentOS 7.6, doesn't support PATH, but --paths option


### PR DESCRIPTION
While investigating the issue, I found that get_filesystems_with_label() in blockdev.rs doesn't really account for RAID devices. When a RAID1 mirror boot is configured, blkid -p returns both (/dev/md127) and  (/dev/sdb1) — both carrying the "boot" label but with different UUIDs. I dont think that the UUID deduplication will be suitable here... Soooo.. I filtered out RAID and I noticed we did not account for failed raid situations.. or bad state..  So I added a check in verify_unique_fs() that detects this case and reports which RAID devices are in a odd state. 

fixes:#1731 

Supported by claude