### PR TITLE
s390x: use pvimg tool instead of obsolete genprotimg

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,7 @@ Internal changes:
 
 - install: Fix '--console' flag handling on s390x
 - install: Disable GRUB configuration on s390x
+- s390x: Use `pvimg` instead of obsolete `genprotimg`
 
 Packaging changes:
 

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -281,22 +281,17 @@ fn generate_sdboot(
 
     // finally, Secure Execution sd-boot image
     let sdboot = mountpoint.join("sdboot");
-
-    // C 'genprotimg' tool no longer exists and was replaced by symlink to Rust 'pvimg create',
-    // which by default doesn't overwrite the output image.
-    // For backward compatibility let's silently remove the 'sdboot'.
-    let _ = std::fs::remove_file(&sdboot);
-
-    // FIXME: in F42/el10 switch to 'pvimg create' with '--overwrite' flag.
-    let mut cmd = Command::new("genprotimg");
-    cmd.arg("--verbose")
-        .arg("--image")
+    let mut cmd = Command::new("pvimg");
+    cmd.arg("create")
+        .arg("--verbose")
+        .arg("--kernel")
         .arg(kernel)
         .arg("--ramdisk")
         .arg(initrd)
         .arg("--parmfile")
         .arg(cmdline.path())
         .arg("--no-verify")
+        .arg("--overwrite")
         .arg("--output")
         .arg(&sdboot);
     for k in hostkeys {


### PR DESCRIPTION
el9,el10 and rhel-9.6 now ship s390utils-base >= 2.36.0, so switch from the obsolete `genprotimg` tool to `pvimg`.

We can also use the `--overwrite` option instead of manually removing the existing `sdboot` image.

Btw, `genprotimg` is now just a symlink to `pvimg`.
```
$ file /usr/bin/genprotimg
/usr/bin/genprotimg: symbolic link to pvimg
```