### PR TITLE
s390x/zipl: clear LOADDEV before setting it

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,7 @@ Internal changes:
 - s390x: Fix `write()` to `write_all()` in initrd generation to prevent silent truncation
 - s390x: Minor code cleanups in dasd and zipl handling
 - s390x: Fix lszdev bus ID regex: escape dots and add parser tests
+- s390x: Clear LOADDEV before setting it to avoid conflicts when multiple disks were previously used as LOADDEV
 
 Packaging changes:
 

--- a/src/s390x/zipl.rs
+++ b/src/s390x/zipl.rs
@@ -114,6 +114,14 @@ pub fn set_loaddev<P: AsRef<Path>>(dev: P) -> Result<()> {
     if !Path::new("/dev/vmcp").exists() {
         return Ok(());
     }
+    // If several disks are attached to zVM, more than one may have been used as LOADDEV,
+    // which would cause an error like:
+    //   HCPFCL1613E An attempt was made to set both SCSI and ECKD parameters for a future IPL. These are conflicting parameters.
+    // Ignore any error; the subsequent set will fail if this is a real problem.
+    eprintln!("Clearing LOADDEV");
+    if let Err(e) = runcmd!("vmcp", "set", "loaddev", "clear") {
+        eprintln!("Clearing LOADDEV failed: {e}");
+    }
     eprintln!("Setting LOADDEV");
     let mut cmd = Command::new("vmcp");
     cmd.arg("set").arg("loaddev");


### PR DESCRIPTION
If several disks are attached to zVM, more than one may have been used as `LOADDEV`, which would cause an error like:
```  
  HCPFCL1613E An attempt was made to set both SCSI and ECKD parameters
  for a future IPL. These are conflicting parameters.
```