### PR TITLE
systemd: bring up ssh if coreos.inst.skip_reboot

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ Minor changes:
 
 - verify-unique-fs-label: Fix false failure on RAID1 mirrored boot setups
 - verify-unique-fs-label: Improve diagnostics for unassembled RAID arrays
+- systemd: bring up ssh if coreos.inst.skip_reboot karg was set
 
 Internal changes:
 

--- a/systemd/coreos-installer-noreboot.service
+++ b/systemd/coreos-installer-noreboot.service
@@ -3,6 +3,11 @@ Description=Give Login Shell After CoreOS Installer
 Requires=coreos-installer.target
 After=coreos-installer.target
 ConditionPathExists=!/run/coreos-installer-reboot
+# If the users passed coreos.inst.skip_reboot karg and they provided SSH
+# keys in an Ignition config then let's leave a path to get in to the
+# system remotely. They can then inspect the system and send it down
+# for a reboot manually.
+Wants=sshd.service systemd-user-sessions.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This will allow someone to ssh into the system that's waiting for the user to tell it to reboot.