### PR TITLE
s390x: cleanups

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,6 +23,7 @@ Internal changes:
 - s390x: Use `pvimg` instead of obsolete `genprotimg`
 - s390x: Fix `write()` to `write_all()` in initrd generation to prevent silent truncation
 - s390x: Minor code cleanups in dasd and zipl handling
+- s390x: Fix lszdev bus ID regex: escape dots and add parser tests
 
 Packaging changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,7 @@ Internal changes:
 - install: Disable GRUB configuration on s390x
 - s390x: Use `pvimg` instead of obsolete `genprotimg`
 - s390x: Fix `write()` to `write_all()` in initrd generation to prevent silent truncation
+- s390x: Minor code cleanups in dasd and zipl handling
 
 Packaging changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,7 @@ Internal changes:
 - install: Fix '--console' flag handling on s390x
 - install: Disable GRUB configuration on s390x
 - s390x: Use `pvimg` instead of obsolete `genprotimg`
+- s390x: Fix `write()` to `write_all()` in initrd generation to prevent silent truncation
 
 Packaging changes:
 

--- a/src/s390x/dasd.rs
+++ b/src/s390x/dasd.rs
@@ -49,13 +49,14 @@ enum DasdType {
 
 fn get_dasd_type<P: AsRef<Path>>(device: P) -> Result<DasdType> {
     let device = device.as_ref();
-    let device = device
+    let canonical = device
         .canonicalize()
-        .with_context(|| format!("getting absolute path to {}", device.display()))?
+        .with_context(|| format!("getting absolute path to {}", device.display()))?;
+    let device = canonical
         .file_name()
         .with_context(|| format!("getting name of {}", device.display()))?
-        .to_string_lossy()
-        .to_string();
+        .to_str()
+        .with_context(|| format!("device name is not UTF-8: {}", device.display()))?;
     if device.starts_with("vd") {
         return Ok(DasdType::Virt);
     }
@@ -92,15 +93,17 @@ pub fn image_copy_s390x(
     dest_path: &Path,
     _saved: Option<&SavedPartitions>,
 ) -> Result<()> {
+    let dest_path = dest_path
+        .to_str()
+        .with_context(|| format!("device path is not UTF-8: {}", dest_path.display()))?;
+
     let ranges = match get_dasd_type(dest_path)? {
-        DasdType::Fba => fba_make_partitions(&dest_path.to_string_lossy(), dest_file, first_mb)?,
-        DasdType::Eckd | DasdType::Virt => {
-            eckd_make_partitions(&dest_path.to_string_lossy(), dest_file, first_mb)?
-        }
+        DasdType::Fba => fba_make_partitions(dest_path, dest_file, first_mb)?,
+        DasdType::Eckd | DasdType::Virt => eckd_make_partitions(dest_path, dest_file, first_mb)?,
     };
 
     // copy each partition
-    eprintln!("Installing to {}", dest_path.display());
+    eprintln!("Installing to {dest_path}");
     let mut buf = [0u8; 1024 * 1024];
     // there shouldn't be any partition data in the first MiB, so don't
     // worry about copying first_mb

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -35,6 +35,7 @@ pub fn chreipl<P: AsRef<Path>>(dev: P) -> Result<()> {
 }
 
 /// Secure boot (Secure IPL) includes support of SCSI and ECKD DASD boot devices
+#[derive(Debug, PartialEq)]
 enum Loaddev {
     Eckd(String),
     Scsi(String, String, String),
@@ -42,10 +43,15 @@ enum Loaddev {
 
 fn parse_lszdev_eckd(line: &str) -> Result<Loaddev> {
     // ECKD ID looks like: 0.0.5223, we need only last part of it (5223)
+    // Format: cssid . ssid . devno — all hex fields, dots are literal separators.
+    // See https://github.com/torvalds/linux/blob/master/arch/s390/include/asm/cio.h
+    // See https://github.com/ibm-s390-linux/s390-tools/blob/master/libccw/ccw.c
+    // We accept any hex value from lszdev; ID validation is the kernel's responsibility.
     lazy_static! {
-        static ref REGEX: Regex = Regex::new(r#"[[:digit:]].[[:digit:]].([[:xdigit:]]+)"#).unwrap();
+        static ref REGEX: Regex =
+            Regex::new(r#"^[[:xdigit:]]{1,2}\.[[:xdigit:]]\.([[:xdigit:]]{1,4})$"#).unwrap();
     }
-    if let Some(cap) = REGEX.captures_iter(line).next() {
+    if let Some(cap) = REGEX.captures(line) {
         return Ok(Loaddev::Eckd(cap[1].to_string()));
     }
     bail!("bad ECKD id: {}", line);
@@ -53,14 +59,15 @@ fn parse_lszdev_eckd(line: &str) -> Result<Loaddev> {
 
 fn parse_lszdev_zfcp(line: &str) -> Result<Loaddev> {
     // SCSI ID looks like: 0.0.8000:0x500507630400d1e3:0x4000401d00000000
-    // So here is regex to parse required ids: 8000,500507630400d1e3,4000401d00000000
+    // Format: cssid . ssid . devno : 0x wwpn : 0x lun — same bus ID scheme as ECKD,
+    // followed by 64-bit WWPN and LUN. We accept any hex value from lszdev.
     lazy_static! {
         static ref REGEX: Regex = Regex::new(
-            r#"[[:digit:]].[[:digit:]].([[:xdigit:]]+):0x([[:xdigit:]]+):0x([[:xdigit:]]+)"#
+            r#"^[[:xdigit:]]{1,2}\.[[:xdigit:]]\.([[:xdigit:]]{1,4}):0x([[:xdigit:]]+):0x([[:xdigit:]]+)$"#
         )
         .unwrap();
     }
-    if let Some(cap) = REGEX.captures_iter(line).next() {
+    if let Some(cap) = REGEX.captures(line) {
         return Ok(Loaddev::Scsi(
             cap[1].to_string(),
             cap[2].to_string(),
@@ -90,6 +97,7 @@ fn parse_lszdev<P: AsRef<Path>>(dev: P) -> Result<Loaddev> {
         .trim()
         .split_once(' ')
         .with_context(|| format!("parsing lszdev {output}"))?;
+    let id = id.trim();
     match devtype {
         "dasd-eckd" => parse_lszdev_eckd(id),
         "zfcp-lun" => parse_lszdev_zfcp(id),
@@ -388,6 +396,49 @@ fn extract_firstboot_kargs(s: &str) -> Result<Option<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_lszdev_eckd() {
+        assert_eq!(
+            parse_lszdev_eckd("0.0.5223").unwrap(),
+            Loaddev::Eckd("5223".into())
+        );
+        // short devno
+        assert_eq!(
+            parse_lszdev_eckd("0.0.ff").unwrap(),
+            Loaddev::Eckd("ff".into())
+        );
+        // 2-digit cssid
+        assert_eq!(
+            parse_lszdev_eckd("ff.f.ffff").unwrap(),
+            Loaddev::Eckd("ffff".into())
+        );
+        // dots must be literal
+        assert!(parse_lszdev_eckd("0X0X5223").is_err());
+        assert!(parse_lszdev_eckd("0,0,5223").is_err());
+        assert!(parse_lszdev_eckd("not-an-id").is_err());
+        assert!(parse_lszdev_eckd("0.0.gggg").is_err());
+        assert!(parse_lszdev_eckd("0.0.").is_err());
+        // anchored — devno > 4 hex digits must not partially match
+        assert!(parse_lszdev_eckd("0.0.12345").is_err());
+    }
+
+    #[test]
+    fn test_parse_lszdev_zfcp() {
+        assert_eq!(
+            parse_lszdev_zfcp("0.0.800e:0x500507630400d1e3:0x4000409a00000000").unwrap(),
+            Loaddev::Scsi(
+                "800e".into(),
+                "500507630400d1e3".into(),
+                "4000409a00000000".into(),
+            )
+        );
+        // dots must be literal
+        assert!(parse_lszdev_zfcp("0X0X800e:0x500507630400d1e3:0x4000409a00000000").is_err());
+        // zfcp-host line has no lun — must fail
+        assert!(parse_lszdev_zfcp(" 0.0.800e").is_err());
+        assert!(parse_lszdev_zfcp("not-an-id").is_err());
+    }
 
     #[test]
     fn test_extract_firstboot_kargs() {

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -248,7 +248,7 @@ fn generate_sdboot(
         .write_all(options.as_bytes())
         .context("writing zipl se cmdline")?;
 
-    let mut appendies = files.map_or_else(Vec::new, |v| v.iter().map(PathBuf::from).collect());
+    let mut appendies = files.map_or_else(Vec::new, |v| v.into_iter().map(PathBuf::from).collect());
 
     let lukskeys_path = PathBuf::from("/etc/luks");
     let crypttab_path = PathBuf::from("/etc/crypttab");
@@ -269,7 +269,7 @@ fn generate_sdboot(
 
     // during cosa-build we override hostkey(s) with a universal one
     let hostkeys = match hostkeys {
-        Some(keys) => keys.iter().map(PathBuf::from).collect(),
+        Some(keys) => keys.into_iter().map(PathBuf::from).collect(),
         None => find_files("/etc/se-hostkeys", |e: &DirEntry| {
             Ok(e.file_name()
                 .to_str()

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -193,7 +193,7 @@ fn generate_initrd<P: AsRef<Path>>(source: P, files: &[PathBuf]) -> Result<Named
     // appending
     let initrd = initrd.to_bytes()?;
     dest.as_file_mut()
-        .write(&initrd)
+        .write_all(&initrd)
         .with_context(|| format!("appending luks-initrd to {}", dest.path().display()))?;
     Ok(dest)
 }


### PR DESCRIPTION
See individual commits:
-  s390x/zipl: fix lszdev bus ID regex and add parser tests
- d34f3 s390x: minor code cleanups in dasd and zipl handling
-  s390x/zipl: fix write() to write_all() in generate_initrd